### PR TITLE
refactor: DRY cache_service.py queries and add cache write helper

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -311,6 +311,67 @@ class DiscogsCacheService:
             logger.error(f"Cache write_release failed: {e}")
             raise CacheUnavailableError(f"Cache write_release failed: {e}") from e
 
+    def _build_search_query(
+        self,
+        artist: str | None = None,
+        album: str | None = None,
+        limit: int = 5,
+    ) -> tuple[str, list]:
+        """Build a parameterized SQL query for release search.
+
+        Generates the appropriate WHERE clause, similarity scoring, and positional
+        parameters based on which search fields are provided. This replaces three
+        near-identical query branches with a single parameterized builder.
+
+        Args:
+            artist: Artist name to search for
+            album: Album/release title to search for
+            limit: Maximum number of results to return
+
+        Returns:
+            Tuple of (query_sql, params) ready for pool.fetch()
+        """
+        conditions = []
+        similarity_cols = []
+        params: list = []
+        idx = 1
+
+        if album:
+            conditions.append(f"lower(r.title) % lower(${idx})")
+            similarity_cols.append(f"similarity(lower(r.title), lower(${idx}))")
+            params.append(album)
+            idx += 1
+        if artist:
+            conditions.append(f"lower(ra.artist_name) % lower(${idx})")
+            similarity_cols.append(f"similarity(lower(ra.artist_name), lower(${idx}))")
+            params.append(artist)
+            idx += 1
+
+        score_expr = (
+            f"GREATEST({', '.join(similarity_cols)})"
+            if len(similarity_cols) > 1
+            else similarity_cols[0]
+        )
+
+        inner = f"""
+            SELECT DISTINCT ON (r.id)
+                r.id as release_id, r.title, ra.artist_name, r.artwork_url,
+                {score_expr} as score
+            FROM release r
+            JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+            WHERE {" OR ".join(conditions)}
+            ORDER BY r.id, score DESC
+        """
+
+        params.append(limit * 2)
+        query = f"""
+            SELECT * FROM ({inner}) sub
+            ORDER BY score DESC
+            LIMIT ${idx}
+        """
+
+        return query, params
+
     async def search_releases(
         self, artist: str | None = None, album: str | None = None, limit: int = 5
     ) -> list[dict]:
@@ -333,59 +394,8 @@ class DiscogsCacheService:
             return []
 
         try:
-            if artist and album:
-                query = """
-                    SELECT DISTINCT ON (r.id)
-                        r.id as release_id, r.title, ra.artist_name, r.artwork_url,
-                        GREATEST(
-                            similarity(lower(r.title), lower($1)),
-                            similarity(lower(ra.artist_name), lower($2))
-                        ) as score
-                    FROM release r
-                    JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
-                    WHERE lower(r.title) % lower($1)
-                       OR lower(ra.artist_name) % lower($2)
-                    ORDER BY r.id, score DESC
-                """
-                # Re-sort by score after DISTINCT ON
-                query = f"""
-                    SELECT * FROM ({query}) sub
-                    ORDER BY score DESC
-                    LIMIT $3
-                """
-                rows = await self.pool.fetch(query, album, artist, limit * 2)
-            elif artist:
-                query = """
-                    SELECT DISTINCT ON (r.id)
-                        r.id as release_id, r.title, ra.artist_name, r.artwork_url,
-                        similarity(lower(ra.artist_name), lower($1)) as score
-                    FROM release r
-                    JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
-                    WHERE lower(ra.artist_name) % lower($1)
-                    ORDER BY r.id, score DESC
-                """
-                query = f"""
-                    SELECT * FROM ({query}) sub
-                    ORDER BY score DESC
-                    LIMIT $2
-                """
-                rows = await self.pool.fetch(query, artist, limit * 2)
-            else:  # album only
-                query = """
-                    SELECT DISTINCT ON (r.id)
-                        r.id as release_id, r.title, ra.artist_name, r.artwork_url,
-                        similarity(lower(r.title), lower($1)) as score
-                    FROM release r
-                    JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
-                    WHERE lower(r.title) % lower($1)
-                    ORDER BY r.id, score DESC
-                """
-                query = f"""
-                    SELECT * FROM ({query}) sub
-                    ORDER BY score DESC
-                    LIMIT $2
-                """
-                rows = await self.pool.fetch(query, album, limit * 2)
+            query, params = self._build_search_query(artist=artist, album=album, limit=limit)
+            rows = await self.pool.fetch(query, *params)
 
             results = []
             seen_titles = set()

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -231,6 +231,31 @@ class DiscogsService:
             add_discogs_breadcrumb("cache_error", {"error": str(e)}, level="warning")
             return CacheResult(hit=False)
 
+    async def _try_cache_write(
+        self,
+        operation: str,
+        cache_fn: Callable[[], Awaitable[None]],
+        breadcrumb_data: dict,
+    ) -> None:
+        """Try to write a result to the PostgreSQL cache.
+
+        Silently handles failures so cache writes never break the main flow.
+
+        Args:
+            operation: Name for logging and breadcrumbs (e.g., "write_release")
+            cache_fn: Zero-argument async callable that performs the cache write
+            breadcrumb_data: Data for Sentry breadcrumbs
+        """
+        if not self.cache_service or should_skip_cache():
+            return
+        try:
+            add_discogs_breadcrumb(f"cache_{operation}", breadcrumb_data)
+            await cache_fn()
+            logger.debug(f"Cache {operation} succeeded")
+        except Exception as e:
+            logger.warning(f"Cache {operation} failed: {e}")
+            add_discogs_breadcrumb("cache_write_error", {"error": str(e)}, level="warning")
+
     async def _timed_api_call(
         self,
         method: str,
@@ -462,14 +487,11 @@ class DiscogsService:
             )
 
             # Write back to cache for future queries
-            if self.cache_service and not should_skip_cache():
-                try:
-                    add_discogs_breadcrumb("cache_write_release", {"release_id": release_id})
-                    await self.cache_service.write_release(release)
-                    logger.debug(f"Cached release {release_id}")
-                except Exception as e:
-                    logger.warning(f"Failed to cache release {release_id}: {e}")
-                    add_discogs_breadcrumb("cache_write_error", {"error": str(e)}, level="warning")
+            await self._try_cache_write(
+                "write_release",
+                lambda: self.cache_service.write_release(release),  # type: ignore[union-attr]
+                {"release_id": release_id},
+            )
 
             return release
 

--- a/tests/unit/test_discogs_cache_service.py
+++ b/tests/unit/test_discogs_cache_service.py
@@ -474,3 +474,53 @@ class TestSearchReleases:
 
         with pytest.raises(CacheUnavailableError):
             await cache.search_releases(artist="Autechre", album="Confield")
+
+
+class TestBuildSearchQuery:
+    """Tests for _build_search_query helper that generates parameterized SQL."""
+
+    def _build(self, artist=None, album=None, limit=5):
+        from discogs.cache_service import DiscogsCacheService
+
+        cache = DiscogsCacheService(pool=MagicMock())
+        return cache._build_search_query(artist=artist, album=album, limit=limit)
+
+    def test_artist_and_album_includes_both_conditions(self):
+        """Test both artist and album generate WHERE with both conditions."""
+        query, params = self._build(artist="Autechre", album="Confield")
+        assert "lower(r.title)" in query
+        assert "lower(ra.artist_name)" in query
+        assert "GREATEST" in query
+        assert params == ["Confield", "Autechre", 10]  # limit * 2
+
+    def test_artist_only_excludes_album(self):
+        """Test artist-only search does not reference album similarity."""
+        query, params = self._build(artist="Autechre")
+        assert "lower(ra.artist_name)" in query
+        assert "GREATEST" not in query
+        assert params == ["Autechre", 10]
+
+    def test_album_only_excludes_artist(self):
+        """Test album-only search does not reference artist similarity."""
+        query, params = self._build(album="Confield")
+        assert "lower(r.title)" in query
+        assert "GREATEST" not in query
+        assert params == ["Confield", 10]
+
+    def test_limit_is_doubled(self):
+        """Test that limit parameter is doubled for the SQL LIMIT clause."""
+        _, params = self._build(artist="Autechre", album="Confield", limit=3)
+        assert params[-1] == 6  # 3 * 2
+
+    def test_returns_sql_with_limit_placeholder(self):
+        """Test returned SQL uses correct positional placeholders."""
+        query, params = self._build(artist="Autechre", album="Confield")
+        # Should have $3 for LIMIT (2 search params + 1 limit)
+        assert f"${len(params)}" in query
+
+    def test_artist_only_returns_correct_placeholder_count(self):
+        """Test artist-only uses $1 for artist and $2 for limit."""
+        query, params = self._build(artist="Autechre")
+        assert "$1" in query
+        assert "$2" in query
+        assert "$3" not in query


### PR DESCRIPTION
## Summary

- Extract `_build_search_query(artist, album, limit)` to replace 3 near-identical SQL branches in `cache_service.py`
- Add `_try_cache_write()` helper in `service.py` for the cache write-back pattern
- Add `TestBuildSearchQuery` test class (6 tests)

Closes #35

## Test plan

- [x] All 536 unit tests pass
- [x] `ruff check` and `ruff format` clean
- [x] Existing `TestSearchReleases` tests verify behavioral equivalence