### PR TITLE
Add streaming links to CLI lookup tools

### DIFF
--- a/models.py
+++ b/models.py
@@ -66,10 +66,10 @@ class ReleaseMetadata(BaseModel):
     def preview_url(self) -> str | None:
         """First available streaming URL in priority order."""
         for url in (
+            self.bandcamp_url,
             self.spotify_url,
             self.apple_music_url,
             self.youtube_music_url,
-            self.bandcamp_url,
             self.soundcloud_url,
         ):
             if url:

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -163,6 +163,19 @@ def print_library_results(
         print(f"  Source:     {artwork.get('source')}")
         print(f"  Confidence: {artwork.get('confidence', 0):.2f}")
 
+        streaming_links = [
+            ("Bandcamp", artwork.get("bandcamp_url")),
+            ("Spotify", artwork.get("spotify_url")),
+            ("Apple Music", artwork.get("apple_music_url")),
+            ("YouTube Music", artwork.get("youtube_music_url")),
+            ("SoundCloud", artwork.get("soundcloud_url")),
+        ]
+        available = [(name, url) for name, url in streaming_links if url]
+        if available:
+            print_section("Streaming")
+            for name, url in available:
+                print(f"  {name + ':':16s}{url}")
+
 
 def print_cache_stats(cache_stats: dict) -> None:
     """Print Discogs cache statistics."""

--- a/scripts/repl.py
+++ b/scripts/repl.py
@@ -99,6 +99,19 @@ def print_result(data: dict) -> None:
             print(f"  Discogs:    {artwork.get('release_url')}")
         print(f"  Confidence: {artwork.get('confidence', 0):.2f}")
 
+        streaming_links = [
+            ("Bandcamp", artwork.get("bandcamp_url")),
+            ("Spotify", artwork.get("spotify_url")),
+            ("Apple Music", artwork.get("apple_music_url")),
+            ("YouTube Music", artwork.get("youtube_music_url")),
+            ("SoundCloud", artwork.get("soundcloud_url")),
+        ]
+        available = [(name, url) for name, url in streaming_links if url]
+        if available:
+            print(f"\n  {'Streaming':-^50}")
+            for name, url in available:
+                print(f"  {name + ':':16s}{url}")
+
     print()
 
 


### PR DESCRIPTION
## Summary
- Display available streaming links (Bandcamp, Spotify, Apple Music, YouTube Music, SoundCloud) in `scripts/lookup.py` and `scripts/repl.py` output
- Reorder `ReleaseMetadata.preview_url` priority to prefer Bandcamp first

Closes #84

## Test plan
- [ ] Run `scripts/lookup.py "Juana Molina DOGA"` and verify streaming links appear in output
- [ ] Run `scripts/repl.py` and verify streaming links appear in REPL results
- [ ] Verify Bandcamp link appears first when available
- [ ] Verify no streaming section appears when no links are present