### PR TITLE
feat: expose Discogs cache stats in API response

### DIFF
--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -172,3 +173,41 @@ class RequestTelemetry:
         logger.debug(
             f"Sent telemetry: {len(self.steps)} steps, total {self.get_total_duration_ms():.1f}ms"
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-request cache stats via ContextVar
+# ---------------------------------------------------------------------------
+
+_cache_stats_var: ContextVar[dict] = ContextVar("cache_stats")
+
+
+def init_cache_stats() -> None:
+    """Initialize cache stats for the current request context."""
+    _cache_stats_var.set({"pg_hits": 0, "pg_misses": 0, "api_calls": 0})
+
+
+def record_pg_cache_hit() -> None:
+    """Record a PostgreSQL cache hit in the current request context."""
+    stats = _cache_stats_var.get(None)
+    if stats is not None:
+        stats["pg_hits"] += 1
+
+
+def record_pg_cache_miss() -> None:
+    """Record a PostgreSQL cache miss in the current request context."""
+    stats = _cache_stats_var.get(None)
+    if stats is not None:
+        stats["pg_misses"] += 1
+
+
+def record_discogs_api_call() -> None:
+    """Record a Discogs API call in the current request context."""
+    stats = _cache_stats_var.get(None)
+    if stats is not None:
+        stats["api_calls"] += 1
+
+
+def get_cache_stats() -> dict | None:
+    """Get cache stats for the current request context, or None if not initialized."""
+    return _cache_stats_var.get(None)

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -10,6 +10,7 @@ import httpx
 
 from config.settings import get_settings
 from core.matching import calculate_confidence, is_compilation_artist
+from core.telemetry import record_discogs_api_call, record_pg_cache_hit, record_pg_cache_miss
 from discogs.memory_cache import RELEASE_CACHE, SEARCH_CACHE, TRACK_CACHE, async_cached
 from discogs.models import (
     DiscogsSearchRequest,
@@ -176,6 +177,7 @@ class DiscogsService:
                 )
                 if cached_releases:
                     logger.info(f"Cache hit: found {len(cached_releases)} releases for '{track}'")
+                    record_pg_cache_hit()
                     add_discogs_breadcrumb(
                         "cache_hit", {"track": track, "count": len(cached_releases)}
                     )
@@ -187,6 +189,7 @@ class DiscogsService:
                         cached=True,
                     )
                 logger.debug(f"Cache miss for track '{track}'")
+                record_pg_cache_miss()
                 add_discogs_breadcrumb("cache_miss", {"track": track})
             except Exception as e:
                 logger.warning(f"Cache lookup failed, falling back to API: {e}")
@@ -210,6 +213,7 @@ class DiscogsService:
             response = await self._request_with_retry("GET", "/database/search", params=params)
 
             if response is not None:
+                record_discogs_api_call()
                 response.raise_for_status()
                 data = response.json()
 
@@ -238,6 +242,7 @@ class DiscogsService:
                 )
 
                 if response is not None:
+                    record_discogs_api_call()
                     response.raise_for_status()
                     data = response.json()
 
@@ -318,9 +323,11 @@ class DiscogsService:
                 cached_release = await self.cache_service.get_release(release_id)
                 if cached_release:
                     logger.info(f"Cache hit: release {release_id}")
+                    record_pg_cache_hit()
                     add_discogs_breadcrumb("cache_hit", {"release_id": release_id})
                     return cached_release
                 logger.debug(f"Cache miss for release {release_id}")
+                record_pg_cache_miss()
                 add_discogs_breadcrumb("cache_miss", {"release_id": release_id})
             except Exception as e:
                 logger.warning(f"Cache lookup failed, falling back to API: {e}")
@@ -334,6 +341,7 @@ class DiscogsService:
                 logger.warning(f"Failed to fetch release {release_id} (rate limited or error)")
                 return None
 
+            record_discogs_api_call()
             response.raise_for_status()
             data = response.json()
 
@@ -415,6 +423,7 @@ class DiscogsService:
                 logger.warning("Discogs search failed (rate limited or error)")
                 return DiscogsSearchResponse(cached=False)
 
+            record_discogs_api_call()
             response.raise_for_status()
             data = response.json()
 
@@ -435,6 +444,7 @@ class DiscogsService:
                     "GET", "/database/search", params=fallback_params
                 )
                 if response is not None:
+                    record_discogs_api_call()
                     response.raise_for_status()
                     data = response.json()
 
@@ -534,11 +544,13 @@ class DiscogsService:
                         f"Cache {'validated' if cached_result else 'rejected'}: "
                         f"'{track}' by '{artist}' on release {release_id}"
                     )
+                    record_pg_cache_hit()
                     add_discogs_breadcrumb(
                         "cache_hit", {"release_id": release_id, "validated": cached_result}
                     )
                     return cached_result
                 logger.debug(f"Cache miss for validation on release {release_id}")
+                record_pg_cache_miss()
                 add_discogs_breadcrumb("cache_miss", {"release_id": release_id})
             except Exception as e:
                 logger.warning(f"Cache validation failed, falling back to API: {e}")

--- a/routers/request.py
+++ b/routers/request.py
@@ -55,7 +55,7 @@ from core.search import (
     execute_search_pipeline,
     get_search_type_from_state,
 )
-from core.telemetry import RequestTelemetry
+from core.telemetry import RequestTelemetry, get_cache_stats, init_cache_stats
 from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
 from discogs.models import DiscogsSearchRequest, DiscogsSearchResult
 from discogs.service import DiscogsService
@@ -108,6 +108,7 @@ class UnifiedResponse(BaseModel):
     song_not_found: bool = False
     found_on_compilation: bool = False
     context_message: str | None = None
+    cache_stats: dict | None = None
 
 
 async def resolve_albums_for_track(
@@ -818,6 +819,7 @@ async def handle_request(
         raise HTTPException(status_code=400, detail="Message cannot be empty")
 
     # Initialize telemetry
+    init_cache_stats()
     telemetry = RequestTelemetry()
     search_type = "none"
 
@@ -932,6 +934,7 @@ async def handle_request(
             song_not_found=song_not_found,
             found_on_compilation=found_on_compilation,
             context_message=context,
+            cache_stats=get_cache_stats(),
         )
 
     except HTTPException:

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -3,6 +3,7 @@
 
 Usage:
     python scripts/lookup.py "play bohemian rhapsody by queen"
+    python scripts/lookup.py --staging "the beatles abbey road"
     python scripts/lookup.py --verbose "the beatles abbey road"
 """
 
@@ -17,6 +18,7 @@ import httpx
 logger = logging.getLogger(__name__)
 
 PROD_URL = "https://request-o-matic-production.up.railway.app/api/v1"
+STAGING_URL = "https://request-o-matic-staging.up.railway.app/api/v1"
 LOCAL_URL = "http://localhost:8000/api/v1"
 
 
@@ -145,10 +147,22 @@ def print_library_results(
         print(f"  Confidence: {artwork.get('confidence', 0):.2f}")
 
 
-async def run_lookup(query: str, verbose: bool = False, local: bool = False) -> dict[str, Any]:
+def print_cache_stats(cache_stats: dict) -> None:
+    """Print Discogs cache statistics."""
+    print_section("Discogs Cache")
+    pg_hits = cache_stats.get("pg_hits", 0)
+    pg_misses = cache_stats.get("pg_misses", 0)
+    api_calls = cache_stats.get("api_calls", 0)
+    print(f"  PostgreSQL cache:  {pg_hits} hits, {pg_misses} misses")
+    print(f"  Discogs API calls: {api_calls}")
+
+
+async def run_lookup(
+    query: str, verbose: bool = False, local: bool = False, staging: bool = False
+) -> dict[str, Any]:
     """Call the /request endpoint with skip_slack=true."""
     set_up_logging(verbose)
-    base_url = LOCAL_URL if local else PROD_URL
+    base_url = LOCAL_URL if local else STAGING_URL if staging else PROD_URL
     logger.info(f"Processing query: {query}")
     logger.info(f"Using API: {base_url}")
 
@@ -180,6 +194,11 @@ async def run_lookup(query: str, verbose: bool = False, local: bool = False) -> 
                 data.get("context_message"),
             )
 
+            # Display cache stats if present
+            cache_stats = data.get("cache_stats")
+            if cache_stats:
+                print_cache_stats(cache_stats)
+
             return cast(dict[str, Any], data)
 
         except httpx.HTTPStatusError as e:
@@ -210,17 +229,24 @@ Examples:
         action="store_true",
         help="Enable verbose/debug logging",
     )
-    parser.add_argument(
+    server_group = parser.add_mutually_exclusive_group()
+    server_group.add_argument(
         "-l",
         "--local",
         action="store_true",
         help="Use local server (localhost:8000) instead of production",
     )
+    server_group.add_argument(
+        "-s",
+        "--staging",
+        action="store_true",
+        help="Use staging server instead of production",
+    )
 
     args = parser.parse_args()
 
     try:
-        asyncio.run(run_lookup(args.query, args.verbose, args.local))
+        asyncio.run(run_lookup(args.query, args.verbose, args.local, args.staging))
     except KeyboardInterrupt:
         print("\nInterrupted.")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- Track PostgreSQL cache hits/misses and Discogs API calls per request using a `ContextVar` in `core/telemetry.py`
- Include `cache_stats` in the `/request` API response (`UnifiedResponse`)
- Display a "Discogs Cache" section in `scripts/lookup.py` when stats are present
- Add `--staging` flag to `lookup.py` for easier testing against staging

## Test plan
- [x] All 387 unit tests pass
- [ ] Run `lookup.py --staging` and verify cache stats section appears in output
- [ ] Verify `cache_stats` field in `/request` JSON response