### PR TITLE
Switch Groq client to async, remove dead discogs/search calls

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -4,7 +4,7 @@ import logging
 
 import httpx
 from fastapi import Depends
-from groq import Groq
+from groq import AsyncGroq
 from posthog import Posthog
 
 from config.settings import Settings, get_settings
@@ -39,21 +39,21 @@ async def close_http_client() -> None:
         _http_client = None
 
 
-def get_groq_client(settings: Settings = Depends(get_settings)) -> Groq:
+def get_groq_client(settings: Settings = Depends(get_settings)) -> AsyncGroq:
     """Get Groq client instance.
 
     Args:
         settings: Application settings
 
     Returns:
-        Groq: Groq client instance
+        AsyncGroq: Async Groq client instance
 
     Raises:
         ServiceInitializationError: If Groq API key is not configured
     """
     if not settings.groq_api_key:
         raise ServiceInitializationError("GROQ_API_KEY not configured")
-    return Groq(api_key=settings.groq_api_key)
+    return AsyncGroq(api_key=settings.groq_api_key)
 
 
 async def get_lookup_client(

--- a/routers/parse.py
+++ b/routers/parse.py
@@ -3,7 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
-from groq import Groq
+from groq import AsyncGroq
 from pydantic import BaseModel
 
 from core.dependencies import get_groq_client
@@ -48,14 +48,14 @@ class ParseRequestBody(BaseModel):
 )
 async def parse(
     request: ParseRequestBody,
-    client: Groq = Depends(get_groq_client),
+    client: AsyncGroq = Depends(get_groq_client),
 ):
     """Parse a listener message and extract song request metadata."""
     if not request.message.strip():
         raise HTTPException(status_code=400, detail="Message cannot be empty")
 
     try:
-        result = parse_request(request.message, client)
+        result = await parse_request(request.message, client)
         logger.info(f"Parsed request: is_request={result.is_request}, type={result.message_type}")
         return result
     except ValueError as e:

--- a/routers/request.py
+++ b/routers/request.py
@@ -11,7 +11,7 @@ import logging
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from groq import Groq
+from groq import AsyncGroq
 from posthog import Posthog
 from pydantic import BaseModel
 
@@ -147,7 +147,7 @@ async def post_results_to_slack(
 )
 async def handle_request(
     request: RequestBody,
-    groq_client: Groq = Depends(get_groq_client),
+    groq_client: AsyncGroq = Depends(get_groq_client),
     slack_service: SlackService | None = Depends(get_slack_service),
     posthog_client: Posthog | None = Depends(get_posthog_client),
     lookup_client: LookupServiceClient | None = Depends(get_lookup_client),
@@ -173,7 +173,7 @@ async def handle_request(
         # Step 1: Parse the message
         with telemetry.track_step("parse"):
             telemetry.record_api_call("groq")
-            parsed = parse_request(request.message, groq_client)
+            parsed = await parse_request(request.message, groq_client)
             logger.info(
                 f"Parsed request: is_request={parsed.is_request}, type={parsed.message_type}"
             )

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -42,50 +42,6 @@ def print_parsed_request(parsed: dict) -> None:
     print(f"  Raw Message:   {parsed.get('raw_message')}")
 
 
-async def lookup_discogs_urls(
-    client: httpx.AsyncClient,
-    base_url: str,
-    results: list[dict],
-) -> dict[int, str]:
-    """Look up Discogs URLs for each library result.
-
-    Returns a dict mapping item ID to Discogs release URL.
-    """
-    discogs_urls: dict[int, str] = {}
-
-    async def fetch_discogs_url(item: dict) -> tuple[int, str | None]:
-        """Fetch Discogs URL for a single item."""
-        item_id: int = item.get("id", 0)
-        artist = item.get("artist", "")
-        title = item.get("title", "")
-
-        if not artist or not title:
-            return item_id, None
-
-        try:
-            response = await client.post(
-                f"{base_url}/discogs/search",
-                json={"artist": artist, "album": title},
-                params={"limit": 1},
-            )
-            if response.status_code == 200:
-                data = response.json()
-                results_list = data.get("results", [])
-                if results_list:
-                    return item_id, results_list[0].get("release_url")
-        except Exception:
-            pass
-        return item_id, None
-
-    # Fetch all Discogs URLs concurrently
-    tasks = [fetch_discogs_url(item) for item in results]
-    for item_id, url in await asyncio.gather(*tasks):
-        if url:
-            discogs_urls[item_id] = url
-
-    return discogs_urls
-
-
 def print_search_summary(data: dict) -> None:
     """Print search summary showing what kind of results we got."""
     parsed = data.get("parsed", {})
@@ -117,7 +73,6 @@ def print_search_summary(data: dict) -> None:
 def print_library_results(
     results: list[dict],
     artwork: dict | None,
-    discogs_urls: dict[int, str] | None = None,
     context_message: str | None = None,
 ) -> None:
     """Print library search results."""
@@ -132,10 +87,7 @@ def print_library_results(
             print("  No results found in library.")
         return
 
-    discogs_urls = discogs_urls or {}
-
     for i, item in enumerate(results, 1):
-        item_id = item.get("id")
         title = item.get("title", "")
         artist = item.get("artist", "")
         print(f"  [{i}] {artist} - {title}")
@@ -150,8 +102,6 @@ def print_library_results(
             print(f"      Location: {call_letters} {artist_num}/{release_num}")
         else:
             print("      Location: (none)")
-        if item_id in discogs_urls:
-            print(f"      Discogs:  {discogs_urls[item_id]}")
         print(f"      WXYC:     {item.get('library_url') or '(none)'}")
         print()
 
@@ -233,18 +183,11 @@ async def run_lookup(
             if not parsed.get("is_request", False):
                 return cast(dict[str, Any], data)
 
-            # Look up Discogs URLs for each library result
+            # Display library results and context
             library_results = data.get("library_results", [])
-            discogs_urls = {}
-            if library_results:
-                logger.info("Looking up Discogs URLs...")
-                discogs_urls = await lookup_discogs_urls(client, base_url, library_results)
-
-            # Display results with Discogs URLs and context
             print_library_results(
                 library_results,
                 data.get("artwork"),
-                discogs_urls,
                 data.get("context_message"),
             )
 

--- a/services/parser.py
+++ b/services/parser.py
@@ -2,7 +2,7 @@ import json
 import logging
 from enum import StrEnum
 
-from groq import Groq
+from groq import AsyncGroq
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -63,12 +63,12 @@ USER_PROMPT_TEMPLATE = """Parse this message:
 {message}"""
 
 
-def parse_request(message: str, client: Groq) -> ParsedRequest:
+async def parse_request(message: str, client: AsyncGroq) -> ParsedRequest:
     """Parse a listener message and extract song request metadata."""
     logger.info(f"Parsing message: {message[:100]}...")
 
     try:
-        response = client.chat.completions.create(
+        response = await client.chat.completions.create(
             model="llama-3.1-8b-instant",
             messages=[
                 {"role": "system", "content": SYSTEM_PROMPT},

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -60,14 +60,14 @@ class TestParserIntegration:
 
         The artist "Quix*o*tic" should NOT be normalized to "Quixotic".
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = QUIXOTIC_SPECIAL_CHARS
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Artist: {result.artist}")
@@ -90,11 +90,11 @@ class TestParserIntegration:
     @skip_if_no_groq
     async def test_preserves_special_chars_in_various_artists(self):
         """Test preservation of special characters in well-known artist names."""
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
 
         test_cases = [
             ("play something by P!nk", "P!nk", "!"),
@@ -102,7 +102,7 @@ class TestParserIntegration:
         ]
 
         for message, _expected_contains, special_char in test_cases:
-            result = parse_request(message, client)
+            result = await parse_request(message, client)
 
             print(f"\n📝 '{message}' -> Artist: {result.artist}")
 
@@ -124,14 +124,14 @@ class TestParserIntegration:
 
         Expected: Should extract song and artist from comma-separated format.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = MI_AMI_COMMA_FORMAT
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Song: {result.song}")
@@ -159,13 +159,13 @@ class TestParserIntegration:
         an emotional expression, but "I Love Acid" is a song by Luke Vibert.
         The comma-separated format should take priority.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
 
-        result = parse_request("I love acid, luke vibert", client)
+        result = await parse_request("I love acid, luke vibert", client)
 
         print("\n📝 Parsed result:")
         print(f"  Song: {result.song}")
@@ -198,15 +198,15 @@ class TestParserIntegration:
         Expected: artist should be "Eternal" (what the listener wrote), song should
         be "Mind Odyssey", album should be null.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = ETERNAL_HALLUCINATION
         assert s.artist is not None and s.song is not None
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Artist: {result.artist}")
@@ -245,14 +245,14 @@ class TestParserIntegration:
         song title and 'lp' as the album, instead of splitting on dashes to get
         song=Spoonful, artist=Cream, album=Wheels of Fire.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = SPOONFUL_DASH_FORMAT
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Song: {result.song}")
@@ -288,14 +288,14 @@ class TestParserIntegration:
 
         Expected: artist="Phil Collins", song=null.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = SOME_PHIL_COLLINS_FILLER
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Song: {result.song}")
@@ -323,14 +323,14 @@ class TestParserIntegration:
 
         Expected: artist="Helden", song=null.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = SOMETHING_BY_HELDEN_FILLER
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Song: {result.song}")
@@ -356,14 +356,14 @@ class TestParserIntegration:
 
         Expected: artist="MJ Lenderman", song=null.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = MJ_LENDERMAN_BARE_ARTIST
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Song: {result.song}")
@@ -392,14 +392,14 @@ class TestParserIntegration:
 
         Expected: artist="Fleetwood Mac", song="Sara".
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = SARA_FLEETWOOD_MAC_GREETING
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Song: {result.song}")
@@ -428,14 +428,14 @@ class TestParserIntegration:
         Expected: artist="Plug", song="Me And Mr Jones". The parser must use the
         artist name from the message, not substitute a known performer.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = PLUG_COMMA_FORMAT
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Artist: {result.artist}")
@@ -472,14 +472,14 @@ class TestParserIntegration:
         Bug: The parser treated 'well' as conversational filler and dropped it,
         resulting in no song title being extracted.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = MONK_WELL_YOU_NEEDNT
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Song: {result.song}")
@@ -504,14 +504,14 @@ class TestParserIntegration:
         Bug: The parser treated editorial phrase 'Beck's best album' as the album title
         and the actual album name 'Stereopathic Soulmanure' as a song title.
         """
-        from groq import Groq
+        from groq import AsyncGroq
 
         from services.parser import parse_request
 
-        client = Groq(api_key=GROQ_API_KEY)
+        client = AsyncGroq(api_key=GROQ_API_KEY)
         s = BECK_EDITORIAL_ALBUM
 
-        result = parse_request(s.raw_message, client)
+        result = await parse_request(s.raw_message, client)
 
         print("\n📝 Parsed result:")
         print(f"  Artist: {result.artist}")

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -96,7 +96,9 @@ class TestDelegationBranch:
         """Delegation returns results from lookup service, skipping inline pipeline."""
         mock_lookup_client.lookup.return_value = sample_lookup_response
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -130,7 +132,9 @@ class TestDelegationBranch:
             corrected_artist=None,
         )
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -153,7 +157,7 @@ class TestDelegationBranch:
         parsed = make_parsed_request(artist="Living Color", raw_message="play living color")
         mock_lookup_client.lookup.return_value = sample_lookup_response
 
-        with patch("routers.request.parse_request", return_value=parsed):
+        with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -175,7 +179,9 @@ class TestDelegationBranch:
             "Internal Server Error", request=mock_response.request, response=mock_response
         )
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -192,7 +198,9 @@ class TestDelegationBranch:
         """Connection error to lookup service returns 502."""
         mock_lookup_client.lookup.side_effect = httpx.ConnectError("Connection refused")
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -209,7 +217,9 @@ class TestDelegationBranch:
         """Timeout from lookup service returns 502."""
         mock_lookup_client.lookup.side_effect = httpx.TimeoutException("Read timed out")
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -226,7 +236,9 @@ class TestDelegationBranch:
         """skip_cache=True is forwarded to the lookup service."""
         mock_lookup_client.lookup.return_value = sample_lookup_response
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -254,7 +266,9 @@ class TestDelegationBranch:
             found_on_compilation=False,
         )
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -310,7 +324,9 @@ class TestDelegationBranch:
             search_type="artist_search",
         )
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -340,7 +356,7 @@ class TestDelegationBranch:
             raw_message="play bohemian rhapsody by queen",
         )
 
-        with patch("routers.request.parse_request", return_value=parsed):
+        with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -384,7 +400,9 @@ class TestDelegatedCacheStats:
         sample_lookup_response.cache_stats = remote_stats
         mock_lookup_client.lookup.return_value = sample_lookup_response
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -420,7 +438,9 @@ class TestDelegatedCacheStats:
         sample_lookup_response.cache_stats = remote_stats
         mock_lookup_client.lookup.return_value = sample_lookup_response
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -444,7 +464,9 @@ class TestDelegatedCacheStats:
         sample_lookup_response.cache_stats = None
         mock_lookup_client.lookup.return_value = sample_lookup_response
 
-        with patch("routers.request.parse_request", return_value=SAMPLE_PARSED):
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -104,7 +104,7 @@ class TestGetGroqClient:
 
     def test_creates_client_with_api_key(self, mock_settings):
         """Test that get_groq_client creates client when API key is set."""
-        with patch("core.dependencies.Groq") as mock_groq:
+        with patch("core.dependencies.AsyncGroq") as mock_groq:
             get_groq_client(mock_settings)
             mock_groq.assert_called_once_with(api_key="test_groq_key")
 

--- a/tests/unit/test_non_request_early_return.py
+++ b/tests/unit/test_non_request_early_return.py
@@ -1,6 +1,6 @@
 """Tests for early return when parser classifies a message as not a request."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -52,7 +52,7 @@ class TestNonRequestEarlyReturn:
             raw_message="love the show!",
         )
 
-        with patch("routers.request.parse_request", return_value=parsed):
+        with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -80,7 +80,7 @@ class TestNonRequestEarlyReturn:
             raw_message="I love acid, luke vibert",
         )
 
-        with patch("routers.request.parse_request", return_value=parsed):
+        with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -104,7 +104,7 @@ class TestNonRequestEarlyReturn:
             raw_message="you guys are great, keep it up",
         )
 
-        with patch("routers.request.parse_request", return_value=parsed):
+        with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:
@@ -127,7 +127,7 @@ class TestNonRequestEarlyReturn:
             raw_message="play bohemian rhapsody by queen",
         )
 
-        with patch("routers.request.parse_request", return_value=parsed):
+        with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as client:

--- a/tests/unit/test_parse_router.py
+++ b/tests/unit/test_parse_router.py
@@ -1,6 +1,6 @@
 """Unit tests for routers/parse.py."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -48,7 +48,7 @@ class TestParseEndpoint:
     @pytest.mark.asyncio
     async def test_parse_successful(self, app, mock_groq_client, sample_parsed_request):
         """Test successful message parsing."""
-        with patch("routers.parse.parse_request") as mock_parse:
+        with patch("routers.parse.parse_request", new_callable=AsyncMock) as mock_parse:
             mock_parse.return_value = sample_parsed_request
 
             async with AsyncClient(
@@ -90,7 +90,7 @@ class TestParseEndpoint:
     @pytest.mark.asyncio
     async def test_parse_value_error_returns_500(self, app, mock_groq_client):
         """Test that ValueError from parser returns 500."""
-        with patch("routers.parse.parse_request") as mock_parse:
+        with patch("routers.parse.parse_request", new_callable=AsyncMock) as mock_parse:
             mock_parse.side_effect = ValueError("Invalid message format")
 
             async with AsyncClient(
@@ -104,7 +104,7 @@ class TestParseEndpoint:
     @pytest.mark.asyncio
     async def test_parse_unexpected_error_returns_500(self, app, mock_groq_client):
         """Test that unexpected exceptions return 500 with generic message."""
-        with patch("routers.parse.parse_request") as mock_parse:
+        with patch("routers.parse.parse_request", new_callable=AsyncMock) as mock_parse:
             mock_parse.side_effect = RuntimeError("Unexpected error")
 
             async with AsyncClient(
@@ -124,7 +124,7 @@ class TestParseEndpoint:
             raw_message="Thanks for listening!",
         )
 
-        with patch("routers.parse.parse_request") as mock_parse:
+        with patch("routers.parse.parse_request", new_callable=AsyncMock) as mock_parse:
             mock_parse.return_value = non_request
 
             async with AsyncClient(
@@ -151,7 +151,7 @@ class TestParseEndpoint:
             raw_message="Love the show!",
         )
 
-        with patch("routers.parse.parse_request") as mock_parse:
+        with patch("routers.parse.parse_request", new_callable=AsyncMock) as mock_parse:
             mock_parse.return_value = feedback
 
             async with AsyncClient(
@@ -193,7 +193,7 @@ class TestParseEndpoint:
             raw_message="Play Stairway to Heaven by Led Zeppelin",
         )
 
-        with patch("routers.parse.parse_request") as mock_parse:
+        with patch("routers.parse.parse_request", new_callable=AsyncMock) as mock_parse:
             mock_parse.return_value = request
 
             async with AsyncClient(
@@ -219,7 +219,7 @@ class TestParseEndpoint:
             raw_message="Play something by The Beatles",
         )
 
-        with patch("routers.parse.parse_request") as mock_parse:
+        with patch("routers.parse.parse_request", new_callable=AsyncMock) as mock_parse:
             mock_parse.return_value = request
 
             async with AsyncClient(


### PR DESCRIPTION
## Summary

- Switch `Groq` -> `AsyncGroq` so `parse_request` no longer blocks the event loop
- Remove dead `lookup_discogs_urls` function from `scripts/lookup.py` (called a `/discogs/search` endpoint that no longer exists)
- Update all test mocks to use `AsyncMock` for the now-async `parse_request`

Closes #90

## Test plan

- [x] All 181 unit tests pass
- [x] Ruff format + lint clean
- [x] CI passes
- [x] Deploy to staging and verify `/api/v1/request` works end-to-end