### PR TITLE
Refactor: Extract duplicated track validation logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Request-O-Matic is a FastAPI service for WXYC radio that processes song requests
 - `discogs/cache_service.py` - PostgreSQL cache for Discogs data (reduces API calls)
 - `discogs/memory_cache.py` - In-memory TTL cache for API responses
 - `services/lookup_client.py` - HTTP client for library-metadata-lookup delegation
+- `core/matching.py` - Shared text normalization, artist matching, deduplication, and track validation utilities
 - `core/sentry.py` - Sentry error tracking integration
 - `core/telemetry.py` - PostHog telemetry with cache stats tracking
 ### Discogs Cache (Optional)

--- a/core/matching.py
+++ b/core/matching.py
@@ -4,7 +4,13 @@ This module centralizes the matching rules used throughout the search flow.
 Constants were consolidated from multiple locations to ensure consistency.
 """
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from discogs.models import TrackItem
 
 # =============================================================================
 # Search Result Limiting
@@ -176,3 +182,56 @@ def detect_ambiguous_format(raw_message: str) -> tuple[str, str] | None:
             return (parts[0].strip(), parts[1].strip())
 
     return None
+
+
+# =============================================================================
+# Track Validation
+# =============================================================================
+
+
+def validate_track_on_tracklist(
+    tracklist: list[TrackItem],
+    release_artist: str,
+    track: str,
+    artist: str,
+) -> bool:
+    """Check whether a track by an artist appears on a tracklist.
+
+    Handles both single-artist releases (checks release_artist) and
+    compilations (checks per-track artists). Strips Discogs numbering
+    like ``(2)`` from artist names before comparing.
+
+    Args:
+        tracklist: List of TrackItem objects from a release
+        release_artist: Primary artist on the release
+        track: Track title to find
+        artist: Artist name to match
+
+    Returns:
+        True if the track by the artist is found on the tracklist
+    """
+    track_lower = track.lower()
+    artist_lower = artist.lower()
+
+    for item in tracklist:
+        item_title = item.title.lower()
+        # Check if track title matches (substring in either direction)
+        if track_lower not in item_title and item_title not in track_lower:
+            continue
+
+        # Check per-track artists first (for compilations)
+        if item.artists:
+            for track_artist in item.artists:
+                track_artist_lower = track_artist.lower().split("(")[0].strip()
+                if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
+                    return True
+        else:
+            # For single-artist releases, check release artist
+            rel_artist = release_artist.lower()
+            # Remove Discogs numbering like "(2)"
+            rel_artist = rel_artist.split("(")[0].strip()
+
+            if artist_lower in rel_artist or rel_artist in artist_lower:
+                return True
+
+    return False

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -11,6 +11,7 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 
 import logging
 
+from core.matching import validate_track_on_tracklist
 from discogs.models import ReleaseInfo, ReleaseMetadataResponse, TrackItem
 
 logger = logging.getLogger(__name__)
@@ -433,27 +434,4 @@ class DiscogsCacheService:
         if release is None:
             return None  # Cache miss - caller should try API
 
-        track_lower = track.lower()
-        artist_lower = artist.lower()
-
-        for item in release.tracklist:
-            item_title = item.title.lower()
-
-            # Check if track title matches
-            if track_lower not in item_title and item_title not in track_lower:
-                continue
-
-            # Check per-track artists first (for compilations)
-            if item.artists:
-                for track_artist in item.artists:
-                    track_artist_lower = track_artist.lower().split("(")[0].strip()
-                    if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
-                        return True
-            else:
-                # For single-artist releases, check release artist
-                release_artist = release.artist.lower()
-                release_artist = release_artist.split("(")[0].strip()
-                if artist_lower in release_artist or release_artist in artist_lower:
-                    return True
-
-        return False
+        return validate_track_on_tracklist(release.tracklist, release.artist, track, artist)

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from config.settings import get_settings
-from core.matching import calculate_confidence, is_compilation_artist
+from core.matching import calculate_confidence, is_compilation_artist, validate_track_on_tracklist
 from core.telemetry import (
     record_api_time,
     record_discogs_api_call,
@@ -702,33 +702,9 @@ class DiscogsService:
         if release is None:
             return False
 
-        track_lower = track.lower()
-        artist_lower = artist.lower()
-
-        for item in release.tracklist:
-            item_title = item.title.lower()
-            # Check if track title matches
-            if track_lower not in item_title and item_title not in track_lower:
-                continue
-
-            # Check per-track artists first (for compilations)
-            if item.artists:
-                for track_artist in item.artists:
-                    track_artist_lower = track_artist.lower().split("(")[0].strip()
-                    if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
-                        logger.info(
-                            f"Validated: '{track}' by '{artist}' found on release {release_id}"
-                        )
-                        return True
-            else:
-                # For single-artist releases, check release artist
-                release_artist = release.artist.lower()
-                # Remove Discogs numbering like "(2)"
-                release_artist = release_artist.split("(")[0].strip()
-
-                if artist_lower in release_artist or release_artist in artist_lower:
-                    logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
-                    return True
-
-        logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")
-        return False
+        found = validate_track_on_tracklist(release.tracklist, release.artist, track, artist)
+        if found:
+            logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
+        else:
+            logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")
+        return found

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -1,5 +1,7 @@
 """Tests for core.matching module."""
 
+import pytest
+
 from core.matching import (
     COMPILATION_KEYWORDS,
     MAX_SEARCH_RESULTS,
@@ -7,7 +9,9 @@ from core.matching import (
     calculate_confidence,
     detect_ambiguous_format,
     is_compilation_artist,
+    validate_track_on_tracklist,
 )
+from discogs.models import TrackItem
 
 
 class TestConstants:
@@ -203,3 +207,106 @@ class TestDetectAmbiguousFormat:
         # "Puzzle pop -cootie catcher" should detect ambiguous format
         result = detect_ambiguous_format("Puzzle pop -cootie catcher")
         assert result == ("Puzzle pop", "cootie catcher")
+
+
+class TestValidateTrackOnTracklist:
+    """Test validate_track_on_tracklist function."""
+
+    @pytest.mark.parametrize(
+        "description,tracklist,release_artist,track,artist,expected",
+        [
+            (
+                "finds track by per-track artist (compilation)",
+                [TrackItem(position="1", title="My Song", artists=["The Artist"])],
+                "Various Artists",
+                "My Song",
+                "The Artist",
+                True,
+            ),
+            (
+                "finds track by release artist (single-artist release)",
+                [TrackItem(position="1", title="My Song", artists=[])],
+                "The Artist",
+                "My Song",
+                "The Artist",
+                True,
+            ),
+            (
+                "returns False when track not found",
+                [TrackItem(position="1", title="Different Song", artists=["The Artist"])],
+                "The Artist",
+                "My Song",
+                "The Artist",
+                False,
+            ),
+            (
+                "returns False when artist not found",
+                [TrackItem(position="1", title="My Song", artists=["Other Artist"])],
+                "Other Artist",
+                "My Song",
+                "The Artist",
+                False,
+            ),
+            (
+                "handles Discogs numbering like (2) in artist names",
+                [TrackItem(position="1", title="My Song", artists=[])],
+                "The Artist (2)",
+                "My Song",
+                "The Artist",
+                True,
+            ),
+            (
+                "case-insensitive matching",
+                [TrackItem(position="1", title="MY SONG", artists=["THE ARTIST"])],
+                "Various Artists",
+                "my song",
+                "the artist",
+                True,
+            ),
+            (
+                "partial title match - track_lower in item_title",
+                [TrackItem(position="1", title="My Song (Extended Mix)", artists=["The Artist"])],
+                "Various Artists",
+                "My Song",
+                "The Artist",
+                True,
+            ),
+            (
+                "partial title match - item_title in track_lower",
+                [TrackItem(position="1", title="My Song", artists=["The Artist"])],
+                "Various Artists",
+                "My Song (Extended Mix)",
+                "The Artist",
+                True,
+            ),
+            (
+                "empty tracklist returns False",
+                [],
+                "The Artist",
+                "My Song",
+                "The Artist",
+                False,
+            ),
+            (
+                "partial artist match - artist_lower in track_artist",
+                [TrackItem(position="1", title="My Song", artists=["The Artist Feat. Someone"])],
+                "Various Artists",
+                "My Song",
+                "The Artist",
+                True,
+            ),
+            (
+                "partial artist match - track_artist in artist_lower",
+                [TrackItem(position="1", title="My Song", artists=["Artist"])],
+                "Various Artists",
+                "My Song",
+                "The Artist",
+                True,
+            ),
+        ],
+        ids=lambda x: x if isinstance(x, str) else "",
+    )
+    def test_validate_track_on_tracklist(
+        self, description, tracklist, release_artist, track, artist, expected
+    ):
+        assert validate_track_on_tracklist(tracklist, release_artist, track, artist) is expected


### PR DESCRIPTION
## Summary
- Extract line-for-line duplicated track validation logic from `discogs/service.py` and `discogs/cache_service.py` into `validate_track_on_tracklist()` in `core/matching.py`
- Add 11 parameterized tests covering compilation tracks, single-artist releases, Discogs numbering, partial matching, and edge cases
- Update CLAUDE.md to document `core/matching.py`

Closes #21

## Test plan
- [x] All 472 existing unit tests pass unchanged
- [x] 11 new parameterized tests pass
- [x] ruff and black clean on changed files