### PR TITLE
Update README and CLAUDE.md after script migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,3 +167,12 @@ Optional:
 - Use `black` for formatting, `ruff` for linting
 - Type hints encouraged but not enforced
 - Async/await for all I/O operations
+
+## Example Music Data for Tests
+
+WXYC is a freeform station. When creating test fixtures or mock data, use representative artists instead of mainstream acts like Queen, Radiohead, or The Beatles. The canonical data source is `wxyc-shared/src/test-utils/wxyc-example-data.json`.
+
+Preferred defaults for fixtures:
+- `ParsedRequest`: `artist="Juana Molina", song="la paradoja", album="DOGA"`
+- `LibraryItem`: `artist="Stereolab", title="Aluminum Tunes", genre="Rock"`
+- Other good choices: Cat Power / "Moon Pix" (Matador), Jessica Pratt / "On Your Own Love Again" (Drag City), Chuquimamani-Condori / "Edits" (self-released), Duke Ellington & John Coltrane / "Duke Ellington & John Coltrane" (Impulse Records), Sessa / "Pequena Vertigem de Amor" (Mexican Summer), Large Professor / "1st Class" (Matador Records)

--- a/README.md
+++ b/README.md
@@ -88,15 +88,7 @@ ENABLE_ARTWORK_LOOKUP=true
 - **SLACK_WEBHOOK_URL**: Create an incoming webhook in your Slack workspace's [App Settings](https://api.slack.com/messaging/webhooks)
 - **POSTHOG_API_KEY**: Optional - Get your project API key from [PostHog](https://posthog.com/) for telemetry tracking
 
-### 4. Verify Database
-
-The project includes a pre-built SQLite database (`library.db`). If you need to rebuild it or if the file is missing:
-
-```bash
-python scripts/export_to_sqlite.py
-```
-
-### 5. Run the Application
+### 4. Run the Application
 
 #### Option A: Using Python directly
 
@@ -270,14 +262,6 @@ The project uses:
 - **Custom exceptions** for better error handling
 
 ## Troubleshooting
-
-### Database Not Found Error
-
-If you see an error about `library.db` not being found:
-
-```bash
-python scripts/export_to_sqlite.py
-```
 
 ### GROQ_API_KEY Not Set Error
 


### PR DESCRIPTION
## Summary

- Remove stale references to `scripts/export_to_sqlite.py` in README (moved to library-metadata-lookup in #50)
- Remove "Database Not Found" troubleshooting section referencing the moved script
- Add example music data section to CLAUDE.md

Follow-up to #50.