### PR TITLE
Fix cold start timeouts with shallow health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,17 +96,17 @@ jobs:
 
       - name: Smoke test
         run: |
-          curl -sf https://request-o-matic-staging.up.railway.app/health | python3 -c "
+          curl -sf https://request-o-matic-staging.up.railway.app/health/ready | python3 -c "
           import sys, json
           data = json.load(sys.stdin)
           services = data['services']
           errors = []
           if services['groq'] != 'ok':
               errors.append(f\"groq: {services['groq']}\")
-          if services['database'] != 'ok':
-              errors.append(f\"database: {services['database']}\")
-          if services['discogs_api'] != 'ok':
-              errors.append(f\"discogs_api: {services['discogs_api']}\")
+          if services['lookup'] not in ('ok', 'unavailable'):
+              errors.append(f\"lookup: {services['lookup']}\")
+          if services['slack'] not in ('ok', 'unavailable'):
+              errors.append(f\"slack: {services['slack']}\")
           if errors:
               print('Smoke test FAILED:', ', '.join(errors))
               sys.exit(1)
@@ -157,17 +157,17 @@ jobs:
 
       - name: Smoke test
         run: |
-          curl -sf https://request-o-matic-production.up.railway.app/health | python3 -c "
+          curl -sf https://request-o-matic-production.up.railway.app/health/ready | python3 -c "
           import sys, json
           data = json.load(sys.stdin)
           services = data['services']
           errors = []
           if services['groq'] != 'ok':
               errors.append(f\"groq: {services['groq']}\")
-          if services['database'] != 'ok':
-              errors.append(f\"database: {services['database']}\")
-          if services['discogs_api'] != 'ok':
-              errors.append(f\"discogs_api: {services['discogs_api']}\")
+          if services['lookup'] not in ('ok', 'unavailable'):
+              errors.append(f\"lookup: {services['lookup']}\")
+          if services['slack'] not in ('ok', 'unavailable'):
+              errors.append(f\"slack: {services['slack']}\")
           if errors:
               print('Smoke test FAILED:', ', '.join(errors))
               sys.exit(1)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Request-O-Matic is a FastAPI service for WXYC radio that processes song requests
 ### Key Files
 - `models.py` - Shared DTOs: `LibraryItem`, `ReleaseMetadata`
 - `routers/request.py` - Request handling: parse, delegate to lookup service, post to Slack
-- `routers/health.py` - Health check endpoint (groq, lookup, slack services)
+- `routers/health.py` - Health check endpoints: `GET /health` (shallow liveness probe, no external calls) and `GET /health/ready` (deep readiness check: groq, lookup, slack services). Railway's `healthcheckPath` uses `/health` so the container becomes routable immediately on boot.
 - `services/parser.py` - Groq AI message parsing
 - `services/lookup_client.py` - HTTP client for library-metadata-lookup delegation
 - `services/slack.py` - Slack message formatting and posting

--- a/railway.toml
+++ b/railway.toml
@@ -1,8 +1,8 @@
 [build]
-builder = "nixpacks"
+builder = "dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 300
+healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,3 @@ python-dotenv>=1.0.0
 httpx>=0.25.0
 posthog>=7.0.0
 sentry-sdk[fastapi]>=2.0.0
-pytest>=7.0.0
-pytest-asyncio>=0.21.0
-pytest-httpx>=0.22.0

--- a/routers/health.py
+++ b/routers/health.py
@@ -80,14 +80,27 @@ async def _run_check(coro) -> str:
 
 @router.get(
     "/health",
-    summary="Health check",
-    description="Check the health status of the application and its services",
+    summary="Liveness check",
+    description="Shallow liveness probe. Returns 200 immediately with no external calls. Used by Railway's healthcheckPath to mark the container as routable.",
+    responses={
+        200: {"description": "Service is alive"},
+    },
+)
+async def liveness_check():
+    """Shallow liveness probe -- no external calls, instant response."""
+    return JSONResponse(content={"status": "ok"})
+
+
+@router.get(
+    "/health/ready",
+    summary="Readiness check",
+    description="Deep readiness probe. Checks connectivity to Groq, lookup service, and Slack.",
     responses={
         200: {"description": "Service is healthy or degraded"},
         503: {"description": "Service is unhealthy (core dependency down)"},
     },
 )
-async def health_check(
+async def readiness_check(
     settings: Settings = Depends(get_settings),
     http_client: httpx.AsyncClient = Depends(get_http_client),
 ):

--- a/tests/unit/test_health_router.py
+++ b/tests/unit/test_health_router.py
@@ -59,8 +59,37 @@ def mock_http_client():
     return client
 
 
-class TestHealthCheck:
-    """Tests for the health check endpoint."""
+class TestLivenessCheck:
+    """Tests for the shallow /health liveness endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_ok(self):
+        """Liveness check returns 200 immediately with no dependencies."""
+        settings = _make_settings()
+        app = _make_app(settings)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            response = await c.get("/health")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_no_external_calls(self):
+        """Liveness check must not make any HTTP calls."""
+        settings = _make_settings()
+        client = AsyncMock()
+        app = _make_app(settings, client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            await c.get("/health")
+
+        client.get.assert_not_called()
+        client.post.assert_not_called()
+
+
+class TestReadinessCheck:
+    """Tests for the deep /health/ready readiness endpoint."""
 
     @pytest.mark.asyncio
     async def test_all_services_healthy(self, mock_http_client):
@@ -75,7 +104,7 @@ class TestHealthCheck:
             return_value="https://hooks.slack.com/test",
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health")
+                response = await c.get("/health/ready")
 
         assert response.status_code == 200
         data = response.json()
@@ -109,7 +138,7 @@ class TestHealthCheck:
             return_value="https://hooks.slack.com/test",
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health")
+                response = await c.get("/health/ready")
 
         assert response.status_code == 503
         data = response.json()
@@ -140,7 +169,7 @@ class TestHealthCheck:
             return_value="https://hooks.slack.com/test",
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health")
+                response = await c.get("/health/ready")
 
         assert response.status_code == 200
         data = response.json()
@@ -158,7 +187,7 @@ class TestHealthCheck:
             return_value="https://hooks.slack.com/test",
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health")
+                response = await c.get("/health/ready")
 
         assert response.status_code == 200
         data = response.json()
@@ -172,7 +201,7 @@ class TestHealthCheck:
 
         with patch("routers.health.get_cached_slack_webhook_url", return_value=None):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health")
+                response = await c.get("/health/ready")
 
         assert response.status_code == 200
         data = response.json()
@@ -208,7 +237,7 @@ class TestHealthCheck:
             patch("routers.health.CHECK_TIMEOUT", 0.05),
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health")
+                response = await c.get("/health/ready")
 
         assert response.status_code == 503
         data = response.json()
@@ -225,7 +254,7 @@ class TestHealthCheck:
             return_value="https://hooks.slack.com/test",
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health")
+                response = await c.get("/health/ready")
 
         data = response.json()
         assert "features" not in data
@@ -259,7 +288,7 @@ class TestHealthCheck:
             return_value="https://hooks.slack.com/test",
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                await c.get("/health")
+                await c.get("/health/ready")
 
         lookup_urls = [u for u in captured_urls if "lookup" in u]
         assert lookup_urls == ["https://lookup.example.com/health"]
@@ -294,7 +323,7 @@ class TestHealthCheck:
             return_value="https://hooks.slack.com/test",
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health")
+                response = await c.get("/health/ready")
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -28,8 +28,9 @@ class TestAppConfiguration:
 
             routes = [route.path for route in app.routes if hasattr(route, "path")]
 
-            # Check for health endpoint
+            # Check for health endpoints
             assert "/health" in routes
+            assert "/health/ready" in routes
 
             # Check for versioned API routes
             assert any("/api/v1/request" in route for route in routes)


### PR DESCRIPTION
## Summary

- Split health check: `GET /health` returns instantly (liveness), `GET /health/ready` probes dependencies (readiness)
- Switch Railway builder from nixpacks to existing slim Dockerfile
- Remove test deps from production image
- Fix stale service names in CI smoke tests (`database`/`discogs_api` -> `lookup`/`slack`)

Closes #88

## Test plan

- [x] All 181 unit tests pass
- [x] Ruff format + lint clean
- [ ] Deploy to staging and verify `curl /health` returns instantly
- [ ] Verify `curl /health/ready` returns deep service checks
- [ ] Cold start: sleep service, hit `/health`, confirm fast response