### PR TITLE
refactor: extract shared URL constants and logging into scripts/_common

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -255,7 +255,7 @@ async def get_slack_webhook_url(
 
     # Fetch from Railway endpoint
     try:
-        response = await http_client.get("https://wxyc-requests-endpoint-production.up.railway.app")
+        response = await http_client.get(settings.slack_webhook_key_url)
         response.raise_for_status()
         webhook_key = response.text.strip()
         webhook_url = f"https://hooks.slack.com/services/{webhook_key}"

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -1,0 +1,25 @@
+"""Shared constants and utilities for CLI scripts."""
+
+import logging
+
+PROD_URL = "https://request-o-matic-production.up.railway.app/api/v1"
+STAGING_URL = "https://request-o-matic-staging.up.railway.app/api/v1"
+LOCAL_URL = "http://localhost:8000/api/v1"
+
+
+def set_up_logging(verbose: bool, default_level: int = logging.INFO) -> None:
+    """Configure logging based on verbosity level.
+
+    Args:
+        verbose: If True, use DEBUG level; otherwise use default_level.
+        default_level: Logging level when not verbose (default: INFO).
+    """
+    level = logging.DEBUG if verbose else default_level
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+    if not verbose:
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)

--- a/scripts/benchmark_requests.py
+++ b/scripts/benchmark_requests.py
@@ -32,11 +32,9 @@ from typing import Any
 
 import httpx
 
-logger = logging.getLogger(__name__)
+from scripts._common import LOCAL_URL, PROD_URL, STAGING_URL
 
-PROD_URL = "https://request-o-matic-production.up.railway.app/api/v1"
-STAGING_URL = "https://request-o-matic-staging.up.railway.app/api/v1"
-LOCAL_URL = "http://localhost:8000/api/v1"
+logger = logging.getLogger(__name__)
 
 # One representative query per search path, drawn from integration tests.
 QUERIES: list[dict[str, str]] = [

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -15,24 +15,9 @@ from typing import Any, cast
 
 import httpx
 
+from scripts._common import LOCAL_URL, PROD_URL, STAGING_URL, set_up_logging
+
 logger = logging.getLogger(__name__)
-
-PROD_URL = "https://request-o-matic-production.up.railway.app/api/v1"
-STAGING_URL = "https://request-o-matic-staging.up.railway.app/api/v1"
-LOCAL_URL = "http://localhost:8000/api/v1"
-
-
-def set_up_logging(verbose: bool) -> None:
-    """Configure logging based on verbosity level."""
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler()],
-    )
-    if not verbose:
-        logging.getLogger("httpx").setLevel(logging.WARNING)
-        logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 
 def print_section(title: str) -> None:

--- a/scripts/repl.py
+++ b/scripts/repl.py
@@ -17,6 +17,8 @@ from typing import Any, cast
 
 import httpx
 
+from scripts._common import LOCAL_URL, PROD_URL, set_up_logging
+
 # History file location
 HISTORY_FILE = Path.home() / ".request_repl_history"
 
@@ -41,22 +43,6 @@ def configure_readline() -> None:
 
 
 logger = logging.getLogger(__name__)
-
-PROD_URL = "https://request-o-matic-production.up.railway.app/api/v1"
-LOCAL_URL = "http://localhost:8000/api/v1"
-
-
-def set_up_logging(verbose: bool) -> None:
-    """Configure logging based on verbosity level."""
-    level = logging.DEBUG if verbose else logging.WARNING
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler()],
-    )
-    if not verbose:
-        logging.getLogger("httpx").setLevel(logging.WARNING)
-        logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 
 def print_result(data: dict) -> None:
@@ -150,7 +136,7 @@ def save_history() -> None:
 
 async def repl(base_url: str, verbose: bool) -> None:
     """Run the interactive REPL."""
-    set_up_logging(verbose)
+    set_up_logging(verbose, default_level=logging.WARNING)
     configure_readline()
     load_history()
 


### PR DESCRIPTION
## Summary

- Create `scripts/_common.py` with shared URL constants and `set_up_logging()`
- Update 3 scripts to import from `_common`
- Replace hardcoded URL in `core/dependencies.py` with `settings.slack_webhook_key_url`

Closes #38

## Test plan

- [x] All 530 unit tests pass
- [x] `ruff check` and `ruff format` clean