### PR TITLE
Fix CLI scripts failing outside project directory

### DIFF
--- a/scripts/benchmark_requests.py
+++ b/scripts/benchmark_requests.py
@@ -28,7 +28,11 @@ import logging
 import statistics
 import sys
 import time
+from pathlib import Path
 from typing import Any
+
+# Allow running from any directory
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import httpx
 

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -11,7 +11,11 @@ import argparse
 import asyncio
 import logging
 import sys
+from pathlib import Path
 from typing import Any, cast
+
+# Allow running from any directory
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import httpx
 

--- a/scripts/repl.py
+++ b/scripts/repl.py
@@ -15,6 +15,9 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
+# Allow running from any directory
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 import httpx
 
 from scripts._common import LOCAL_URL, PROD_URL, set_up_logging


### PR DESCRIPTION
## Summary
- Resolve the project root from `__file__` and insert it into `sys.path` in `lookup.py`, `repl.py`, and `benchmark_requests.py` so that the `from scripts._common import ...` works regardless of the caller's working directory.

Closes #66

## Test plan
- [ ] Run `python scripts/lookup.py "Stereolab"` from the project root (should still work)
- [ ] Run `python /path/to/request-o-matic/scripts/lookup.py "Stereolab"` from a different directory (previously failed, now works)