### PR TITLE
Optimize Discogs cache schema: drop unused tables/columns, add FK CASCADE

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -137,7 +137,7 @@ class DiscogsCacheService:
         try:
             # Get release basic info
             release_row = await self.pool.fetchrow(
-                "SELECT id, title, year, country FROM release WHERE id = $1",
+                "SELECT id, title, release_year, artwork_url FROM release WHERE id = $1",
                 release_id,
             )
 
@@ -204,7 +204,8 @@ class DiscogsCacheService:
                 release_id=release_id,
                 title=release_row["title"],
                 artist=primary_artist,
-                year=release_row["year"],
+                year=release_row["release_year"],
+                artwork_url=release_row["artwork_url"],
                 tracklist=tracklist,
                 release_url=f"https://www.discogs.com/release/{release_id}",
                 cached=True,
@@ -230,15 +231,17 @@ class DiscogsCacheService:
                 # Upsert release
                 await conn.execute(
                     """
-                    INSERT INTO release (id, title, year)
-                    VALUES ($1, $2, $3)
+                    INSERT INTO release (id, title, release_year, artwork_url)
+                    VALUES ($1, $2, $3, $4)
                     ON CONFLICT (id) DO UPDATE SET
                         title = EXCLUDED.title,
-                        year = EXCLUDED.year
+                        release_year = EXCLUDED.release_year,
+                        artwork_url = EXCLUDED.artwork_url
                     """,
                     release.release_id,
                     release.title,
                     release.year,
+                    release.artwork_url,
                 )
 
                 # Upsert primary artist

--- a/scripts/setup-discogs-db/04-create-database.sql
+++ b/scripts/setup-discogs-db/04-create-database.sql
@@ -1,5 +1,8 @@
--- Create Discogs cache database schema
+-- Create Discogs cache database schema (optimized)
 -- Run with: psql -U postgres -f 04-create-database.sql
+--
+-- This schema only includes columns actively queried by cache_service.py.
+-- FK constraints with ON DELETE CASCADE enable single-table pruning.
 
 -- Create database (run as superuser)
 -- CREATE DATABASE discogs;
@@ -11,89 +14,38 @@
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- ============================================
--- Core tables (from discogs-xml2db structure)
+-- Core tables
 -- ============================================
 
 -- Releases
 CREATE TABLE IF NOT EXISTS release (
     id              integer PRIMARY KEY,
     title           text NOT NULL,
-    released        text,
-    country         text,
-    notes           text,
-    data_quality    text,
-    master_id       integer,
-    status          text
+    release_year    smallint,
+    artwork_url     text
 );
 
 -- Artists on releases
 CREATE TABLE IF NOT EXISTS release_artist (
-    id              serial PRIMARY KEY,
-    release_id      integer NOT NULL,
-    artist_id       integer,
+    release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     artist_name     text NOT NULL,
-    extra           integer DEFAULT 0,  -- 0 = main artist, 1 = extra credit
-    anv             text,               -- artist name variation
-    position        integer,
-    join_string     text,
-    role            text,
-    tracks          text
+    extra           integer DEFAULT 0  -- 0 = main artist, 1 = extra credit
 );
 
 -- Tracks on releases
 CREATE TABLE IF NOT EXISTS release_track (
-    id              serial PRIMARY KEY,
-    release_id      integer NOT NULL,
+    release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     sequence        integer NOT NULL,
-    position        text,               -- "A1", "B2", etc.
-    parent          text,
+    position        text,              -- "A1", "B2", etc.
     title           text NOT NULL,
-    duration        text,
-    track_id        text
+    duration        text
 );
 
 -- Artists on specific tracks (for compilations)
 CREATE TABLE IF NOT EXISTS release_track_artist (
-    id              serial PRIMARY KEY,
-    release_id      integer NOT NULL,
+    release_id      integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
     track_sequence  integer NOT NULL,
-    artist_id       integer,
-    artist_name     text NOT NULL,
-    extra           integer DEFAULT 0,
-    anv             text,
-    position        integer,
-    join_string     text,
-    role            text
-);
-
--- Labels on releases
-CREATE TABLE IF NOT EXISTS release_label (
-    id              serial PRIMARY KEY,
-    release_id      integer NOT NULL,
-    label_name      text,
-    catno           text
-);
-
--- Genres and styles
-CREATE TABLE IF NOT EXISTS release_genre (
-    id              serial PRIMARY KEY,
-    release_id      integer NOT NULL,
-    genre           text NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS release_style (
-    id              serial PRIMARY KEY,
-    release_id      integer NOT NULL,
-    style           text NOT NULL
-);
-
--- Artist lookup table
-CREATE TABLE IF NOT EXISTS artist (
-    id              integer PRIMARY KEY,
-    name            text NOT NULL,
-    realname        text,
-    data_quality    text,
-    profile         text
+    artist_name     text NOT NULL
 );
 
 -- ============================================
@@ -101,7 +53,7 @@ CREATE TABLE IF NOT EXISTS artist (
 -- ============================================
 
 CREATE TABLE IF NOT EXISTS cache_metadata (
-    release_id      integer PRIMARY KEY,
+    release_id      integer PRIMARY KEY REFERENCES release(id) ON DELETE CASCADE,
     cached_at       timestamptz NOT NULL DEFAULT now(),
     source          text NOT NULL,  -- 'bulk_import' or 'api_fetch'
     last_validated  timestamptz
@@ -115,9 +67,6 @@ CREATE TABLE IF NOT EXISTS cache_metadata (
 CREATE INDEX IF NOT EXISTS idx_release_artist_release_id ON release_artist(release_id);
 CREATE INDEX IF NOT EXISTS idx_release_track_release_id ON release_track(release_id);
 CREATE INDEX IF NOT EXISTS idx_release_track_artist_release_id ON release_track_artist(release_id);
-CREATE INDEX IF NOT EXISTS idx_release_label_release_id ON release_label(release_id);
-CREATE INDEX IF NOT EXISTS idx_release_genre_release_id ON release_genre(release_id);
-CREATE INDEX IF NOT EXISTS idx_release_style_release_id ON release_style(release_id);
 
 -- Cache metadata indexes
 CREATE INDEX IF NOT EXISTS idx_cache_metadata_cached_at ON cache_metadata(cached_at);

--- a/scripts/setup-discogs-db/05-create-indexes.sql
+++ b/scripts/setup-discogs-db/05-create-indexes.sql
@@ -34,10 +34,6 @@ ON release_track_artist USING GIN (lower(artist_name) gin_trgm_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_release_title_trgm
 ON release USING GIN (lower(title) gin_trgm_ops);
 
--- 5. Artist table name search: "Find artist 'New Order'"
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_artist_name_trgm
-ON artist USING GIN (lower(name) gin_trgm_ops);
-
 -- ============================================
 -- Verification queries
 -- ============================================

--- a/scripts/setup-discogs-db/06-optimize-schema.sql
+++ b/scripts/setup-discogs-db/06-optimize-schema.sql
@@ -1,0 +1,179 @@
+-- Optimize Discogs cache schema: drop unused tables/columns, add FK constraints
+-- Run once against the existing database to migrate in-place.
+--
+-- Usage:
+--   psql -U postgres -d discogs -f 06-optimize-schema.sql
+--
+-- After running, execute VACUUM FULL separately (locks tables):
+--   VACUUM FULL release;
+--   VACUUM FULL release_artist;
+--   VACUUM FULL release_track;
+--   VACUUM FULL release_track_artist;
+
+BEGIN;
+
+-- ============================================
+-- 1. Drop unused tables
+-- ============================================
+
+DROP TABLE IF EXISTS release_label CASCADE;
+DROP TABLE IF EXISTS release_genre CASCADE;
+DROP TABLE IF EXISTS release_style CASCADE;
+DROP TABLE IF EXISTS artist CASCADE;
+
+-- ============================================
+-- 2. Add artwork_url column to release
+-- ============================================
+
+ALTER TABLE release ADD COLUMN IF NOT EXISTS artwork_url text;
+
+-- Populate from release_image if that table exists.
+-- Only keep primary images (one per release).
+-- Uncomment and run manually if release_image table is available:
+--
+-- UPDATE release r SET artwork_url = ri.uri
+-- FROM (SELECT DISTINCT ON (release_id) release_id, uri
+--        FROM release_image WHERE type = 'primary'
+--        ORDER BY release_id, uri) ri
+-- WHERE r.id = ri.release_id;
+--
+-- DROP TABLE IF EXISTS release_image CASCADE;
+
+-- ============================================
+-- 3. Add release_year column (extract from released text)
+-- ============================================
+
+ALTER TABLE release ADD COLUMN IF NOT EXISTS release_year smallint;
+
+UPDATE release SET release_year = CAST(LEFT(released, 4) AS smallint)
+WHERE released IS NOT NULL
+  AND released ~ '^\d{4}';
+
+-- ============================================
+-- 4. Drop unused columns from release
+-- ============================================
+
+ALTER TABLE release DROP COLUMN IF EXISTS notes;
+ALTER TABLE release DROP COLUMN IF EXISTS data_quality;
+ALTER TABLE release DROP COLUMN IF EXISTS status;
+ALTER TABLE release DROP COLUMN IF EXISTS country;
+ALTER TABLE release DROP COLUMN IF EXISTS released;
+
+-- ============================================
+-- 5. Drop unused columns from release_artist
+-- ============================================
+
+ALTER TABLE release_artist DROP COLUMN IF EXISTS artist_id;
+ALTER TABLE release_artist DROP COLUMN IF EXISTS anv;
+ALTER TABLE release_artist DROP COLUMN IF EXISTS position;
+ALTER TABLE release_artist DROP COLUMN IF EXISTS join_string;
+ALTER TABLE release_artist DROP COLUMN IF EXISTS role;
+ALTER TABLE release_artist DROP COLUMN IF EXISTS tracks;
+
+-- ============================================
+-- 6. Drop unused columns from release_track
+-- ============================================
+
+ALTER TABLE release_track DROP COLUMN IF EXISTS parent;
+ALTER TABLE release_track DROP COLUMN IF EXISTS track_id;
+
+-- ============================================
+-- 7. Drop unused columns from release_track_artist
+-- ============================================
+
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS artist_id;
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS extra;
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS anv;
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS position;
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS join_string;
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS role;
+
+-- ============================================
+-- 8. Add FK constraints with CASCADE
+-- ============================================
+
+-- Drop existing constraints if they exist (safe to re-run)
+ALTER TABLE release_artist DROP CONSTRAINT IF EXISTS fk_release_artist_release;
+ALTER TABLE release_track DROP CONSTRAINT IF EXISTS fk_release_track_release;
+ALTER TABLE release_track_artist DROP CONSTRAINT IF EXISTS fk_release_track_artist_release;
+ALTER TABLE cache_metadata DROP CONSTRAINT IF EXISTS fk_cache_metadata_release;
+
+ALTER TABLE release_artist
+    ADD CONSTRAINT fk_release_artist_release
+    FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE;
+
+ALTER TABLE release_track
+    ADD CONSTRAINT fk_release_track_release
+    FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE;
+
+ALTER TABLE release_track_artist
+    ADD CONSTRAINT fk_release_track_artist_release
+    FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE;
+
+ALTER TABLE cache_metadata
+    ADD CONSTRAINT fk_cache_metadata_release
+    FOREIGN KEY (release_id) REFERENCES release(id) ON DELETE CASCADE;
+
+-- ============================================
+-- 9. Drop serial PK columns from child tables
+-- ============================================
+-- These tables don't need surrogate keys; they're looked up by release_id.
+
+ALTER TABLE release_artist DROP COLUMN IF EXISTS id;
+ALTER TABLE release_track DROP COLUMN IF EXISTS id;
+ALTER TABLE release_track_artist DROP COLUMN IF EXISTS id;
+
+-- ============================================
+-- 10. Drop indexes for removed tables
+-- ============================================
+
+DROP INDEX IF EXISTS idx_release_label_release_id;
+DROP INDEX IF EXISTS idx_release_genre_release_id;
+DROP INDEX IF EXISTS idx_release_style_release_id;
+DROP INDEX IF EXISTS idx_artist_name_trgm;
+
+COMMIT;
+
+-- ============================================
+-- 11. Master release deduplication
+-- ============================================
+-- For releases sharing a master_id, keep the one with the most tracks.
+-- FK CASCADE handles child row cleanup automatically.
+-- Run this AFTER the main migration, in a separate transaction.
+
+BEGIN;
+
+DELETE FROM release
+WHERE id IN (
+    SELECT id FROM (
+        SELECT r.id, r.master_id,
+               ROW_NUMBER() OVER (
+                   PARTITION BY r.master_id
+                   ORDER BY tc.track_count DESC, r.id ASC
+               ) as rn
+        FROM release r
+        JOIN (
+            SELECT release_id, COUNT(*) as track_count
+            FROM release_track
+            GROUP BY release_id
+        ) tc ON tc.release_id = r.id
+        WHERE r.master_id IS NOT NULL
+    ) ranked
+    WHERE rn > 1
+);
+
+-- Now drop master_id (no longer needed)
+ALTER TABLE release DROP COLUMN IF EXISTS master_id;
+
+COMMIT;
+
+-- ============================================
+-- Post-migration: reclaim disk space
+-- ============================================
+-- Run these separately as they lock tables:
+--
+-- VACUUM FULL release;
+-- VACUUM FULL release_artist;
+-- VACUUM FULL release_track;
+-- VACUUM FULL release_track_artist;
+-- VACUUM FULL cache_metadata;

--- a/scripts/setup-discogs-db/filter_discogs_csv.py
+++ b/scripts/setup-discogs-db/filter_discogs_csv.py
@@ -19,20 +19,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# CSV files that need to be filtered by release_id
+# CSV files that need to be filtered by release_id.
+# Only includes files needed by the optimized schema (see 04-create-database.sql).
+# Dropped tables (release_label, release_genre, release_style) are excluded.
 RELEASE_ID_FILES = [
     "release.csv",
     "release_artist.csv",
     "release_track.csv",
     "release_track_artist.csv",
-    "release_company.csv",
-    "release_format.csv",
-    "release_genre.csv",
-    "release_identifier.csv",
-    "release_image.csv",
-    "release_label.csv",
-    "release_style.csv",
-    "release_video.csv",
+    "release_image.csv",  # for artwork_url extraction during import
 ]
 
 
@@ -178,17 +173,6 @@ def main():
         reduction_pct = (1 - output_count / input_count) * 100 if input_count > 0 else 0
         stats[filename] = (input_count, output_count, reduction_pct)
         logger.info(f"  {input_count:,} → {output_count:,} rows ({reduction_pct:.1f}% reduction)")
-
-    # Step 4: Copy artist-related files unchanged (we need full artist data for joins)
-    artist_files = ["artist.csv", "artist_alias.csv", "artist_namevariation.csv", "artist_url.csv"]
-    for filename in artist_files:
-        input_path = csv_input_dir / filename
-        if input_path.exists():
-            output_path = csv_output_dir / filename
-            logger.info(f"Copying {filename} (unchanged)...")
-            import shutil
-
-            shutil.copy(input_path, output_path)
 
     # Summary
     logger.info("\n=== Summary ===")

--- a/scripts/setup-discogs-db/import_csv.py
+++ b/scripts/setup-discogs-db/import_csv.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
-"""Import Discogs CSV files into PostgreSQL with proper multiline handling."""
+"""Import Discogs CSV files into PostgreSQL with proper multiline handling.
+
+Imports only the columns needed by the optimized schema (see 04-create-database.sql).
+Dropped tables (release_label, release_genre, release_style, artist) are skipped.
+The release_image.csv is processed separately to populate artwork_url on release.
+"""
 
 import csv
 import logging
+import re
 import sys
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypedDict
 
 import psycopg
 
@@ -14,107 +22,134 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Table configs: (csv_filename, table_name, columns, required_columns)
-# required_columns lists column names that must not be null
-TABLES = [
-    (
-        "release.csv",
-        "release",
-        ["id", "title", "released", "country", "notes", "data_quality", "master_id", "status"],
-        ["id", "title"],
-    ),
-    (
-        "release_artist.csv",
-        "release_artist",
-        [
-            "release_id",
-            "artist_id",
-            "artist_name",
-            "extra",
-            "anv",
-            "position",
-            "join_string",
-            "role",
-            "tracks",
-        ],
-        ["release_id", "artist_id"],
-    ),
-    (
-        "release_track.csv",
-        "release_track",
-        ["release_id", "sequence", "position", "parent", "title", "duration", "track_id"],
-        ["release_id", "title"],
-    ),
-    (
-        "release_track_artist.csv",
-        "release_track_artist",
-        [
-            "release_id",
-            "track_sequence",
-            "artist_id",
-            "artist_name",
-            "extra",
-            "anv",
-            "position",
-            "join_string",
-            "role",
-        ],
-        ["release_id", "track_sequence", "artist_id"],
-    ),
-    ("release_label.csv", "release_label", ["release_id", "label_name", "catno"], ["release_id"]),
-    ("release_genre.csv", "release_genre", ["release_id", "genre"], ["release_id"]),
-    ("release_style.csv", "release_style", ["release_id", "style"], ["release_id"]),
-    ("artist.csv", "artist", ["id", "name", "realname", "data_quality", "profile"], ["id", "name"]),
+# Table configs: (csv_filename, table_name, csv_columns, db_columns, required_columns, transforms)
+#
+# csv_columns: columns to read from the CSV (in CSV header order)
+# db_columns: corresponding column names in the DB table
+# required_columns: CSV column names that must not be null
+# transforms: dict mapping csv_column -> callable for value transformation
+#
+# When csv_columns != db_columns, values are mapped positionally.
+
+YEAR_RE = re.compile(r"^\d{4}")
+
+
+def extract_year(released: str | None) -> str | None:
+    """Extract 4-digit year from a Discogs 'released' text field."""
+    if released and YEAR_RE.match(released):
+        return released[:4]
+    return None
+
+
+class TableConfig(TypedDict):
+    csv_file: str
+    table: str
+    csv_columns: list[str]
+    db_columns: list[str]
+    required: list[str]
+    transforms: dict[str, Callable[[str | None], str | None]]
+
+
+TABLES: list[TableConfig] = [
+    {
+        "csv_file": "release.csv",
+        "table": "release",
+        "csv_columns": ["id", "title", "released"],
+        "db_columns": ["id", "title", "release_year"],
+        "required": ["id", "title"],
+        "transforms": {"released": extract_year},
+    },
+    {
+        "csv_file": "release_artist.csv",
+        "table": "release_artist",
+        "csv_columns": ["release_id", "artist_name", "extra"],
+        "db_columns": ["release_id", "artist_name", "extra"],
+        "required": ["release_id"],
+        "transforms": {},
+    },
+    {
+        "csv_file": "release_track.csv",
+        "table": "release_track",
+        "csv_columns": ["release_id", "sequence", "position", "title", "duration"],
+        "db_columns": ["release_id", "sequence", "position", "title", "duration"],
+        "required": ["release_id", "title"],
+        "transforms": {},
+    },
+    {
+        "csv_file": "release_track_artist.csv",
+        "table": "release_track_artist",
+        "csv_columns": ["release_id", "track_sequence", "artist_name"],
+        "db_columns": ["release_id", "track_sequence", "artist_name"],
+        "required": ["release_id", "track_sequence"],
+        "transforms": {},
+    },
 ]
 
 
 def import_csv(
-    conn, csv_path: Path, table: str, columns: list[str], required_columns: list[str]
+    conn,
+    csv_path: Path,
+    table: str,
+    csv_columns: list[str],
+    db_columns: list[str],
+    required_columns: list[str],
+    transforms: dict,
 ) -> int:
-    """Import a CSV file into a table, skipping rows with null required fields."""
+    """Import a CSV file into a table, selecting only needed columns.
+
+    Reads the CSV header to find column indices, extracts only the columns
+    listed in csv_columns, applies any transforms, and writes to the DB
+    using the corresponding db_columns names.
+    """
     logger.info(f"Importing {csv_path.name} into {table}...")
 
-    # Build the COPY command
-    col_list = ", ".join(columns)
-
-    # Get indices of required columns
-    required_indices = [columns.index(col) for col in required_columns]
+    db_col_list = ", ".join(db_columns)
 
     with open(csv_path, encoding="utf-8", errors="replace") as f:
-        # Skip header
-        next(f)
+        reader = csv.DictReader(f)
+        header = reader.fieldnames
+        if not header:
+            logger.warning(f"  No header found in {csv_path.name}, skipping")
+            return 0
+
+        # Verify required CSV columns exist in header
+        missing = [c for c in csv_columns if c not in header]
+        if missing:
+            logger.error(f"  Missing columns in {csv_path.name}: {missing}")
+            return 0
+
+        # Find indices of required columns for null checking
+        required_set = set(required_columns)
 
         with conn.cursor() as cur:
-            with cur.copy(f"COPY {table} ({col_list}) FROM STDIN") as copy:
-                reader = csv.reader(f)
+            with cur.copy(f"COPY {table} ({db_col_list}) FROM STDIN") as copy:
                 count = 0
                 skipped = 0
                 for row in reader:
-                    # Pad row to match columns if short
-                    while len(row) < len(columns):
-                        row.append("")
-                    # Truncate if too long
-                    row = row[: len(columns)]
-
-                    # Convert empty strings to None for integer columns
-                    processed: list[str | None] = []
-                    for val in row:
-                        if val == "":
-                            processed.append(None)
-                        else:
-                            processed.append(val)
-
-                    # Skip rows where required columns are null
+                    # Extract only the columns we need
+                    values: list[str | None] = []
                     skip = False
-                    for idx in required_indices:
-                        if processed[idx] is None:
+                    for csv_col in csv_columns:
+                        val = row.get(csv_col, "")
+                        if val == "":
+                            val = None
+
+                        # Apply transform if defined
+                        if csv_col in transforms:
+                            val = transforms[csv_col](val)
+
+                        # Check required columns
+                        if csv_col in required_set and val is None:
                             skip = True
                             break
+
+                        values.append(val)
+
                     if skip:
                         skipped += 1
                         continue
 
-                    copy.write_row(processed)
+                    copy.write_row(values)
                     count += 1
 
                     if count % 500000 == 0:
@@ -126,6 +161,79 @@ def import_csv(
     else:
         logger.info(f"  Imported {count:,} rows")
     return count
+
+
+def import_artwork(conn, csv_dir: Path) -> int:
+    """Populate release.artwork_url from release_image.csv.
+
+    Reads the release_image CSV and updates the release table with the URI
+    of each release's primary image. Only 'primary' type images are used;
+    if none exists, the first image is used as fallback.
+    """
+    csv_path = csv_dir / "release_image.csv"
+    if not csv_path.exists():
+        logger.warning("release_image.csv not found, skipping artwork import")
+        return 0
+
+    logger.info("Importing artwork URLs from release_image.csv...")
+
+    # Collect primary image URIs (one per release)
+    artwork: dict[int, str] = {}
+    fallback: dict[int, str] = {}
+
+    with open(csv_path, encoding="utf-8", errors="replace") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                release_id = int(row["release_id"])
+            except (ValueError, KeyError):
+                continue
+
+            uri = row.get("uri", "")
+            if not uri:
+                continue
+
+            img_type = row.get("type", "")
+            if img_type == "primary" and release_id not in artwork:
+                artwork[release_id] = uri
+            elif release_id not in fallback:
+                fallback[release_id] = uri
+
+    # Merge: prefer primary, fall back to first image
+    for release_id, uri in fallback.items():
+        if release_id not in artwork:
+            artwork[release_id] = uri
+
+    if not artwork:
+        logger.info("  No artwork URLs found")
+        return 0
+
+    # Batch update using a temp table for efficiency
+    logger.info(f"  Updating {len(artwork):,} releases with artwork URLs...")
+    with conn.cursor() as cur:
+        cur.execute("""
+            CREATE TEMP TABLE _artwork (
+                release_id integer PRIMARY KEY,
+                artwork_url text NOT NULL
+            )
+        """)
+
+        with cur.copy("COPY _artwork (release_id, artwork_url) FROM STDIN") as copy:
+            for release_id, uri in artwork.items():
+                copy.write_row((release_id, uri))
+
+        cur.execute("""
+            UPDATE release r
+            SET artwork_url = a.artwork_url
+            FROM _artwork a
+            WHERE r.id = a.release_id
+        """)
+
+        cur.execute("DROP TABLE _artwork")
+
+    conn.commit()
+    logger.info(f"  Updated {len(artwork):,} releases with artwork URLs")
+    return len(artwork)
 
 
 def main():
@@ -144,14 +252,25 @@ def main():
     conn = psycopg.connect(db_url)
 
     total = 0
-    for csv_file, table, columns, required_columns in TABLES:
-        csv_path = csv_dir / csv_file
+    for table_config in TABLES:
+        csv_path = csv_dir / table_config["csv_file"]
         if not csv_path.exists():
-            logger.warning(f"Skipping {csv_file} (not found)")
+            logger.warning(f"Skipping {table_config['csv_file']} (not found)")
             continue
 
-        count = import_csv(conn, csv_path, table, columns, required_columns)
+        count = import_csv(
+            conn,
+            csv_path,
+            table_config["table"],
+            table_config["csv_columns"],
+            table_config["db_columns"],
+            table_config["required"],
+            table_config["transforms"],
+        )
         total += count
+
+    # Import artwork from release_image.csv
+    import_artwork(conn, csv_dir)
 
     # Populate cache_metadata
     logger.info("Populating cache_metadata...")

--- a/tests/unit/test_discogs_cache_service.py
+++ b/tests/unit/test_discogs_cache_service.py
@@ -87,8 +87,8 @@ class TestGetRelease:
             return_value={
                 "id": 28138,
                 "title": "Confield",
-                "year": 2001,
-                "country": "UK",
+                "release_year": 2001,
+                "artwork_url": "https://img.discogs.com/abc/cover.jpg",
             }
         )
         # Artists query
@@ -114,6 +114,7 @@ class TestGetRelease:
         assert result.title == "Confield"
         assert result.artist == "Autechre"
         assert result.year == 2001
+        assert result.artwork_url == "https://img.discogs.com/abc/cover.jpg"
         assert len(result.tracklist) == 2
         assert result.tracklist[0].title == "VI Scose Poise"
 
@@ -171,6 +172,10 @@ class TestWriteRelease:
 
         # Verify execute was called (for release upsert)
         assert mock_conn.execute.called
+        # Verify the release upsert uses the new column names
+        first_call_query = mock_conn.execute.call_args_list[0][0][0]
+        assert "release_year" in first_call_query
+        assert "artwork_url" in first_call_query
         # Verify executemany was called (for tracks)
         assert mock_conn.executemany.called
 
@@ -261,7 +266,12 @@ class TestValidateTrackOnRelease:
         mock_pool = MagicMock()
         # Release exists
         mock_pool.fetchrow = AsyncMock(
-            return_value={"id": 28138, "title": "Confield", "year": 2001, "country": "UK"}
+            return_value={
+                "id": 28138,
+                "title": "Confield",
+                "release_year": 2001,
+                "artwork_url": None,
+            }
         )
         # Track query returns match
         mock_pool.fetch = AsyncMock(
@@ -284,7 +294,12 @@ class TestValidateTrackOnRelease:
         """Test returns False when track not on release."""
         mock_pool = MagicMock()
         mock_pool.fetchrow = AsyncMock(
-            return_value={"id": 28138, "title": "Confield", "year": 2001, "country": "UK"}
+            return_value={
+                "id": 28138,
+                "title": "Confield",
+                "release_year": 2001,
+                "artwork_url": None,
+            }
         )
         mock_pool.fetch = AsyncMock(
             side_effect=[


### PR DESCRIPTION
## Summary

- Drop 4 unused tables (`release_label`, `release_genre`, `release_style`, `artist`) and 22 unused columns across the remaining tables, keeping only columns actively queried by `cache_service.py`
- Add FK constraints with `ON DELETE CASCADE` on all child tables, enabling single-table pruning (complements PR #3's verify/prune workflow)
- Fix `year` column bug: rename `released` (text like "2001-03-15") to `release_year` (smallint), which was previously queried as `year` (a column that didn't exist)
- Add `artwork_url` column to `release`, populated from `release_image.csv` during bulk import and cached from API responses
- Deduplicate releases sharing a `master_id`, keeping the release with the most tracks
- Add `06-optimize-schema.sql` migration script for transforming the existing 40 GB database in-place

Depends on #3 (merge that first). The `verify_cache.py` changes in #3 already account for the dropped tables and CASCADE pruning.

Estimated savings: **~35-40 GB** (down to ~2-5 GB).

### Files changed

| File | Change |
|------|--------|
| `scripts/setup-discogs-db/06-optimize-schema.sql` | New migration script for existing DB |
| `scripts/setup-discogs-db/04-create-database.sql` | Slim schema for fresh imports |
| `scripts/setup-discogs-db/05-create-indexes.sql` | Remove dropped table indexes |
| `discogs/cache_service.py` | Fix `year` bug, add `artwork_url` support |
| `scripts/setup-discogs-db/import_csv.py` | Import only needed columns, extract year, import artwork |
| `scripts/setup-discogs-db/filter_discogs_csv.py` | Skip filtering dropped tables' CSVs |
| `tests/unit/test_discogs_cache_service.py` | Update mocks for new column names |

## Test plan

- [x] 393 unit tests pass (full suite)
- [ ] Run `06-optimize-schema.sql` against a backup of the Discogs cache DB
- [ ] Verify `cache_service.py` queries work against the optimized schema
- [ ] Run `verify_cache.py` dry run to confirm classification still works with CASCADE