### PR TITLE
fix: scale fuzzy match threshold by name length

### DIFF
--- a/library/db.py
+++ b/library/db.py
@@ -268,6 +268,11 @@ class LibraryDB:
 
         # Get candidate artists using prefix of first significant word
         artist_lower = artist.lower()
+
+        # For short names, a single-character difference is proportionally large,
+        # so raise the threshold to prevent false corrections (e.g. "Plug" -> "Plugz")
+        effective_threshold = max(threshold, 100 - len(artist_lower) * 2)
+
         words = artist_lower.split()
 
         # Use first word with 3+ chars for candidate search
@@ -299,12 +304,15 @@ class LibraryDB:
                 continue
 
             score = fuzz.ratio(artist_lower, candidate.lower())
-            if score > best_score and score >= threshold:
+            if score > best_score and score >= effective_threshold:
                 best_score = score
                 best_match = candidate
 
         if best_match and best_match.lower() != artist_lower:
-            logger.info(f"Corrected artist '{artist}' to '{best_match}' (score: {best_score})")
+            logger.info(
+                f"Corrected artist '{artist}' to '{best_match}' "
+                f"(score: {best_score}, threshold: {effective_threshold})"
+            )
             return best_match
 
         return None

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1355,3 +1355,49 @@ class TestFullRequestIntegration:
         assert pg_hits == 0, f"Expected 0 PG cache hits with skip_cache=True, got {pg_hits}"
 
         print("✅ skip_cache=True correctly bypassed all caches")
+
+    @pytest.mark.asyncio
+    async def test_plug_not_corrected_to_plugz(self, base_url):
+        """
+        Test that 'me and mr. jones by plug from drum n bass for papa' does NOT
+        falsely correct artist "Plug" to "Plugz".
+
+        Bug: find_similar_artist("Plug") fuzzy-matched to "Plugz" at 89% similarity,
+        exceeding the flat 85% threshold. This overwrote the parsed artist before
+        library search, so FTS5 never saw "Plug" and missed Luke Vibert's album.
+
+        Note: The library catalogs Plug's albums under "Luke Vibert", so we don't
+        expect library results here -- just that the artist isn't falsely corrected.
+        """
+        import httpx
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{base_url}/request",
+                json={
+                    "message": "me and mr. jones by plug from drum n bass for papa",
+                    "skip_slack": True,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        parsed = data.get("parsed", {})
+        results = data.get("library_results", [])
+
+        print("\n📝 Parsed:")
+        print(f"  Artist: {parsed.get('artist')}")
+        print(f"  Song: {parsed.get('song')}")
+        print(f"  Album: {parsed.get('album')}")
+
+        print("\n📚 Library Results:")
+        for r in results:
+            print(f"  - {r.get('artist')} - {r.get('title')}")
+
+        # Artist should NOT be corrected to Plugz
+        for r in results:
+            assert "plugz" not in r.get("artist", "").lower(), (
+                f"Should not return Plugz albums, got '{r.get('artist')}'"
+            )
+
+        print("\n✅ Correctly avoided false correction of 'Plug' to 'Plugz'!")

--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -377,6 +377,7 @@ async def spelling_db(tmp_path):
             (3, "Theatre of Pain", "Mötley Crüe", "MO", 5, 1, "Rock", "vinyl"),
             (4, "Favourite Worst Nightmare", "Arctic Monkeys", "AR", 3, 2, "Rock", "cd"),
             (5, "Led Zeppelin IV", "Led Zeppelin", "LE", 1, 4, "Rock", "vinyl"),
+            (6, "Better Luck", "Plugz", "PL", 20, 1, "Rock", "vinyl"),
         ]
 
         await conn.executemany("INSERT INTO library VALUES (?, ?, ?, ?, ?, ?, ?, ?)", test_albums)
@@ -441,3 +442,32 @@ class TestFindSimilarArtist:
         result = await spelling_db.find_similar_artist("Arctic Monkies")
 
         assert result == "Arctic Monkeys"
+
+    @pytest.mark.asyncio
+    async def test_short_name_not_corrected_to_similar(self, spelling_db: LibraryDB):
+        """Test that short name 'Plug' is NOT corrected to 'Plugz'.
+
+        For short names, a single character difference is proportionally large,
+        so the threshold should be raised to prevent false corrections.
+        """
+        result = await spelling_db.find_similar_artist("Plug")
+
+        assert result is None, (
+            f"Expected None (no correction), got '{result}'. "
+            "Short names should not be corrected to similar-but-different artists."
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "misspelled, expected",
+        [
+            ("Living Color", "Living Colour"),
+            ("Led Zepplin", "Led Zeppelin"),
+            ("Arctic Monkies", "Arctic Monkeys"),
+        ],
+    )
+    async def test_long_name_still_corrected(self, spelling_db: LibraryDB, misspelled, expected):
+        """Regression guard: long names with typos are still corrected."""
+        result = await spelling_db.find_similar_artist(misspelled)
+
+        assert result == expected


### PR DESCRIPTION
## Summary
- Adds a length-dependent effective threshold to `find_similar_artist` that raises the bar for short artist names where a single character edit is proportionally more significant
- Prevents false corrections like "Plug" -> "Plugz" (89% score, but only a 4-char name)
- Names 8+ characters long are unaffected (formula evaluates to the existing 85% floor)

Closes #17

## Test plan
- [x] Unit test: `test_short_name_not_corrected_to_similar` -- "Plug" is NOT corrected to "Plugz"
- [x] Unit test: `test_long_name_still_corrected` (parameterized) -- Living Color, Led Zepplin, Arctic Monkies all still corrected
- [x] Integration test: `test_plug_not_corrected_to_plugz` -- end-to-end verification against local server
- [x] Integration regression: `test_living_color_corrects_to_living_colour` still passes