### PR TITLE
fix: filter fallback artist albums by track presence via Discogs vali…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ Request-O-Matic is a FastAPI service for WXYC radio that processes song requests
 3. **Library Search**: Search SQLite database with fuzzy matching
 4. **Artist Filtering**: Filter results to match requested artist (prefix matching)
 5. **Compilation Search**: If no results, search for track on compilations
-6. **Artwork**: Fetch album art from Discogs
-7. **Slack**: Post formatted results with artwork
+6. **Track Validation**: If fallback returned all artist albums, validate each against Discogs tracklists to keep only albums containing the requested track
+7. **Artwork**: Fetch album art from Discogs
+8. **Slack**: Post formatted results with artwork
 
 ### Key Files
 - `routers/request.py` - Main request handling and search orchestration

--- a/routers/request.py
+++ b/routers/request.py
@@ -637,6 +637,68 @@ async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryIte
     return results
 
 
+async def filter_results_by_track_validation(
+    results: list[LibraryItem],
+    song: str | None,
+    artist: str | None,
+    discogs_service: DiscogsService | None,
+) -> list[LibraryItem] | None:
+    """Filter fallback results to only albums that contain the requested track.
+
+    When the search pipeline falls back to returning all artist albums
+    (song_not_found=True), this function validates each album against Discogs
+    to determine which ones actually contain the requested track.
+
+    Args:
+        results: Fallback library results (all albums by artist)
+        song: Requested song title
+        artist: Requested artist name
+        discogs_service: Discogs service for API lookups
+
+    Returns:
+        Filtered list of results containing the track, or None if validation
+        isn't possible (no Discogs service, no song/artist, or no albums validated)
+    """
+    if not discogs_service or not song or not artist or not results:
+        return None
+
+    async def validate_one(item: LibraryItem) -> LibraryItem | None:
+        try:
+            response = await discogs_service.search(
+                DiscogsSearchRequest(album=item.title, artist=artist)
+            )
+            if not response.results:
+                return None
+
+            best_result = response.results[0]
+            if best_result.release_id:
+                is_valid = await discogs_service.validate_track_on_release(
+                    best_result.release_id, song, artist
+                )
+                if is_valid:
+                    logger.info(
+                        f"Track validation: '{song}' confirmed on '{item.title}' "
+                        f"(release {best_result.release_id})"
+                    )
+                    return item
+        except Exception as e:
+            logger.warning(f"Track validation failed for '{item.title}': {e}")
+        return None
+
+    validation_results = await asyncio.gather(*[validate_one(item) for item in results])
+    validated = [r for r in validation_results if r is not None]
+
+    if validated:
+        logger.info(
+            f"Track validation filtered {len(results)} albums to {len(validated)} "
+            f"containing '{song}'"
+        )
+        return validated
+
+    logger.info(f"Track validation could not confirm '{song}' on any album")
+    return None
+
+
 async def fetch_artwork_for_items(
     items: list[LibraryItem],
     discogs_service: DiscogsService | None,
@@ -880,6 +942,18 @@ async def handle_request(
             # Record Discogs API call if compilation search was used
             if found_on_compilation:
                 telemetry.record_api_call("discogs")
+
+        # Step 3b: Validate fallback results against Discogs track data
+        # When the pipeline fell back to returning all artist albums, try to
+        # filter to only albums that actually contain the requested track.
+        if song_not_found and library_results and parsed.song and parsed.artist:
+            with telemetry.track_step("track_validation"):
+                validated = await filter_results_by_track_validation(
+                    library_results, parsed.song, parsed.artist, discogs_service
+                )
+                if validated:
+                    library_results = validated
+                    song_not_found = False
 
         # Step 4: Fetch artwork for library items
         with telemetry.track_step("artwork_fetch"):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1255,3 +1255,70 @@ class TestFullRequestIntegration:
 
         # At least one query should return multiple results
         assert found_multi_result, "Expected at least one query to return multiple results"
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        reason="Known bug: fallback search returns all artist albums without track filtering"
+    )
+    async def test_6_underground_sneaker_pimps_returns_only_becoming_x(self, base_url):
+        """
+        Test that '6 underground - sneaker pimps' only returns albums with the track.
+
+        Bug: The search was returning both 'Becoming X' and 'Kiss & Swallow' with
+        the message "6 Underground is not on any album in the library", even though
+        6 Underground IS on Becoming X.
+
+        Expected: Should return only 'Becoming X' (which has 6 Underground)
+        and NOT return 'Kiss & Swallow' (which doesn't have it).
+        """
+        import httpx
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                f"{base_url}/request",
+                json={"message": "6 underground - sneaker pimps", "skip_slack": True},
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        parsed = data.get("parsed", {})
+        results = data.get("library_results", [])
+        song_not_found = data.get("song_not_found", True)
+        context_message = data.get("context_message", "")
+
+        print("\n📝 Parsed:")
+        print(f"  Artist: {parsed.get('artist')}")
+        print(f"  Song: {parsed.get('song')}")
+
+        print("\n📚 Library Results:")
+        for r in results:
+            print(f"  - {r.get('artist')} - {r.get('title')}")
+
+        print(f"\n📋 Context: {context_message}")
+        print(f"  song_not_found: {song_not_found}")
+
+        # Should have results
+        assert len(results) > 0, "Should find results for Sneaker Pimps"
+
+        # All results should be by Sneaker Pimps
+        for r in results:
+            assert "sneaker pimps" in r.get("artist", "").lower(), (
+                f"Expected Sneaker Pimps, got {r.get('artist')}"
+            )
+
+        # Should NOT include Kiss & Swallow (which doesn't have 6 Underground)
+        titles = [r.get("title", "").lower() for r in results]
+        assert "kiss & swallow" not in titles, (
+            "Kiss & Swallow should NOT be in results because it doesn't have '6 Underground'"
+        )
+
+        # Should include Becoming X (which has 6 Underground)
+        has_becoming_x = any("becoming x" in title for title in titles)
+        assert has_becoming_x, f"Expected 'Becoming X' (which has 6 Underground), but got: {titles}"
+
+        # Should NOT say "not on any album" since it IS on Becoming X
+        assert song_not_found is False, (
+            "song_not_found should be False since 6 Underground is on Becoming X"
+        )
+
+        print("\n✅ Correctly returned only albums with the requested track!")

--- a/tests/unit/test_request_flow.py
+++ b/tests/unit/test_request_flow.py
@@ -4,9 +4,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from discogs.models import DiscogsSearchResponse, DiscogsSearchResult
 from library.models import LibraryItem
 from routers.request import (
     build_context_message,
+    filter_results_by_track_validation,
     search_compilations_for_track,
 )
 from services.parser import MessageType, ParsedRequest
@@ -475,3 +477,219 @@ async def test_compilation_found_replaces_artist_albums():
     assert "Various Artists" in library_results[0].artist
     assert found_on_compilation is True
     assert song_not_found is False
+
+
+class TestFilterResultsByTrackValidation:
+    """Tests for filter_results_by_track_validation.
+
+    When the search pipeline falls back to returning all artist albums
+    (song_not_found=True), this function validates each album against Discogs
+    to determine which ones actually contain the requested track.
+    """
+
+    @pytest.fixture
+    def becoming_x(self):
+        return LibraryItem(
+            id=2725,
+            artist="Sneaker Pimps",
+            title="Becoming X",
+            call_letters="Sn",
+            artist_call_number=5,
+            release_call_number=1,
+            genre="Hiphop",
+            format="cd",
+        )
+
+    @pytest.fixture
+    def kiss_and_swallow(self):
+        return LibraryItem(
+            id=70823,
+            artist="Sneaker Pimps",
+            title="Kiss & Swallow",
+            call_letters="Sn",
+            artist_call_number=5,
+            release_call_number=2,
+            genre="Hiphop",
+            format="cdr",
+        )
+
+    @pytest.mark.asyncio
+    async def test_keeps_only_albums_with_track(self, becoming_x, kiss_and_swallow):
+        """6 Underground is on Becoming X but not Kiss & Swallow.
+
+        Bug: Fallback search returned all Sneaker Pimps albums without filtering
+        by track presence. The validation should keep only Becoming X.
+        """
+        mock_discogs = AsyncMock()
+
+        mock_discogs.search.side_effect = [
+            DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        album="Becoming X",
+                        artist="Sneaker Pimps",
+                        release_id=1273511,
+                        release_url="https://www.discogs.com/release/1273511",
+                    )
+                ],
+                total=1,
+            ),
+            DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        album="Kiss & Swallow",
+                        artist="Sneaker Pimps",
+                        release_id=11181051,
+                        release_url="https://www.discogs.com/release/11181051",
+                    )
+                ],
+                total=1,
+            ),
+        ]
+
+        # Becoming X has "6 Underground", Kiss & Swallow does not
+        mock_discogs.validate_track_on_release.side_effect = [True, False]
+
+        results = await filter_results_by_track_validation(
+            [becoming_x, kiss_and_swallow],
+            "6 Underground",
+            "Sneaker Pimps",
+            mock_discogs,
+        )
+
+        assert results is not None
+        assert len(results) == 1
+        assert results[0].title == "Becoming X"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_albums_validated(self, becoming_x, kiss_and_swallow):
+        """When no albums are validated, return None to keep fallback behavior."""
+        mock_discogs = AsyncMock()
+
+        mock_discogs.search.side_effect = [
+            DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        album="Becoming X",
+                        artist="Sneaker Pimps",
+                        release_id=1273511,
+                        release_url="https://www.discogs.com/release/1273511",
+                    )
+                ],
+                total=1,
+            ),
+            DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        album="Kiss & Swallow",
+                        artist="Sneaker Pimps",
+                        release_id=11181051,
+                        release_url="https://www.discogs.com/release/11181051",
+                    )
+                ],
+                total=1,
+            ),
+        ]
+
+        # Neither album validates (Discogs tracklist data missing or different)
+        mock_discogs.validate_track_on_release.side_effect = [False, False]
+
+        results = await filter_results_by_track_validation(
+            [becoming_x, kiss_and_swallow],
+            "6 Underground",
+            "Sneaker Pimps",
+            mock_discogs,
+        )
+
+        assert results is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_discogs_service(self, becoming_x, kiss_and_swallow):
+        """When Discogs service is unavailable, return None."""
+        results = await filter_results_by_track_validation(
+            [becoming_x, kiss_and_swallow],
+            "6 Underground",
+            "Sneaker Pimps",
+            None,
+        )
+
+        assert results is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_song(self, becoming_x):
+        """When no song is provided, return None."""
+        mock_discogs = AsyncMock()
+
+        results = await filter_results_by_track_validation(
+            [becoming_x], None, "Sneaker Pimps", mock_discogs
+        )
+
+        assert results is None
+
+    @pytest.mark.asyncio
+    async def test_handles_discogs_search_returning_no_results(self, becoming_x, kiss_and_swallow):
+        """When Discogs search returns no results for an album, skip it."""
+        mock_discogs = AsyncMock()
+
+        mock_discogs.search.side_effect = [
+            DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        album="Becoming X",
+                        artist="Sneaker Pimps",
+                        release_id=1273511,
+                        release_url="https://www.discogs.com/release/1273511",
+                    )
+                ],
+                total=1,
+            ),
+            # Kiss & Swallow not found on Discogs
+            DiscogsSearchResponse(results=[], total=0),
+        ]
+
+        mock_discogs.validate_track_on_release.return_value = True
+
+        results = await filter_results_by_track_validation(
+            [becoming_x, kiss_and_swallow],
+            "6 Underground",
+            "Sneaker Pimps",
+            mock_discogs,
+        )
+
+        assert results is not None
+        assert len(results) == 1
+        assert results[0].title == "Becoming X"
+
+    @pytest.mark.asyncio
+    async def test_handles_discogs_exception_gracefully(self, becoming_x, kiss_and_swallow):
+        """When Discogs throws an exception for one album, continue with others."""
+        mock_discogs = AsyncMock()
+
+        mock_discogs.search.side_effect = [
+            Exception("Discogs API error"),
+            DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        album="Kiss & Swallow",
+                        artist="Sneaker Pimps",
+                        release_id=11181051,
+                        release_url="https://www.discogs.com/release/11181051",
+                    )
+                ],
+                total=1,
+            ),
+        ]
+
+        mock_discogs.validate_track_on_release.return_value = True
+
+        results = await filter_results_by_track_validation(
+            [becoming_x, kiss_and_swallow],
+            "6 Underground",
+            "Sneaker Pimps",
+            mock_discogs,
+        )
+
+        # Kiss & Swallow validated (even though Becoming X errored)
+        assert results is not None
+        assert len(results) == 1
+        assert results[0].title == "Kiss & Swallow"


### PR DESCRIPTION
…dation

When searching for a song by an artist, if the Discogs track lookup fails to identify which album contains the track, the pipeline falls back to returning all albums by the artist. Previously these were returned as-is with a misleading "not on any album" message.

Now a post-pipeline step validates each fallback album against Discogs tracklists (in parallel) and filters to only albums confirmed to contain the requested track. Gracefully degrades to existing behavior when Discogs is unavailable or validation is inconclusive.

Fixes: "6 underground - sneaker pimps" returning Kiss & Swallow alongside Becoming X. Same class of bug as Lush/Thoughtforms and Biosphere/The Things I Tell You.