### PR TITLE
fix: extend fuzz.ratio gate to exact FTS5 search path

### DIFF
--- a/core/orchestration.py
+++ b/core/orchestration.py
@@ -530,6 +530,24 @@ async def search_compilations_for_track(
     return limit_results(results), discogs_titles
 
 
+def _album_title_acceptable(query_lower: str, result_lower: str) -> bool:
+    """Check if a library album title is an acceptable match for a Discogs album title.
+
+    Accepts if EITHER:
+    - fuzz.ratio >= 50 (titles are similar in length and content), OR
+    - one title is a prefix of the other (library often omits parentheticals,
+      e.g. "Morvern Callar" vs "Morvern Callar (Original Motion Picture Soundtrack)")
+
+    Rejects cases like "808 State" matching "The Best Of 808 State: Blueprint"
+    where tokens overlap but the titles refer to different albums.
+    """
+    from rapidfuzz import fuzz
+
+    if query_lower.startswith(result_lower) or result_lower.startswith(query_lower):
+        return True
+    return fuzz.ratio(query_lower, result_lower) >= 50
+
+
 async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryItem]:
     """Search for album with fuzzy keyword matching.
 
@@ -544,6 +562,19 @@ async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryIte
 
     # Try exact search first (use higher limit to allow artist filtering later)
     results = await db.search(query=album_title, limit=MAX_SEARCH_RESULTS)
+
+    # Filter exact results by length-sensitive similarity to prevent FTS5
+    # false positives. FTS5 tokenizes the query and matches on any shared
+    # tokens, so "The Best Of 808 State: Blueprint" matches "808 State".
+    # Accept a result if EITHER:
+    #  - fuzz.ratio >= 50 (titles are similar in length and content), OR
+    #  - one title is a prefix of the other (library often omits parentheticals,
+    #    e.g. "Morvern Callar" vs "Morvern Callar (Original Motion Picture Soundtrack)")
+    if results:
+        album_lower = album_title.lower()
+        results = [
+            r for r in results if _album_title_acceptable(album_lower, (r.title or "").lower())
+        ]
 
     if not results:
         significant_words = list(extract_significant_words(album_title, min_length=3))
@@ -568,28 +599,22 @@ async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryIte
                     # Calculate overall fuzzy similarity
                     similarity = fuzz.token_set_ratio(album_lower, result_title_lower)
 
-                    # fuzz.ratio is length-sensitive — penalizes large length
-                    # differences that token_set_ratio ignores (subset bias).
-                    standard_similarity = fuzz.ratio(album_lower, result_title_lower)
+                    # Require keyword overlap AND title acceptability (same
+                    # length-sensitive check used for exact results).
+                    title_ok = _album_title_acceptable(album_lower, result_title_lower)
 
-                    # Require ALL THREE:
-                    # 1. 2+ keyword matches
-                    # 2. 60% token_set_ratio (token overlap)
-                    # 3. 50% fuzz.ratio (length-sensitive similarity)
-                    # This prevents short library titles from matching long Discogs
-                    # album names just because their tokens are a subset.
-                    if keyword_matches >= 2 and similarity >= 60 and standard_similarity >= 50:
+                    if keyword_matches >= 2 and similarity >= 60 and title_ok:
                         logger.debug(
                             f"Album match: '{result.title}' "
                             f"(keywords={keyword_matches}, "
-                            f"token_set={similarity}, ratio={standard_similarity:.0f})"
+                            f"token_set={similarity}, title_ok={title_ok})"
                         )
                         filtered_results.append(result)
                     else:
                         logger.debug(
                             f"Album rejected: '{result.title}' "
                             f"(keywords={keyword_matches}, "
-                            f"token_set={similarity}, ratio={standard_similarity:.0f})"
+                            f"token_set={similarity}, title_ok={title_ok})"
                         )
 
                 results = filtered_results

--- a/tests/unit/test_orchestration.py
+++ b/tests/unit/test_orchestration.py
@@ -83,3 +83,38 @@ async def test_search_album_fuzzy_rejects_subset_match():
         "'Essential Dance Music Classics Volume Three' — "
         "token_set_ratio is 100% due to subset bias but fuzz.ratio is only 41%"
     )
+
+
+@pytest.mark.asyncio
+async def test_search_album_fuzzy_rejects_subset_match_on_exact_search():
+    """search_album_fuzzy should also filter exact FTS5 results by length-sensitive similarity.
+
+    Bug (FLOW_COMA_808_STATE): FTS5 tokenizes "The Best Of 808 State: Blueprint" and
+    matches "808 State" because it contains tokens "808" and "State". The fuzz.ratio gate
+    was only on the fuzzy fallback path, so the exact search returned false positives.
+    """
+    _ = FLOW_COMA_808_STATE  # link to scenario
+
+    db = AsyncMock()
+    # Exact FTS5 search returns the false positive directly
+    db.search = AsyncMock(
+        return_value=[
+            LibraryItem(
+                id=958,
+                title="808 State",
+                artist="808 State",
+                genre="Electronic",
+                format="vinyl",
+                call_letters="Ei",
+                artist_call_number=1,
+                release_call_number=1,
+            )
+        ]
+    )
+
+    results = await search_album_fuzzy(db, "The Best Of 808 State: Blueprint")
+    assert results == [], (
+        "Should reject '808 State' as a match for "
+        "'The Best Of 808 State: Blueprint' — "
+        "FTS5 matches on shared tokens but fuzz.ratio correctly penalizes length mismatch"
+    )

--- a/tests/unit/test_request_flow.py
+++ b/tests/unit/test_request_flow.py
@@ -301,19 +301,18 @@ async def test_compilation_filtering_allows_soundtrack_when_discogs_says_various
 
         results, discogs_titles = await search_compilations_for_track(mock_db, parsed)
 
-    # Current behavior: when Discogs says "Various" released something,
-    # ANY compilation-type album from the fuzzy search is allowed through.
-    # This is permissive but may cause false positives.
-    # For refactoring, we preserve this behavior.
-    assert len(results) == 3, (
-        f"Expected 3 results, got {len(results)}: {[r.title for r in results]}"
+    # The fuzz.ratio + prefix gate in search_album_fuzzy filters out unrelated
+    # compilations whose titles don't match the Discogs album title.
+    assert len(results) == 2, (
+        f"Expected 2 results, got {len(results)}: {[r.title for r in results]}"
     )
 
     result_ids = {r.id for r in results}
     assert 101 in result_ids, "Should include artist's own album"
     assert 100 in result_ids, "Should include soundtrack (Discogs said 'Various')"
-    assert 102 in result_ids, (
-        "Current behavior: unrelated compilation also included (permissive filter)"
+    assert 102 not in result_ids, (
+        "Unrelated compilation should be excluded — its title 'Random Electronic "
+        "Compilation' is not similar enough to 'Morvern Callar'"
     )
 
 


### PR DESCRIPTION
## Summary

- Extract `_album_title_acceptable()` helper that checks if a library album title is an acceptable match for a Discogs album title using both `fuzz.ratio` (length-sensitive) and prefix matching
- Apply the check to the exact FTS5 search path (previously only applied to the fuzzy fallback)
- Add unit test for the exact search path false positive scenario
- Update `test_compilation_filtering_allows_soundtrack_when_discogs_says_various` to expect the now-correctly-rejected unrelated compilation

Closes #53

## Test plan

- [x] Unit test `test_search_album_fuzzy_rejects_subset_match_on_exact_search` passes
- [x] All 581 unit tests pass
- [ ] Integration test `test_flow_coma_808_state_excludes_unrelated_album` passes against staging
- [ ] No regressions in existing integration tests