### PR TITLE
Refactor: Extract cache-then-API boilerplate into _try_cache helper

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -252,7 +252,7 @@ class DiscogsService:
         """
         cache_result = await self._try_cache(
             "search_releases_by_track",
-            lambda: self.cache_service.search_releases_by_track(
+            lambda: self.cache_service.search_releases_by_track(  # type: ignore[union-attr]
                 track=track, artist=artist, limit=limit
             ),
             {"track": track, "artist": artist},
@@ -394,12 +394,12 @@ class DiscogsService:
         """
         cache_result = await self._try_cache(
             "get_release",
-            lambda: self.cache_service.get_release(release_id),
+            lambda: self.cache_service.get_release(release_id),  # type: ignore[union-attr]
             {"release_id": release_id},
         )
         if cache_result.hit:
             logger.info(f"Cache hit: release {release_id}")
-            return cache_result.value
+            return cache_result.value  # type: ignore[no-any-return]
 
         # Fall back to Discogs API
         try:
@@ -543,7 +543,7 @@ class DiscogsService:
         # Try local cache first
         cache_result = await self._try_cache(
             "search_releases",
-            lambda: self.cache_service.search_releases(
+            lambda: self.cache_service.search_releases(  # type: ignore[union-attr]
                 artist=request.artist,
                 album=request.album or request.track,
                 limit=limit,
@@ -695,7 +695,9 @@ class DiscogsService:
         # Try cache validation first
         cache_result = await self._try_cache(
             "validate_track",
-            lambda: self.cache_service.validate_track_on_release(release_id, track, artist),
+            lambda: self.cache_service.validate_track_on_release(  # type: ignore[union-attr]
+                release_id, track, artist
+            ),
             {"release_id": release_id, "track": track, "artist": artist},
         )
         if cache_result.hit:
@@ -703,7 +705,7 @@ class DiscogsService:
                 f"Cache {'validated' if cache_result.value else 'rejected'}: "
                 f"'{track}' by '{artist}' on release {release_id}"
             )
-            return cache_result.value
+            return cache_result.value  # type: ignore[no-any-return]
 
         # Fall back to API via get_release
         release = await self.get_release(release_id)

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -554,6 +554,7 @@ class TestTryCache:
             "test_op", lambda: mock_cache_service.get_release(123), {}
         )
         stats = get_cache_stats()
+        assert stats is not None
         assert stats["pg_time_ms"] > 0
 
         # Reset and test miss case
@@ -563,6 +564,7 @@ class TestTryCache:
             "test_op", lambda: mock_cache_service.get_release(123), {}
         )
         stats = get_cache_stats()
+        assert stats is not None
         assert stats["pg_time_ms"] > 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Extract `CacheResult` dataclass and `_try_cache()` helper to replace 4 identical ~20-line cache-then-API patterns in `DiscogsService`
- Refactor `search_releases_by_track`, `get_release`, `search`, and `validate_track_on_release` to use the helper
- Add 8 unit tests for the new `_try_cache` method

Closes #27

## Test plan

- [x] All 485 unit tests pass
- [x] `ruff check` and `black --check` pass on changed files
- [ ] CI passes
- [ ] Integration tests pass on staging after merge

Refactoring plan PR 4/6.