### PR TITLE
Refactor: Consolidate timed API, dedup, sort, cache singletons, telemetry

### DIFF
--- a/core/matching.py
+++ b/core/matching.py
@@ -7,6 +7,7 @@ Constants were consolidated from multiple locations to ensure consistency.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable, Hashable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -237,6 +238,53 @@ def detect_ambiguous_format(raw_message: str) -> tuple[str, str] | None:
             return (parts[0].strip(), parts[1].strip())
 
     return None
+
+
+# =============================================================================
+# Deduplication
+# =============================================================================
+
+
+def deduplicate[T](
+    items: list[T],
+    key: Callable[[T], Hashable] = lambda x: x.id,  # type: ignore[attr-defined]
+) -> list[T]:
+    """Remove duplicates from a list, preserving first-occurrence order.
+
+    Args:
+        items: List of items to deduplicate
+        key: Function to extract a hashable key from each item (default: item.id)
+
+    Returns:
+        New list with duplicates removed
+    """
+    seen: set[Hashable] = set()
+    result: list[T] = []
+    for item in items:
+        k = key(item)
+        if k not in seen:
+            seen.add(k)
+            result.append(item)
+    return result
+
+
+# =============================================================================
+# Sort by Title Relevance
+# =============================================================================
+
+
+def sort_by_title_relevance(items: list, target: str) -> None:
+    """Sort items in-place so items whose title contains the target come first.
+
+    Args:
+        items: List of items with a ``title`` attribute (may be None)
+        target: Target string to match against item titles (case-insensitive)
+    """
+    target_lower = target.lower()
+    items.sort(
+        key=lambda r: target_lower in (r.title or "").lower(),
+        reverse=True,
+    )
 
 
 # =============================================================================

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -167,46 +167,48 @@ def init_cache_stats() -> None:
     )
 
 
-def record_memory_cache_hit() -> None:
-    """Record an in-memory TTL cache hit in the current request context."""
+def _update_cache_stat(key: str, value: float = 1) -> None:
+    """Update a cache stat in the current request context.
+
+    No-op if cache stats have not been initialized for this request.
+
+    Args:
+        key: Stat key to update (must exist in the stats dict)
+        value: Value to add to the stat (default: 1 for counters)
+    """
     stats = _cache_stats_var.get(None)
     if stats is not None:
-        stats["memory_hits"] += 1
+        stats[key] += value
+
+
+def record_memory_cache_hit() -> None:
+    """Record an in-memory TTL cache hit in the current request context."""
+    _update_cache_stat("memory_hits")
 
 
 def record_pg_cache_hit() -> None:
     """Record a PostgreSQL cache hit in the current request context."""
-    stats = _cache_stats_var.get(None)
-    if stats is not None:
-        stats["pg_hits"] += 1
+    _update_cache_stat("pg_hits")
 
 
 def record_pg_cache_miss() -> None:
     """Record a PostgreSQL cache miss in the current request context."""
-    stats = _cache_stats_var.get(None)
-    if stats is not None:
-        stats["pg_misses"] += 1
+    _update_cache_stat("pg_misses")
 
 
 def record_discogs_api_call() -> None:
     """Record a Discogs API call in the current request context."""
-    stats = _cache_stats_var.get(None)
-    if stats is not None:
-        stats["api_calls"] += 1
+    _update_cache_stat("api_calls")
 
 
 def record_pg_time(ms: float) -> None:
     """Accumulate PostgreSQL cache query time in the current request context."""
-    stats = _cache_stats_var.get(None)
-    if stats is not None:
-        stats["pg_time_ms"] += ms
+    _update_cache_stat("pg_time_ms", ms)
 
 
 def record_api_time(ms: float) -> None:
     """Accumulate Discogs API call time in the current request context."""
-    stats = _cache_stats_var.get(None)
-    if stats is not None:
-        stats["api_time_ms"] += ms
+    _update_cache_stat("api_time_ms", ms)
 
 
 def get_cache_stats() -> dict | None:

--- a/discogs/memory_cache.py
+++ b/discogs/memory_cache.py
@@ -18,12 +18,17 @@ logger = logging.getLogger(__name__)
 # Registry of all caches for bulk operations
 _cache_registry: list[TTLCache] = []
 
-# Lazily-initialized caches (using settings when accessed)
-_track_cache: TTLCache | None = None
-_release_cache: TTLCache | None = None
-_search_cache: TTLCache | None = None
-_artist_cache: TTLCache | None = None
-_label_cache: TTLCache | None = None
+# Table-driven cache configuration: name -> (maxsize_divisor, ttl_setting_attr)
+_CACHE_CONFIGS: dict[str, tuple[int, str]] = {
+    "track": (1, "discogs_track_cache_ttl"),
+    "release": (2, "discogs_release_cache_ttl"),
+    "search": (1, "discogs_search_cache_ttl"),
+    "artist": (2, "discogs_artist_cache_ttl"),
+    "label": (2, "discogs_label_cache_ttl"),
+}
+
+# Lazily-initialized cache instances (keyed by name from _CACHE_CONFIGS)
+_caches: dict[str, TTLCache] = {}
 
 T = TypeVar("T")
 
@@ -82,15 +87,10 @@ def create_ttl_cache(maxsize: int, ttl: int) -> TTLCache:
 
 def clear_all_caches() -> None:
     """Clear all registered caches and reset lazy caches."""
-    global _track_cache, _release_cache, _search_cache, _artist_cache, _label_cache
     for cache in _cache_registry:
         cache.clear()
     # Reset lazy caches so they get recreated with fresh settings
-    _track_cache = None
-    _release_cache = None
-    _search_cache = None
-    _artist_cache = None
-    _label_cache = None
+    _caches.clear()
 
 
 def _set_cached_flag(result: Any, cached: bool) -> Any:
@@ -164,76 +164,52 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
     return decorator
 
 
-def get_track_cache() -> TTLCache:
-    """Get or create the track search cache using settings."""
-    global _track_cache
-    if _track_cache is None:
-        # Import settings lazily to avoid circular imports at module load time
+def _get_cache(name: str) -> TTLCache:
+    """Get or create a named cache using settings from _CACHE_CONFIGS.
+
+    Imports settings lazily to avoid circular imports at module load time.
+
+    Args:
+        name: Cache name (must be a key in _CACHE_CONFIGS)
+
+    Returns:
+        TTLCache instance (created on first access, reused thereafter)
+    """
+    if name not in _caches:
         from config.settings import get_settings
 
+        maxsize_divisor, ttl_attr = _CACHE_CONFIGS[name]
         settings = get_settings()
-        _track_cache = create_ttl_cache(
-            maxsize=settings.discogs_cache_maxsize,
-            ttl=settings.discogs_track_cache_ttl,
+        _caches[name] = create_ttl_cache(
+            maxsize=settings.discogs_cache_maxsize // maxsize_divisor,
+            ttl=getattr(settings, ttl_attr),
         )
-    return _track_cache
+    return _caches[name]
+
+
+def get_track_cache() -> TTLCache:
+    """Get or create the track search cache using settings."""
+    return _get_cache("track")
 
 
 def get_release_cache() -> TTLCache:
     """Get or create the release metadata cache using settings."""
-    global _release_cache
-    if _release_cache is None:
-        from config.settings import get_settings
-
-        settings = get_settings()
-        # Release cache uses half the maxsize since entries are larger
-        _release_cache = create_ttl_cache(
-            maxsize=settings.discogs_cache_maxsize // 2,
-            ttl=settings.discogs_release_cache_ttl,
-        )
-    return _release_cache
+    return _get_cache("release")
 
 
 def get_search_cache() -> TTLCache:
     """Get or create the general search cache using settings."""
-    global _search_cache
-    if _search_cache is None:
-        from config.settings import get_settings
-
-        settings = get_settings()
-        _search_cache = create_ttl_cache(
-            maxsize=settings.discogs_cache_maxsize,
-            ttl=settings.discogs_search_cache_ttl,
-        )
-    return _search_cache
+    return _get_cache("search")
 
 
 def get_artist_cache() -> TTLCache:
     """Get or create the artist image cache using settings."""
-    global _artist_cache
-    if _artist_cache is None:
-        from config.settings import get_settings
-
-        settings = get_settings()
-        _artist_cache = create_ttl_cache(
-            maxsize=settings.discogs_cache_maxsize // 2,
-            ttl=settings.discogs_artist_cache_ttl,
-        )
-    return _artist_cache
+    return _get_cache("artist")
 
 
 def get_label_cache() -> TTLCache:
     """Get or create the label image cache using settings."""
-    global _label_cache
-    if _label_cache is None:
-        from config.settings import get_settings
-
-        settings = get_settings()
-        _label_cache = create_ttl_cache(
-            maxsize=settings.discogs_cache_maxsize // 2,
-            ttl=settings.discogs_label_cache_ttl,
-        )
-    return _label_cache
+    return _get_cache("label")
 
 
 # Convenience constants for backwards compatibility

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -231,6 +231,34 @@ class DiscogsService:
             add_discogs_breadcrumb("cache_error", {"error": str(e)}, level="warning")
             return CacheResult(hit=False)
 
+    async def _timed_api_call(
+        self,
+        method: str,
+        path: str,
+        params: dict | None = None,
+    ) -> dict | None:
+        """Make a timed Discogs API call with telemetry recording.
+
+        Handles the common pattern: start timer, send request, record API time
+        and call count, raise for status, parse JSON.
+
+        Args:
+            method: HTTP method (e.g., "GET")
+            path: API path (e.g., "/database/search")
+            params: Optional query parameters
+
+        Returns:
+            Parsed JSON dict, or None if rate limited/request failed
+        """
+        start = time.perf_counter()
+        response = await self._request_with_retry(method, path, params=params)
+        if response is None:
+            return None
+        record_api_time((time.perf_counter() - start) * 1000)
+        record_discogs_api_call()
+        response.raise_for_status()
+        return response.json()  # type: ignore[no-any-return]
+
     @async_cached(TRACK_CACHE)
     async def search_releases_by_track(
         self, track: str, artist: str | None = None, limit: int = 20
@@ -282,15 +310,8 @@ class DiscogsService:
         logger.info(f"Searching Discogs for releases with track: '{track}', artist: {artist}")
 
         try:
-            start = time.perf_counter()
-            response = await self._request_with_retry("GET", "/database/search", params=params)
-
-            if response is not None:
-                record_api_time((time.perf_counter() - start) * 1000)
-                record_discogs_api_call()
-                response.raise_for_status()
-                data = response.json()
-
+            data = await self._timed_api_call("GET", "/database/search", params=params)
+            if data is not None:
                 for result in data.get("results", []):
                     release_info = self._process_search_result(result, seen_albums)
                     if release_info:
@@ -311,17 +332,8 @@ class DiscogsService:
                 }
 
                 logger.info(f"Supplementing with keyword search: '{query_params['q']}'")
-                start = time.perf_counter()
-                response = await self._request_with_retry(
-                    "GET", "/database/search", params=query_params
-                )
-
-                if response is not None:
-                    record_api_time((time.perf_counter() - start) * 1000)
-                    record_discogs_api_call()
-                    response.raise_for_status()
-                    data = response.json()
-
+                data = await self._timed_api_call("GET", "/database/search", params=query_params)
+                if data is not None:
                     for result in data.get("results", []):
                         release_info = self._process_search_result(result, seen_albums)
                         if release_info:
@@ -403,17 +415,10 @@ class DiscogsService:
 
         # Fall back to Discogs API
         try:
-            start = time.perf_counter()
-            response = await self._request_with_retry("GET", f"/releases/{release_id}")
-
-            if response is None:
+            data = await self._timed_api_call("GET", f"/releases/{release_id}")
+            if data is None:
                 logger.warning(f"Failed to fetch release {release_id} (rate limited or error)")
                 return None
-
-            record_api_time((time.perf_counter() - start) * 1000)
-            record_discogs_api_call()
-            response.raise_for_status()
-            data = response.json()
 
             # Extract artists
             artists = data.get("artists", [])
@@ -483,15 +488,10 @@ class DiscogsService:
             Image URI string, or None if unavailable
         """
         try:
-            start = time.perf_counter()
-            response = await self._request_with_retry("GET", f"/{entity_type}s/{entity_id}")
-            if response is None:
+            data = await self._timed_api_call("GET", f"/{entity_type}s/{entity_id}")
+            if data is None:
                 return None
-            record_api_time((time.perf_counter() - start) * 1000)
-            record_discogs_api_call()
             add_discogs_breadcrumb(f"get_{entity_type}_image", {f"{entity_type}_id": entity_id})
-            response.raise_for_status()
-            data = response.json()
             images = data.get("images", [])
             return images[0].get("uri") if images else None
         except Exception as e:
@@ -574,17 +574,10 @@ class DiscogsService:
         logger.info(f"Searching Discogs with params: {params}")
 
         try:
-            start = time.perf_counter()
-            response = await self._request_with_retry("GET", "/database/search", params=params)
-
-            if response is None:
+            data = await self._timed_api_call("GET", "/database/search", params=params)
+            if data is None:
                 logger.warning("Discogs search failed (rate limited or error)")
                 return DiscogsSearchResponse(cached=False)
-
-            record_api_time((time.perf_counter() - start) * 1000)
-            record_discogs_api_call()
-            response.raise_for_status()
-            data = response.json()
 
             # If strict search returned nothing, try fuzzy query
             if not data.get("results") and (request.artist or request.album):
@@ -599,15 +592,11 @@ class DiscogsService:
                     "q": " ".join(query_parts),
                 }
                 logger.info(f"Strict search empty, trying fuzzy query: {fallback_params}")
-                start = time.perf_counter()
-                response = await self._request_with_retry(
+                fallback_data = await self._timed_api_call(
                     "GET", "/database/search", params=fallback_params
                 )
-                if response is not None:
-                    record_api_time((time.perf_counter() - start) * 1000)
-                    record_discogs_api_call()
-                    response.raise_for_status()
-                    data = response.json()
+                if fallback_data is not None:
+                    data = fallback_data
 
             results = []
             for item in data.get("results", []):

--- a/routers/request.py
+++ b/routers/request.py
@@ -50,10 +50,12 @@ from core.dependencies import (
 )
 from core.matching import (
     MAX_SEARCH_RESULTS,
+    deduplicate,
     extract_significant_words,
     is_compilation_artist,
     matches_artist_or_compilation,
     normalize_text,
+    sort_by_title_relevance,
 )
 from core.search import (
     build_strategies,
@@ -252,13 +254,7 @@ async def search_with_alternative_interpretation(
     elif results1 and results2:
         # Both have results - combine and dedupe by id
         logger.info("Alternative search matched both interpretations, combining results")
-        seen_ids = set()
-        combined = []
-        for item in results1 + results2:
-            if item.id not in seen_ids:
-                combined.append(item)
-                seen_ids.add(item.id)
-        return limit_results(combined), None
+        return limit_results(deduplicate(results1 + results2)), None
 
     return [], None
 
@@ -398,11 +394,7 @@ async def search_library_with_fallback(
 
         if all_results:
             # Sort to prioritize results matching the first (primary) album
-            primary_album_lower = albums[0].lower()
-            all_results.sort(
-                key=lambda r: primary_album_lower in (r.title or "").lower(),
-                reverse=True,
-            )
+            sort_by_title_relevance(all_results, albums[0])
             return all_results, False
 
     # If no albums from Discogs, try artist + song
@@ -414,11 +406,7 @@ async def search_library_with_fallback(
 
         if results:
             # Prioritize results where album title matches song title
-            song_lower = parsed.song.lower()
-            results.sort(
-                key=lambda r: song_lower in (r.title or "").lower(),
-                reverse=True,
-            )
+            sort_by_title_relevance(results, parsed.song)
             # We had a song but couldn't find/confirm albums from Discogs
             # Set song_not_found=True so context message indicates uncertainty
             return results, True
@@ -571,11 +559,7 @@ async def search_compilations_for_track(
     # Prioritize albums whose title matches the song title
     # (e.g., "Meet Me in the City" album for song "Meet Me in the City")
     if results and parsed.song:
-        song_lower = parsed.song.lower()
-        results.sort(
-            key=lambda r: song_lower in (r.title or "").lower(),
-            reverse=True,
-        )
+        sort_by_title_relevance(results, parsed.song)
 
     return limit_results(results), discogs_titles
 

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -593,6 +593,49 @@ class TestTryCache:
         assert result.hit is False
 
 
+class TestTimedApiCall:
+    """Tests for _timed_api_call helper method."""
+
+    @pytest_asyncio.fixture
+    async def service(self):
+        svc = DiscogsService(token="test-token")
+        yield svc
+        await svc.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_parsed_json(self, service: DiscogsService, httpx_mock: HTTPXMock):
+        """Test returns parsed JSON dict on successful response."""
+        httpx_mock.add_response(
+            url=SEARCH_URL_PATTERN,
+            json={"results": [{"id": 1, "title": "Test"}]},
+        )
+        data = await service._timed_api_call("GET", "/database/search", params={"q": "test"})
+        assert data is not None
+        assert data["results"][0]["id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_rate_limit(self, service: DiscogsService, httpx_mock: HTTPXMock):
+        """Test returns None when request_with_retry returns None (rate limited)."""
+        # _request_with_retry does 3 attempts (initial + 2 retries) before giving up
+        for _ in range(3):
+            httpx_mock.add_response(url=SEARCH_URL_PATTERN, status_code=429)
+        data = await service._timed_api_call("GET", "/database/search", params={"q": "test"})
+        assert data is None
+
+    @pytest.mark.asyncio
+    async def test_records_telemetry(self, service: DiscogsService, httpx_mock: HTTPXMock):
+        """Test records API time and call count."""
+        from core.telemetry import get_cache_stats, init_cache_stats
+
+        init_cache_stats()
+        httpx_mock.add_response(url=SEARCH_URL_PATTERN, json={"results": []})
+        await service._timed_api_call("GET", "/database/search", params={"q": "test"})
+        stats = get_cache_stats()
+        assert stats is not None
+        assert stats["api_time_ms"] > 0
+        assert stats["api_calls"] >= 1
+
+
 class TestCacheIntegration:
     """Tests for PostgreSQL cache integration in DiscogsService."""
 

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -7,11 +7,13 @@ from core.matching import (
     MAX_SEARCH_RESULTS,
     STOPWORDS,
     calculate_confidence,
+    deduplicate,
     detect_ambiguous_format,
     extract_significant_words,
     is_compilation_artist,
     matches_artist_or_compilation,
     normalize_text,
+    sort_by_title_relevance,
     validate_track_on_tracklist,
 )
 from discogs.models import TrackItem
@@ -442,3 +444,143 @@ class TestValidateTrackOnTracklist:
         self, description, tracklist, release_artist, track, artist, expected
     ):
         assert validate_track_on_tracklist(tracklist, release_artist, track, artist) is expected
+
+
+class TestDeduplicate:
+    """Test deduplicate function."""
+
+    def test_removes_duplicates_by_default_key(self):
+        """Default key uses item.id."""
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="Album A"),
+            LibraryItem(id=2, title="Album B"),
+            LibraryItem(id=1, title="Album A"),
+        ]
+        result = deduplicate(items)
+        assert len(result) == 2
+        assert result[0].id == 1
+        assert result[1].id == 2
+
+    def test_preserves_first_occurrence_order(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=3, title="Third"),
+            LibraryItem(id=1, title="First"),
+            LibraryItem(id=2, title="Second"),
+            LibraryItem(id=1, title="First Duplicate"),
+        ]
+        result = deduplicate(items)
+        assert [r.id for r in result] == [3, 1, 2]
+
+    def test_custom_key_function(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="Abbey Road"),
+            LibraryItem(id=2, title="abbey road"),
+            LibraryItem(id=3, title="Let It Be"),
+        ]
+        result = deduplicate(items, key=lambda x: (x.title or "").lower())
+        assert len(result) == 2
+        assert result[0].id == 1
+        assert result[1].id == 3
+
+    def test_empty_list(self):
+        assert deduplicate([]) == []
+
+    def test_no_duplicates(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="A"),
+            LibraryItem(id=2, title="B"),
+        ]
+        result = deduplicate(items)
+        assert len(result) == 2
+
+    def test_all_duplicates(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="A"),
+            LibraryItem(id=1, title="A copy"),
+            LibraryItem(id=1, title="A another"),
+        ]
+        result = deduplicate(items)
+        assert len(result) == 1
+        assert result[0].title == "A"
+
+
+class TestSortByTitleRelevance:
+    """Test sort_by_title_relevance function."""
+
+    def test_matching_title_sorted_first(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="Other Album"),
+            LibraryItem(id=2, title="Abbey Road"),
+            LibraryItem(id=3, title="Something Else"),
+        ]
+        sort_by_title_relevance(items, "Abbey Road")
+        assert items[0].id == 2
+
+    def test_substring_match(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="Other Album"),
+            LibraryItem(id=2, title="Abbey Road (Remastered)"),
+        ]
+        sort_by_title_relevance(items, "Abbey Road")
+        assert items[0].id == 2
+
+    def test_case_insensitive(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="Other Album"),
+            LibraryItem(id=2, title="ABBEY ROAD"),
+        ]
+        sort_by_title_relevance(items, "abbey road")
+        assert items[0].id == 2
+
+    def test_no_matches_preserves_order(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="Alpha"),
+            LibraryItem(id=2, title="Beta"),
+        ]
+        sort_by_title_relevance(items, "Gamma")
+        assert items[0].id == 1
+        assert items[1].id == 2
+
+    def test_empty_list(self):
+        items: list = []
+        sort_by_title_relevance(items, "anything")
+        assert items == []
+
+    def test_none_title_handled(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title=None),
+            LibraryItem(id=2, title="Abbey Road"),
+        ]
+        sort_by_title_relevance(items, "Abbey Road")
+        assert items[0].id == 2
+
+    def test_sorts_in_place(self):
+        from library.models import LibraryItem
+
+        items = [
+            LibraryItem(id=1, title="Other"),
+            LibraryItem(id=2, title="Match"),
+        ]
+        original = items
+        sort_by_title_relevance(items, "Match")
+        assert items is original


### PR DESCRIPTION
## Summary

- Extract `_timed_api_call()` to replace 7 identical API call patterns in `DiscogsService`
- Add `deduplicate()` and `sort_by_title_relevance()` to `core/matching.py`, replacing inline patterns in `routers/request.py`
- Table-driven memory cache singletons in `discogs/memory_cache.py`
- Simplified telemetry recorders via `_update_cache_stat()` helper

Closes #29

## Test plan

- [x] 501 unit tests pass
- [x] `ruff check` and `black --check` pass
- [x] `mypy --ignore-missing-imports` passes
- [ ] CI passes
- [ ] Integration tests pass on staging after merge

Refactoring plan PR 5/6. Based on `refactor/cache-fallback-helper` (PR #28).