### PR TITLE
Rename DiscogsSearchResult to ReleaseMetadata, add streaming preview links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Request-O-Matic is a FastAPI service for WXYC radio that processes song requests
 4. **Slack**: Post enriched results with artwork to Slack
 
 ### Key Files
-- `models.py` - Shared DTOs: `LibraryItem`, `DiscogsSearchResult`
+- `models.py` - Shared DTOs: `LibraryItem`, `ReleaseMetadata`
 - `routers/request.py` - Request handling: parse, delegate to lookup service, post to Slack
 - `routers/health.py` - Health check endpoint (groq, lookup, slack services)
 - `services/parser.py` - Groq AI message parsing

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-"""Shared Pydantic models for library and Discogs data.
+"""Shared Pydantic models for library and release metadata.
 
 These DTOs are used to deserialize responses from the library-metadata-lookup
 service. The full library and Discogs modules (search, caching, rate limiting)
@@ -44,8 +44,11 @@ class LibraryItem(BaseModel):
         return f"http://www.wxyc.info/wxycdb/libraryRelease?id={self.id}"
 
 
-class DiscogsSearchResult(BaseModel):
-    """A single result from Discogs search."""
+class ReleaseMetadata(BaseModel):
+    """Metadata for a release: Discogs info, artwork, and streaming links.
+
+    Deserialized from the ``artwork`` field of library-metadata-lookup responses.
+    """
 
     album: str | None = None
     artist: str | None = None
@@ -53,3 +56,22 @@ class DiscogsSearchResult(BaseModel):
     artwork_url: str | None = None
     confidence: float = 0.0
     release_url: str = ""
+    spotify_url: str | None = None
+    apple_music_url: str | None = None
+    youtube_music_url: str | None = None
+    bandcamp_url: str | None = None
+    soundcloud_url: str | None = None
+
+    @property
+    def preview_url(self) -> str | None:
+        """First available streaming URL in priority order."""
+        for url in (
+            self.spotify_url,
+            self.apple_music_url,
+            self.youtube_music_url,
+            self.bandcamp_url,
+            self.soundcloud_url,
+        ):
+            if url:
+                return url
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "httpx>=0.25.0",
     "posthog>=3.0.0",
+    "sentry-sdk[fastapi]>=2.0.0",
 ]
 
 [project.scripts]

--- a/routers/request.py
+++ b/routers/request.py
@@ -23,7 +23,7 @@ from core.dependencies import (
     get_slack_service,
 )
 from core.telemetry import RequestTelemetry, get_cache_stats, init_cache_stats
-from models import DiscogsSearchResult, LibraryItem
+from models import LibraryItem, ReleaseMetadata
 from services.lookup_client import LookupRequest, LookupServiceClient
 from services.parser import MessageType, ParsedRequest, parse_request
 from services.slack import build_simple_slack_blocks, build_slack_blocks
@@ -54,7 +54,7 @@ class UnifiedResponse(BaseModel):
     """Combined response from parsing, artwork lookup, and library search."""
 
     parsed: ParsedRequest
-    artwork: DiscogsSearchResult | None = None
+    artwork: ReleaseMetadata | None = None
     library_results: list[LibraryItem] = []
     # Search metadata
     search_type: str = "none"
@@ -68,7 +68,7 @@ async def post_results_to_slack(
     slack_service: SlackService | None,
     message: str,
     parsed: ParsedRequest,
-    items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]],
+    items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]],
     context: str | None = None,
 ) -> None:
     """Post formatted results to Slack.
@@ -194,7 +194,7 @@ async def handle_request(
             raise HTTPException(status_code=503, detail="Search service not configured")
 
         library_results: list[LibraryItem] = []
-        items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]] = []
+        items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]] = []
         song_not_found = False
         found_on_compilation = False
         context: str | None = None

--- a/services/lookup_client.py
+++ b/services/lookup_client.py
@@ -6,7 +6,7 @@ import logging
 import httpx
 from pydantic import BaseModel
 
-from models import DiscogsSearchResult, LibraryItem
+from models import LibraryItem, ReleaseMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class LookupResultItem(BaseModel):
     """A single lookup result: library item paired with optional artwork."""
 
     library_item: LibraryItem
-    artwork: DiscogsSearchResult | None = None
+    artwork: ReleaseMetadata | None = None
 
 
 class LookupResponse(BaseModel):

--- a/services/slack.py
+++ b/services/slack.py
@@ -4,7 +4,7 @@ from typing import Any
 import httpx
 
 from config.settings import get_settings
-from models import DiscogsSearchResult, LibraryItem
+from models import LibraryItem, ReleaseMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ async def shutdown_slack_service():
 
 def build_slack_blocks(
     message: str,
-    items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]],
+    items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]],
     context: str | None = None,
 ) -> list[dict]:
     """Build Slack message blocks from library results with artwork."""
@@ -65,7 +65,10 @@ def build_slack_blocks(
             f"_{item.call_number}_",
         ]
         if artwork and artwork.release_url:
-            text_lines.append(f"<{artwork.release_url}|Discogs> | <{item.library_url}|WXYC>")
+            links = f"<{artwork.release_url}|Discogs> | <{item.library_url}|WXYC>"
+            if artwork.preview_url:
+                links += f" | <{artwork.preview_url}|Preview>"
+            text_lines.append(links)
 
         block: dict = {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(text_lines)}}
 

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -13,7 +13,7 @@ from core.dependencies import (
     get_posthog_client,
     get_slack_service,
 )
-from models import DiscogsSearchResult, LibraryItem
+from models import LibraryItem, ReleaseMetadata
 from routers.request import router
 from services.lookup_client import LookupResponse, LookupResultItem, LookupServiceClient
 from tests.conftest import make_parsed_request
@@ -43,7 +43,7 @@ def sample_lookup_response():
                     genre="Rock",
                     format="CD",
                 ),
-                artwork=DiscogsSearchResult(
+                artwork=ReleaseMetadata(
                     album="The Game",
                     artist="Queen",
                     release_id=123,
@@ -285,7 +285,7 @@ class TestDelegationBranch:
                         genre="Rock",
                         format="CD",
                     ),
-                    artwork=DiscogsSearchResult(
+                    artwork=ReleaseMetadata(
                         album="A Night at the Opera",
                         artist="Queen",
                         release_id=100,
@@ -432,9 +432,9 @@ class TestDelegatedCacheStats:
         data = response.json()
         cache_stats = data["cache_stats"]
         # At least one of these must be non-zero
-        assert (cache_stats["pg_hits"] + cache_stats["pg_misses"] + cache_stats["api_calls"]) > 0, (
-            "Delegated cache stats should not be all zeros when lookup service reports activity"
-        )
+        assert (
+            cache_stats["pg_hits"] + cache_stats["pg_misses"] + cache_stats["api_calls"]
+        ) > 0, "Delegated cache stats should not be all zeros when lookup service reports activity"
 
     @pytest.mark.asyncio
     async def test_fallback_to_local_stats_when_lookup_returns_none(

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -432,9 +432,9 @@ class TestDelegatedCacheStats:
         data = response.json()
         cache_stats = data["cache_stats"]
         # At least one of these must be non-zero
-        assert (
-            cache_stats["pg_hits"] + cache_stats["pg_misses"] + cache_stats["api_calls"]
-        ) > 0, "Delegated cache stats should not be all zeros when lookup service reports activity"
+        assert (cache_stats["pg_hits"] + cache_stats["pg_misses"] + cache_stats["api_calls"]) > 0, (
+            "Delegated cache stats should not be all zeros when lookup service reports activity"
+        )
 
     @pytest.mark.asyncio
     async def test_fallback_to_local_stats_when_lookup_returns_none(

--- a/tests/unit/test_slack_service.py
+++ b/tests/unit/test_slack_service.py
@@ -132,14 +132,15 @@ class TestBuildSlackBlocks:
     )
     def test_builds_blocks_with_preview_link(self, sample_library_item, streaming_field):
         """Test that a Preview link appears when a streaming URL is available."""
-        artwork = ReleaseMetadata(
-            artist="Stereolab",
-            album="Aluminum Tunes",
-            artwork_url="https://example.com/artwork.jpg",
-            release_id=99999,
-            release_url="https://www.discogs.com/release/99999",
-            **{streaming_field: "https://example.com/stream"},
-        )
+        fields = {
+            "artist": "Stereolab",
+            "album": "Aluminum Tunes",
+            "artwork_url": "https://example.com/artwork.jpg",
+            "release_id": 99999,
+            "release_url": "https://www.discogs.com/release/99999",
+            streaming_field: "https://example.com/stream",
+        }
+        artwork = ReleaseMetadata.model_validate(fields)
 
         blocks = build_slack_blocks(
             message="Result:",

--- a/tests/unit/test_slack_service.py
+++ b/tests/unit/test_slack_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 
-from models import DiscogsSearchResult, LibraryItem
+from models import LibraryItem, ReleaseMetadata
 from services.slack import (
     build_simple_slack_blocks,
     build_slack_blocks,
@@ -33,7 +33,7 @@ def sample_library_item():
 @pytest.fixture
 def sample_discogs_result():
     """Create a sample Discogs search result."""
-    return DiscogsSearchResult(
+    return ReleaseMetadata(
         artist="Queen",
         album="A Night at the Opera",
         artwork_url="https://example.com/artwork.jpg",
@@ -125,6 +125,60 @@ class TestBuildSlackBlocks:
         assert "Discogs" in text
         assert "WXYC" in text
         assert "discogs.com" in text
+
+    @pytest.mark.parametrize(
+        "streaming_field",
+        ["spotify_url", "apple_music_url", "youtube_music_url", "bandcamp_url", "soundcloud_url"],
+    )
+    def test_builds_blocks_with_preview_link(self, sample_library_item, streaming_field):
+        """Test that a Preview link appears when a streaming URL is available."""
+        artwork = ReleaseMetadata(
+            artist="Stereolab",
+            album="Aluminum Tunes",
+            artwork_url="https://example.com/artwork.jpg",
+            release_id=99999,
+            release_url="https://www.discogs.com/release/99999",
+            **{streaming_field: "https://example.com/stream"},
+        )
+
+        blocks = build_slack_blocks(
+            message="Result:",
+            items_with_artwork=[(sample_library_item, artwork)],
+        )
+
+        text = blocks[1]["text"]["text"]
+        assert "<https://example.com/stream|Preview>" in text
+
+    def test_preview_link_priority_order(self, sample_library_item):
+        """Test that Preview link uses the first available URL in priority order."""
+        artwork = ReleaseMetadata(
+            artist="Stereolab",
+            album="Aluminum Tunes",
+            release_id=99999,
+            release_url="https://www.discogs.com/release/99999",
+            spotify_url="https://open.spotify.com/search/stereolab",
+            youtube_music_url="https://music.youtube.com/search?q=stereolab",
+        )
+
+        blocks = build_slack_blocks(
+            message="Result:",
+            items_with_artwork=[(sample_library_item, artwork)],
+        )
+
+        text = blocks[1]["text"]["text"]
+        assert "<https://open.spotify.com/search/stereolab|Preview>" in text
+
+    def test_no_preview_link_without_streaming_urls(
+        self, sample_library_item, sample_discogs_result
+    ):
+        """Test that no Preview link appears when no streaming URLs are set."""
+        blocks = build_slack_blocks(
+            message="Result:",
+            items_with_artwork=[(sample_library_item, sample_discogs_result)],
+        )
+
+        text = blocks[1]["text"]["text"]
+        assert "Preview" not in text
 
     def test_builds_blocks_handles_missing_artist(self):
         """Test building blocks when artist is None."""


### PR DESCRIPTION
## Summary

- Rename `DiscogsSearchResult` to `ReleaseMetadata` to reflect that it now carries Discogs info, artwork, and streaming links
- Add streaming URL fields (`spotify_url`, `apple_music_url`, `youtube_music_url`, `bandcamp_url`, `soundcloud_url`) with a `preview_url` property
- Add "Preview" link to Slack messages (Discogs | WXYC | Preview) when a streaming URL is available
- Add missing `sentry-sdk[fastapi]` to pyproject.toml (fixes 16 pre-existing test failures)

Closes #81

## Test plan

- [x] 7 new unit tests for Preview link (parameterized across all 5 streaming services + priority order + no-preview case)
- [x] All 179 unit tests pass (up from 163 passing + 16 failing)
- [x] Integration tests pass against staging
- [x] Verified LML staging returns streaming URLs that are now preserved by the renamed model
- [ ] Deploy to staging and verify Slack messages show Preview links