### PR TITLE
Add skip_cache flag to bypass caches per-request

### DIFF
--- a/discogs/memory_cache.py
+++ b/discogs/memory_cache.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 from collections.abc import Callable
+from contextvars import ContextVar
 from functools import wraps
 from typing import Any, TypeVar
 
@@ -23,6 +24,20 @@ _release_cache: TTLCache | None = None
 _search_cache: TTLCache | None = None
 
 T = TypeVar("T")
+
+# Per-request flag to bypass all caches (in-memory and PG).
+# Used for benchmarking and A/B cache comparisons.
+_skip_cache_var: ContextVar[bool] = ContextVar("skip_cache", default=False)
+
+
+def set_skip_cache(skip: bool) -> None:
+    """Set the per-request skip_cache flag."""
+    _skip_cache_var.set(skip)
+
+
+def should_skip_cache() -> bool:
+    """Check whether caches should be bypassed for the current request."""
+    return _skip_cache_var.get(False)
 
 
 def make_cache_key(func_name: str, *args, **kwargs) -> str:
@@ -110,6 +125,10 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         async def wrapper(*args, **kwargs) -> T:
+            # Bypass cache entirely when skip_cache flag is set
+            if should_skip_cache():
+                return await func(*args, **kwargs)  # type: ignore[misc, no-any-return]
+
             # Generate cache key from function name and arguments
             # Skip 'self' if present (first arg of instance methods)
             # Check if first arg has this method, indicating it's 'self'

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -18,7 +18,13 @@ from core.telemetry import (
     record_pg_cache_miss,
     record_pg_time,
 )
-from discogs.memory_cache import RELEASE_CACHE, SEARCH_CACHE, TRACK_CACHE, async_cached
+from discogs.memory_cache import (
+    RELEASE_CACHE,
+    SEARCH_CACHE,
+    TRACK_CACHE,
+    async_cached,
+    should_skip_cache,
+)
 from discogs.models import (
     DiscogsSearchRequest,
     DiscogsSearchResponse,
@@ -182,7 +188,7 @@ class DiscogsService:
             TrackReleasesResponse with list of releases
         """
         # Try local cache first
-        if self.cache_service:
+        if self.cache_service and not should_skip_cache():
             try:
                 add_discogs_breadcrumb(
                     "cache_search_releases_by_track",
@@ -339,7 +345,7 @@ class DiscogsService:
             ReleaseMetadataResponse with full metadata, or None on error
         """
         # Try local cache first
-        if self.cache_service:
+        if self.cache_service and not should_skip_cache():
             try:
                 add_discogs_breadcrumb("cache_get_release", {"release_id": release_id})
                 start = time.perf_counter()
@@ -409,7 +415,7 @@ class DiscogsService:
             )
 
             # Write back to cache for future queries
-            if self.cache_service:
+            if self.cache_service and not should_skip_cache():
                 try:
                     add_discogs_breadcrumb("cache_write_release", {"release_id": release_id})
                     await self.cache_service.write_release(release)
@@ -441,7 +447,7 @@ class DiscogsService:
             return DiscogsSearchResponse(cached=False)
 
         # Try local cache first
-        if self.cache_service:
+        if self.cache_service and not should_skip_cache():
             try:
                 add_discogs_breadcrumb(
                     "cache_search_releases",
@@ -605,7 +611,7 @@ class DiscogsService:
             True if the track by the artist is found on the release
         """
         # Try cache validation first
-        if self.cache_service:
+        if self.cache_service and not should_skip_cache():
             try:
                 add_discogs_breadcrumb(
                     "cache_validate_track",

--- a/routers/request.py
+++ b/routers/request.py
@@ -58,6 +58,7 @@ from core.search import (
 )
 from core.telemetry import RequestTelemetry, get_cache_stats, init_cache_stats
 from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
+from discogs.memory_cache import set_skip_cache
 from discogs.models import DiscogsSearchRequest, DiscogsSearchResult
 from discogs.service import DiscogsService
 from library.db import LibraryDB
@@ -96,6 +97,7 @@ class RequestBody(BaseModel):
 
     message: str
     skip_slack: bool = False
+    skip_cache: bool = False
 
 
 class UnifiedResponse(BaseModel):
@@ -892,6 +894,8 @@ async def handle_request(
 
     # Initialize telemetry
     init_cache_stats()
+    if request.skip_cache:
+        set_skip_cache(True)
     telemetry = RequestTelemetry()
     search_type = "none"
 

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -165,7 +165,11 @@ def print_cache_stats(cache_stats: dict) -> None:
 
 
 async def run_lookup(
-    query: str, verbose: bool = False, local: bool = False, staging: bool = False
+    query: str,
+    verbose: bool = False,
+    local: bool = False,
+    staging: bool = False,
+    skip_cache: bool = False,
 ) -> dict[str, Any]:
     """Call the /request endpoint with skip_slack=true."""
     set_up_logging(verbose)
@@ -175,10 +179,14 @@ async def run_lookup(
 
     async with httpx.AsyncClient(timeout=60.0) as client:
         try:
+            body: dict[str, Any] = {"message": query, "skip_slack": True}
+            if skip_cache:
+                body["skip_cache"] = True
+                logger.info("Cache bypass enabled (skip_cache=True)")
             logger.info("Calling /request endpoint...")
             response = await client.post(
                 f"{base_url}/request",
-                json={"message": query, "skip_slack": True},
+                json=body,
             )
             response.raise_for_status()
             data = response.json()
@@ -236,6 +244,12 @@ Examples:
         action="store_true",
         help="Enable verbose/debug logging",
     )
+    parser.add_argument(
+        "-C",
+        "--skip-cache",
+        action="store_true",
+        help="Bypass all caches (in-memory and PG) to force API calls",
+    )
     server_group = parser.add_mutually_exclusive_group()
     server_group.add_argument(
         "-l",
@@ -253,7 +267,7 @@ Examples:
     args = parser.parse_args()
 
     try:
-        asyncio.run(run_lookup(args.query, args.verbose, args.local, args.staging))
+        asyncio.run(run_lookup(args.query, args.verbose, args.local, args.staging, args.skip_cache))
     except KeyboardInterrupt:
         print("\nInterrupted.")
         sys.exit(1)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1322,3 +1322,45 @@ class TestFullRequestIntegration:
         )
 
         print("\n✅ Correctly returned only albums with the requested track!")
+
+    @pytest.mark.asyncio
+    async def test_skip_cache_bypasses_all_caches(self, base_url):
+        """
+        Test that skip_cache=True bypasses both in-memory and PG caches.
+
+        Sends the same query twice: once normally (which populates caches),
+        then with skip_cache=True. The second request should show 0 memory
+        hits and 0 PG hits.
+        """
+        import httpx
+
+        query = "Autechre Confield"
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            # First request: populates caches
+            response1 = await client.post(
+                f"{base_url}/request",
+                json={"message": query, "skip_slack": True},
+            )
+            response1.raise_for_status()
+
+            # Second request: skip_cache should bypass all caches
+            response2 = await client.post(
+                f"{base_url}/request",
+                json={"message": query, "skip_slack": True, "skip_cache": True},
+            )
+            response2.raise_for_status()
+            data = response2.json()
+
+        cache_stats = data.get("cache_stats", {})
+        memory_hits = cache_stats.get("memory_hits", 0)
+        pg_hits = cache_stats.get("pg_hits", 0)
+
+        print(f"\n📊 Cache stats with skip_cache=True: {cache_stats}")
+
+        assert memory_hits == 0, (
+            f"Expected 0 memory cache hits with skip_cache=True, got {memory_hits}"
+        )
+        assert pg_hits == 0, f"Expected 0 PG cache hits with skip_cache=True, got {pg_hits}"
+
+        print("✅ skip_cache=True correctly bypassed all caches")

--- a/tests/unit/test_discogs_cache.py
+++ b/tests/unit/test_discogs_cache.py
@@ -2,7 +2,14 @@
 
 import pytest
 
-from discogs.memory_cache import async_cached, clear_all_caches, create_ttl_cache, make_cache_key
+from discogs.memory_cache import (
+    async_cached,
+    clear_all_caches,
+    create_ttl_cache,
+    make_cache_key,
+    set_skip_cache,
+    should_skip_cache,
+)
 
 # Default test data
 TEST_TRACK = "VI Scose Poise"
@@ -269,3 +276,61 @@ class TestClearAllCaches:
         await func1(TEST_TRACK)
         await func2(TEST_TRACK)
         assert call_count == 4
+
+
+class TestSkipCache:
+    """Tests for the skip_cache ContextVar flag."""
+
+    @pytest.fixture(autouse=True)
+    def reset_skip_cache(self):
+        """Reset the skip_cache flag before and after each test."""
+        set_skip_cache(False)
+        clear_all_caches()
+        yield
+        set_skip_cache(False)
+        clear_all_caches()
+
+    def test_should_skip_cache_defaults_false(self):
+        """Test that should_skip_cache() returns False by default."""
+        assert should_skip_cache() is False
+
+    @pytest.mark.asyncio
+    async def test_async_cached_skipped_when_flag_set(self):
+        """Test that the cache is bypassed when skip_cache flag is set."""
+        cache = create_ttl_cache(maxsize=100, ttl=3600)
+        call_count = 0
+
+        @async_cached(cache)
+        async def my_func(track: str) -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"track": track, "cached": False}
+
+        set_skip_cache(True)
+
+        # Both calls should invoke the function (no caching)
+        result1 = await my_func(TEST_TRACK)
+        result2 = await my_func(TEST_TRACK)
+
+        assert result1["track"] == TEST_TRACK
+        assert result2["track"] == TEST_TRACK
+        assert call_count == 2  # Function called both times
+
+    @pytest.mark.asyncio
+    async def test_async_cached_normal_when_flag_not_set(self):
+        """Test that caching still works normally when skip_cache flag is False."""
+        cache = create_ttl_cache(maxsize=100, ttl=3600)
+        call_count = 0
+
+        @async_cached(cache)
+        async def my_func(track: str) -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {"track": track, "cached": False}
+
+        set_skip_cache(False)
+
+        await my_func(TEST_TRACK)
+        await my_func(TEST_TRACK)
+
+        assert call_count == 1  # Function called only once (second was cache hit)

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -7,7 +7,7 @@ import pytest
 import pytest_asyncio
 from pytest_httpx import HTTPXMock
 
-from discogs.memory_cache import clear_all_caches
+from discogs.memory_cache import clear_all_caches, set_skip_cache
 from discogs.models import (
     DiscogsSearchRequest,
     ReleaseInfo,
@@ -41,12 +41,14 @@ async def service():
 
 @pytest.fixture(autouse=True)
 def clear_caches():
-    """Clear all caches and rate limiting state before and after each test."""
+    """Clear all caches, rate limiting, and skip_cache state before and after each test."""
     clear_all_caches()
     reset_rate_limiting()
+    set_skip_cache(False)
     yield
     clear_all_caches()
     reset_rate_limiting()
+    set_skip_cache(False)
 
 
 class TestSearchReleasesByTrack:
@@ -804,3 +806,138 @@ class TestCacheIntegration:
         assert result.total >= 1
         assert result.cached is False
         assert len(httpx_mock.get_requests()) == 1
+
+
+class TestSkipCacheBypassesPgCache:
+    """Tests that the skip_cache ContextVar bypasses PG cache lookups."""
+
+    @pytest.fixture
+    def mock_cache_service(self):
+        """Create a mock cache service."""
+        from discogs.cache_service import DiscogsCacheService
+
+        cache = MagicMock(spec=DiscogsCacheService)
+        cache.search_releases_by_track = AsyncMock()
+        cache.search_releases = AsyncMock()
+        cache.get_release = AsyncMock()
+        cache.write_release = AsyncMock()
+        cache.validate_track_on_release = AsyncMock()
+        cache.is_available = AsyncMock(return_value=True)
+        return cache
+
+    @pytest_asyncio.fixture
+    async def service_with_cache(self, mock_cache_service):
+        """Create a DiscogsService with cache service."""
+        svc = DiscogsService(token="test-token", cache_service=mock_cache_service)
+        yield svc
+        await svc.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+    async def test_search_skips_pg_cache_when_flag_set(
+        self, service_with_cache: DiscogsService, mock_cache_service, httpx_mock: HTTPXMock
+    ):
+        """Test search() skips PG cache when skip_cache flag is set."""
+        httpx_mock.add_response(
+            url=SEARCH_URL_PATTERN,
+            json={
+                "results": [
+                    {
+                        "id": TEST_RELEASE_ID,
+                        "title": f"{TEST_ARTIST} - {TEST_ALBUM}",
+                        "type": "release",
+                        "thumb": "https://i.discogs.com/thumb.jpg",
+                    }
+                ]
+            },
+        )
+
+        set_skip_cache(True)
+        request = DiscogsSearchRequest(artist=TEST_ARTIST, album=TEST_ALBUM)
+        result = await service_with_cache.search(request)
+
+        # PG cache should NOT have been consulted
+        mock_cache_service.search_releases.assert_not_called()
+        # API should have been called
+        assert len(httpx_mock.get_requests()) >= 1
+        assert result.total >= 1
+
+    @pytest.mark.asyncio
+    async def test_get_release_skips_pg_cache_when_flag_set(
+        self, service_with_cache: DiscogsService, mock_cache_service, httpx_mock: HTTPXMock
+    ):
+        """Test get_release() skips PG cache when skip_cache flag is set."""
+        httpx_mock.add_response(
+            url=RELEASE_URL_PATTERN,
+            json={
+                "id": TEST_RELEASE_ID,
+                "title": TEST_ALBUM,
+                "artists": [{"name": TEST_ARTIST}],
+                "tracklist": [],
+            },
+        )
+
+        set_skip_cache(True)
+        result = await service_with_cache.get_release(TEST_RELEASE_ID)
+
+        # PG cache should NOT have been consulted
+        mock_cache_service.get_release.assert_not_called()
+        # Write-back should also be skipped
+        mock_cache_service.write_release.assert_not_called()
+        # API should have been called
+        assert len(httpx_mock.get_requests()) == 1
+        assert result is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+    async def test_search_releases_by_track_skips_pg_cache_when_flag_set(
+        self, service_with_cache: DiscogsService, mock_cache_service, httpx_mock: HTTPXMock
+    ):
+        """Test search_releases_by_track() skips PG cache when skip_cache flag is set."""
+        httpx_mock.add_response(
+            url=SEARCH_URL_PATTERN,
+            json={
+                "results": [
+                    {
+                        "id": TEST_RELEASE_ID,
+                        "title": f"{TEST_ARTIST} - {TEST_ALBUM}",
+                        "type": "release",
+                    }
+                ]
+            },
+        )
+
+        set_skip_cache(True)
+        await service_with_cache.search_releases_by_track(TEST_TRACK, TEST_ARTIST)
+
+        # PG cache should NOT have been consulted
+        mock_cache_service.search_releases_by_track.assert_not_called()
+        # API should have been called
+        assert len(httpx_mock.get_requests()) >= 1
+
+    @pytest.mark.asyncio
+    async def test_validate_track_skips_pg_cache_when_flag_set(
+        self, service_with_cache: DiscogsService, mock_cache_service, httpx_mock: HTTPXMock
+    ):
+        """Test validate_track_on_release() skips PG cache when skip_cache flag is set."""
+        httpx_mock.add_response(
+            url=RELEASE_URL_PATTERN,
+            json={
+                "id": TEST_RELEASE_ID,
+                "title": TEST_ALBUM,
+                "artists": [{"name": TEST_ARTIST}],
+                "tracklist": [
+                    {"position": "1", "title": TEST_TRACK, "artists": [{"name": TEST_ARTIST}]}
+                ],
+            },
+        )
+
+        set_skip_cache(True)
+        result = await service_with_cache.validate_track_on_release(
+            TEST_RELEASE_ID, TEST_TRACK, TEST_ARTIST
+        )
+
+        # PG cache should NOT have been consulted
+        mock_cache_service.validate_track_on_release.assert_not_called()
+        # Should have fallen through to API
+        assert result is True


### PR DESCRIPTION
## Summary

- Add a `skip_cache` ContextVar flag that bypasses both the in-memory TTL cache (`async_cached` decorator) and the PostgreSQL cache in `DiscogsService` on a per-request basis
- Wire the flag through the `/request` endpoint as `skip_cache: bool = False` on `RequestBody`
- Add `--skip-cache` / `-C` CLI flag to `scripts/lookup.py` for A/B latency comparisons

## Motivation

The benchmark queries all return 0 PG cache hits because the in-memory TTL cache (checked first by `@async_cached`) serves repeat queries. To measure PG cache vs API latency in production, we need a way to bypass both caches per-request without affecting concurrent requests.

## Test plan

- [x] 3 unit tests for ContextVar and `async_cached` bypass in `test_discogs_cache.py`
- [x] 4 unit tests for PG cache bypass across all `DiscogsService` methods in `test_discogs_service.py`
- [x] 1 integration test: same query with and without `skip_cache`, verifying 0 memory/PG hits
- [x] All 413 unit tests pass