### PR TITLE
fix: remove early return that blocks artist-only fallback

### DIFF
--- a/core/orchestration.py
+++ b/core/orchestration.py
@@ -317,15 +317,14 @@ async def search_library_with_fallback(
             sort_by_title_relevance(all_results, albums[0])
             return all_results, False
 
-        # Discogs found specific albums for this track but none matched in the
-        # library.  Don't fall through to generic artist search — that would
-        # return unrelated albums (e.g., "808 State" self-titled for a track
-        # on "The Best Of 808 State: Blueprint").  The compilation search
-        # strategy runs next and can still find the track.
+        # When Discogs found albums but none matched the library, fall through to
+        # artist+song and artist-only search.  filter_results_by_track_validation()
+        # (called by perform_lookup after the search pipeline) validates fallback
+        # results against Discogs tracklists to prevent false positives.
         logger.info(
-            f"Discogs found albums {albums} but none matched in library; skipping artist fallback"
+            f"Discogs found albums {albums} but none matched in library; "
+            "falling through to artist search"
         )
-        return [], True
 
     # If no albums from Discogs, try artist + song
     # This is a fallback when we couldn't confirm which album contains the track

--- a/tests/scenarios.py
+++ b/tests/scenarios.py
@@ -283,6 +283,7 @@ UNIT_COVERAGE: dict[str, list[str]] = {
         "tests/unit/test_request_flow.py::TestFilterResultsByTrackValidation::test_returns_none_when_no_song",
         "tests/unit/test_request_flow.py::TestFilterResultsByTrackValidation::test_handles_discogs_search_returning_no_results",
         "tests/unit/test_request_flow.py::TestFilterResultsByTrackValidation::test_handles_discogs_exception_gracefully",
+        "tests/unit/test_request_helpers.py::test_search_library_falls_back_to_artist_when_discogs_albums_not_in_library",
     ],
     "biosphere_album_filter": [
         "tests/unit/test_request_helpers.py::test_search_library_with_fallback_filters_by_album_title",
@@ -323,7 +324,7 @@ UNIT_COVERAGE: dict[str, list[str]] = {
     "flow_coma_808_state": [
         "tests/unit/test_orchestration.py::test_search_album_fuzzy_rejects_subset_match",
         "tests/unit/test_orchestration.py::test_search_album_fuzzy_rejects_subset_match_on_exact_search",
-        "tests/unit/test_request_helpers.py::test_search_library_no_fallback_when_discogs_found_albums",
+        "tests/unit/test_request_helpers.py::test_search_library_artist_fallback_when_discogs_albums_not_in_library",
     ],
 }
 

--- a/tests/unit/test_request_helpers.py
+++ b/tests/unit/test_request_helpers.py
@@ -17,6 +17,7 @@ from tests.scenarios import (
     BIOSPHERE_ALBUM_FILTER,
     FLOW_COMA_808_STATE,
     LAID_BACK_ARTIST_VS_TITLE,
+    SNEAKER_PIMPS_TRACK_VALIDATION,
     TOY_WORD_BOUNDARY,
     YOUNG_GOV_PREFIX,
 )
@@ -166,13 +167,14 @@ async def test_search_library_with_fallback_artist_only_when_no_discogs_albums(m
 
 
 @pytest.mark.asyncio
-async def test_search_library_no_fallback_when_discogs_found_albums(mock_library_db):
-    """When Discogs found specific albums but none are in the library, don't fall back.
+async def test_search_library_artist_fallback_when_discogs_albums_not_in_library(mock_library_db):
+    """When Discogs found specific albums but none are in library, artist fallback runs.
 
-    Bug (FLOW_COMA_808_STATE): Discogs finds "Flow Coma" on "The Best Of 808 State:
-    Blueprint", but the library doesn't have that album. The old code fell back to
-    artist+song/artist-only search, returning the unrelated "808 State" (self-titled)
-    album which does NOT contain "Flow Coma".
+    Scenario (FLOW_COMA_808_STATE): Discogs finds "Flow Coma" on "The Best Of
+    808 State: Blueprint" but the library doesn't have it. The artist+song fallback
+    returns the "808 State" self-titled album, which is a false positive.
+    filter_results_by_track_validation() (tested separately in
+    TestFilterResultsByTrackValidation) rejects it because "Flow Coma" isn't on it.
     """
     _ = FLOW_COMA_808_STATE  # link to scenario
 
@@ -187,12 +189,11 @@ async def test_search_library_no_fallback_when_discogs_found_albums(mock_library
         release_call_number=1,
     )
 
-    # Album search returns empty, but artist+song and artist-only searches
-    # would return the false positive (if they ran).
+    # Album search returns empty, but artist+song fallback returns the false positive.
     mock_library_db.search.side_effect = [
         [],  # album search: no match for "The Best Of 808 State: Blueprint"
-        [false_positive],  # artist+song: would match "808 State Flow Coma" via fuzzy
-        [false_positive],  # artist-only: would match "808 State"
+        [false_positive],  # artist+song: "808 State Flow Coma" matches via fuzzy
+        [false_positive],  # artist-only: "808 State" matches
     ]
 
     parsed = make_parsed_request(
@@ -205,14 +206,70 @@ async def test_search_library_no_fallback_when_discogs_found_albums(mock_library
         mock_library_db, parsed, ["The Best Of 808 State: Blueprint"]
     )
 
-    # Should return empty — don't fall back to generic artist search
-    assert results == [], (
-        "Should not fall back to artist search when Discogs found specific albums. "
-        "Returning '808 State' (self-titled) would be a false positive."
+    # Artist+song fallback now returns the false positive; it's the job of
+    # filter_results_by_track_validation() to reject it downstream.
+    assert len(results) == 1
+    assert results[0].title == "808 State"
+    assert fallback_used is True
+    assert mock_library_db.search.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_search_library_falls_back_to_artist_when_discogs_albums_not_in_library(
+    mock_library_db,
+):
+    """When Discogs found only singles/EPs not in library, fall through to artist search.
+
+    Bug (SNEAKER_PIMPS_TRACK_VALIDATION): "6 underground by sneaker pimps" — Discogs
+    only returns singles which aren't in the library. The artist-only fallback should
+    still run, returning all Sneaker Pimps albums. filter_results_by_track_validation()
+    (called by perform_lookup) then validates each against Discogs tracklists.
+    """
+    _ = SNEAKER_PIMPS_TRACK_VALIDATION  # link to scenario
+
+    becoming_x = LibraryItem(
+        id=1,
+        artist="Sneaker Pimps",
+        title="Becoming X",
+        call_letters="S",
+        artist_call_number=1,
+        release_call_number=1,
+        genre="Electronic",
+        format="CD",
+    )
+    kiss_swallow = LibraryItem(
+        id=2,
+        artist="Sneaker Pimps",
+        title="Kiss & Swallow",
+        call_letters="S",
+        artist_call_number=1,
+        release_call_number=2,
+        genre="Electronic",
+        format="CD",
+    )
+    mock_library_db.search.side_effect = [
+        [],  # album search for "6 Underground (Rewired)" → no match
+        [],  # album search for "6 Underground" → no match
+        [],  # artist+song "Sneaker Pimps 6 Underground" → no match
+        [becoming_x, kiss_swallow],  # artist-only "Sneaker Pimps" → both albums
+    ]
+
+    parsed = make_parsed_request(
+        song="6 Underground",
+        artist="Sneaker Pimps",
+        raw_message="6 underground - sneaker pimps",
+    )
+
+    results, fallback_used = await search_library_with_fallback(
+        mock_library_db,
+        parsed,
+        ["6 Underground (Rewired)", "6 Underground"],
+    )
+    assert len(results) == 2, (
+        "Artist-only fallback should return both Sneaker Pimps albums; "
+        "filter_results_by_track_validation handles false-positive filtering"
     )
     assert fallback_used is True
-    # Should only have searched for the specific album, not done artist+song or artist-only
-    assert mock_library_db.search.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Remove early return in `search_library_with_fallback` that blocked artist+song and artist-only fallback searches when Discogs found albums not in the library
- `filter_results_by_track_validation()` (called downstream by `perform_lookup`) already validates fallback results against Discogs tracklists, making the early return redundant
- Fixes "6 underground by sneaker pimps" returning no results when Discogs only finds singles
- Mirrors the same fix in library-metadata-lookup (WXYC/library-metadata-lookup#21)

Closes #55

## Test plan
- [x] New test: `test_search_library_falls_back_to_artist_when_discogs_albums_not_in_library` — Sneaker Pimps case
- [x] Renamed: `test_search_library_artist_fallback_when_discogs_albums_not_in_library` — 808 State now expects fallback to run
- [x] Updated `UNIT_COVERAGE` in `tests/scenarios.py`
- [x] All 583 unit tests pass
- [ ] Integration test `test_6_underground_sneaker_pimps_returns_only_becoming_x` passes on staging after library-metadata-lookup deploys
- [ ] Integration test `test_flow_coma_808_state_excludes_unrelated_album` still passes (808 State regression)