### PR TITLE
fix: skip search pipeline for non-request messages

### DIFF
--- a/routers/request.py
+++ b/routers/request.py
@@ -908,6 +908,18 @@ async def handle_request(
                 f"Parsed request: is_request={parsed.is_request}, type={parsed.message_type}"
             )
 
+        # Early return for non-requests (feedback, DJ messages, etc.)
+        # No point running the search pipeline for messages that aren't song requests.
+        if not parsed.is_request:
+            if not request.skip_slack:
+                await post_results_to_slack(
+                    slack_service, request.message, parsed, [], context=None
+                )
+            return UnifiedResponse(
+                parsed=parsed,
+                cache_stats=get_cache_stats(),
+            )
+
         library_results: list[LibraryItem] = []
         items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]] = []
         song_not_found = False

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -97,6 +97,34 @@ async def lookup_discogs_urls(
     return discogs_urls
 
 
+def print_search_summary(data: dict) -> None:
+    """Print search summary showing what kind of results we got."""
+    parsed = data.get("parsed", {})
+    is_request = parsed.get("is_request", False)
+
+    if not is_request:
+        label = parsed.get("message_type", "other")
+        print_section("Search")
+        print(f"  Not a song request ({label}). No library search performed.")
+        return
+
+    song_not_found = data.get("song_not_found", False)
+    found_on_compilation = data.get("found_on_compilation", False)
+    search_type = data.get("search_type", "none")
+    results = data.get("library_results", [])
+
+    print_section("Search")
+    print(f"  Strategy:  {search_type}")
+    if found_on_compilation:
+        print(f"  Match:     found on compilation ({len(results)} result(s))")
+    elif song_not_found and results:
+        print(f"  Match:     song not found -- showing other albums by artist ({len(results)})")
+    elif results:
+        print(f"  Match:     direct ({len(results)} result(s))")
+    else:
+        print("  Match:     no results")
+
+
 def print_library_results(
     results: list[dict],
     artwork: dict | None,
@@ -192,7 +220,15 @@ async def run_lookup(
             data = response.json()
 
             # Display parsed request
-            print_parsed_request(data.get("parsed", {}))
+            parsed = data.get("parsed", {})
+            print_parsed_request(parsed)
+
+            # Display search summary
+            print_search_summary(data)
+
+            # Skip library results for non-requests
+            if not parsed.get("is_request", False):
+                return cast(dict[str, Any], data)
 
             # Look up Discogs URLs for each library result
             library_results = data.get("library_results", [])

--- a/services/parser.py
+++ b/services/parser.py
@@ -44,7 +44,7 @@ Guidelines:
 - Correct obvious typos when you can confidently identify the intended artist/song, but don't remove intentional special characters
 - If someone says "anything by X" or "any song off Y album", that's still a request
 - A message can be both a dj_message AND contain a request (is_request: true)
-- Terse messages like "song title. artist name.", "song - artist", or "song title, artist name" should extract both song and artist
+- Terse messages like "song title. artist name.", "song - artist", or "song title, artist name" should extract both song and artist. This applies even when the song title contains common words like "love", "hate", "like", etc. For example, "I love acid, luke vibert" is a request for the song "I Love Acid" by Luke Vibert, not feedback.
 - When in doubt about whether something is a song title or album, prefer treating it as a song title
 
 Respond with valid JSON only, no markdown formatting."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -584,6 +584,42 @@ class TestParserIntegration:
 
         print("  ✅ Correctly parsed comma-separated format!")
 
+    @pytest.mark.asyncio
+    @skip_if_no_groq
+    async def test_parses_song_with_common_words_in_comma_format(self):
+        """Test that 'I love acid, luke vibert' is a request, not feedback.
+
+        Bug: The parser classified this as feedback because "I love" looks like
+        an emotional expression, but "I Love Acid" is a song by Luke Vibert.
+        The comma-separated format should take priority.
+        """
+        from groq import Groq
+
+        from services.parser import parse_request
+
+        client = Groq(api_key=GROQ_API_KEY)
+
+        result = parse_request("I love acid, luke vibert", client)
+
+        print("\n📝 Parsed result:")
+        print(f"  Song: {result.song}")
+        print(f"  Artist: {result.artist}")
+        print(f"  Is Request: {result.is_request}")
+
+        assert result.is_request is True, (
+            f"Should recognize as a request, got message_type={result.message_type}"
+        )
+        assert result.song is not None, "Should extract 'I Love Acid' as song title"
+        assert result.artist is not None, "Should extract 'Luke Vibert' as artist"
+        assert "love" in result.song.lower() and "acid" in result.song.lower(), (
+            f"Expected song containing 'Love' and 'Acid', got: {result.song}"
+        )
+        assert "vibert" in result.artist.lower(), (
+            f"Expected artist containing 'Vibert', got: {result.artist}"
+        )
+
+        print("  ✅ Correctly parsed song with common words in comma format!")
+
 
 class TestFullRequestIntegration:
     """Test the full /request endpoint.

--- a/tests/unit/test_non_request_early_return.py
+++ b/tests/unit/test_non_request_early_return.py
@@ -1,0 +1,165 @@
+"""Tests for early return when parser classifies a message as not a request."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from core.dependencies import (
+    get_discogs_service,
+    get_groq_client,
+    get_library_db,
+    get_posthog_client,
+    get_slack_service,
+)
+from routers.request import router
+from services.parser import MessageType, ParsedRequest
+
+
+@pytest.fixture
+def mock_groq_client():
+    return Mock()
+
+
+@pytest.fixture
+def mock_library_db():
+    db = AsyncMock()
+    db.search = AsyncMock(return_value=[])
+    return db
+
+
+@pytest.fixture
+def mock_discogs_service():
+    return AsyncMock()
+
+
+@pytest.fixture
+def app(mock_groq_client, mock_library_db, mock_discogs_service):
+    """Create a test app with all dependencies mocked."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+
+    app.dependency_overrides[get_groq_client] = lambda: mock_groq_client
+    app.dependency_overrides[get_library_db] = lambda: mock_library_db
+    app.dependency_overrides[get_discogs_service] = lambda: mock_discogs_service
+    app.dependency_overrides[get_slack_service] = lambda: None
+    app.dependency_overrides[get_posthog_client] = lambda: None
+
+    return app
+
+
+class TestNonRequestEarlyReturn:
+    """When the parser says is_request=False, the handler should skip the search pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_feedback_message_returns_no_library_results(self, app, mock_library_db):
+        """A feedback message like 'love the show!' should not trigger library search."""
+        parsed = ParsedRequest(
+            song=None,
+            artist=None,
+            album=None,
+            is_request=False,
+            message_type=MessageType.FEEDBACK,
+            raw_message="love the show!",
+        )
+
+        with patch("routers.request.parse_request", return_value=parsed):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "love the show!", "skip_slack": True},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["parsed"]["is_request"] is False
+        assert data["library_results"] == []
+        # Should not have searched the library at all
+        mock_library_db.search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_feedback_with_artist_does_not_search(self, app, mock_library_db):
+        """Even if the parser extracts an artist from feedback, don't search.
+
+        This is the 'I love acid, luke vibert' case: parser says feedback
+        and extracts artist=Luke Vibert, but we should not search the library.
+        """
+        parsed = ParsedRequest(
+            song=None,
+            artist="Luke Vibert",
+            album=None,
+            is_request=False,
+            message_type=MessageType.FEEDBACK,
+            raw_message="I love acid, luke vibert",
+        )
+
+        with patch("routers.request.parse_request", return_value=parsed):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "I love acid, luke vibert", "skip_slack": True},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["parsed"]["is_request"] is False
+        assert data["parsed"]["artist"] == "Luke Vibert"
+        assert data["library_results"] == []
+        mock_library_db.search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dj_message_without_request_does_not_search(self, app, mock_library_db):
+        """A DJ message that isn't a request should not trigger search."""
+        parsed = ParsedRequest(
+            song=None,
+            artist=None,
+            album=None,
+            is_request=False,
+            message_type=MessageType.DJ_MESSAGE,
+            raw_message="you guys are great, keep it up",
+        )
+
+        with patch("routers.request.parse_request", return_value=parsed):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "you guys are great, keep it up", "skip_slack": True},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["parsed"]["is_request"] is False
+        assert data["library_results"] == []
+        mock_library_db.search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_actual_request_still_searches(self, app, mock_library_db):
+        """Sanity check: an actual request should still go through the pipeline."""
+        parsed = ParsedRequest(
+            song="Bohemian Rhapsody",
+            artist="Queen",
+            album=None,
+            is_request=True,
+            message_type=MessageType.REQUEST,
+            raw_message="play bohemian rhapsody by queen",
+        )
+
+        with patch("routers.request.parse_request", return_value=parsed):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play bohemian rhapsody by queen", "skip_slack": True},
+                )
+
+        assert response.status_code == 200
+        # The search pipeline should have been invoked (even if it returned nothing)
+        mock_library_db.search.assert_called()


### PR DESCRIPTION
## Summary
- Non-request messages (feedback, DJ messages) no longer run the full search pipeline. The handler returns early with just the parsed data, avoiding confusing results when the parser extracts an artist name from feedback (e.g., "I love acid, luke vibert" returning 5 Luke Vibert albums).
- Fixes parser misclassifying "song title, artist" format as feedback when the song title contains common words like "love" or "hate". Added explicit guidance and example to the system prompt.
- Adds a "Search" summary section to `lookup.py` output showing strategy and match type (direct / compilation / fallback), so it's immediately clear whether results contain the requested song.

## Test plan
- [x] Unit tests: 4 new tests for early return behavior (feedback, feedback-with-artist, DJ message, request still searches)
- [x] Integration test: new test for "I love acid, luke vibert" parsing against real Groq API
- [x] Full unit suite passes (417 tests)
- [x] All parser integration tests pass (4 tests)
- [ ] Manual: run `lookup "I love acid, luke vibert"` against staging after deploy
- [ ] Manual: run `lookup "play bohemian rhapsody by queen"` to verify normal requests unaffected