### PR TITLE
Handle Groq rate limits: return 429 instead of 500

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -53,7 +53,7 @@ def get_groq_client(settings: Settings = Depends(get_settings)) -> AsyncGroq:
     """
     if not settings.groq_api_key:
         raise ServiceInitializationError("GROQ_API_KEY not configured")
-    return AsyncGroq(api_key=settings.groq_api_key)
+    return AsyncGroq(api_key=settings.groq_api_key, max_retries=4)
 
 
 async def get_lookup_client(

--- a/routers/parse.py
+++ b/routers/parse.py
@@ -3,7 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
-from groq import AsyncGroq
+from groq import AsyncGroq, RateLimitError
 from pydantic import BaseModel
 
 from core.dependencies import get_groq_client
@@ -58,6 +58,9 @@ async def parse(
         result = await parse_request(request.message, client)
         logger.info(f"Parsed request: is_request={result.is_request}, type={result.message_type}")
         return result
+    except RateLimitError as e:
+        logger.warning(f"Groq rate limit exceeded: {e}")
+        raise HTTPException(status_code=429, detail="Rate limit exceeded, please retry") from e
     except ValueError as e:
         logger.error(f"Parsing error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/routers/request.py
+++ b/routers/request.py
@@ -11,7 +11,7 @@ import logging
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from groq import AsyncGroq
+from groq import AsyncGroq, RateLimitError
 from posthog import Posthog
 from pydantic import BaseModel
 
@@ -276,6 +276,9 @@ async def handle_request(
 
     except HTTPException:
         raise
+    except RateLimitError as e:
+        logger.warning(f"Groq rate limit exceeded: {e}")
+        raise HTTPException(status_code=429, detail="Rate limit exceeded, please retry") from e
     except ValueError as e:
         logger.error(f"Parsing error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -170,6 +170,28 @@ class TestDelegationBranch:
         assert data["parsed"]["artist"] == "Living Colour"
 
     @pytest.mark.asyncio
+    async def test_groq_rate_limit_returns_429(self, app, mock_lookup_client):
+        """Groq rate limit returns 429 instead of 500."""
+        from groq import RateLimitError
+
+        resp = httpx.Response(429, request=httpx.Request("POST", "https://api.groq.com/test"))
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            side_effect=RateLimitError(message="Rate limit exceeded", response=resp, body=None),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play queen", "skip_slack": True},
+                )
+
+        assert response.status_code == 429
+        assert "Rate limit exceeded" in response.json()["detail"]
+
+    @pytest.mark.asyncio
     async def test_http_error_returns_502(self, app, mock_lookup_client):
         """HTTP error from lookup service returns 502."""
         mock_response = Mock()

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -106,7 +106,7 @@ class TestGetGroqClient:
         """Test that get_groq_client creates client when API key is set."""
         with patch("core.dependencies.AsyncGroq") as mock_groq:
             get_groq_client(mock_settings)
-            mock_groq.assert_called_once_with(api_key="test_groq_key")
+            mock_groq.assert_called_once_with(api_key="test_groq_key", max_retries=4)
 
     def test_raises_without_api_key(self):
         """Test that get_groq_client raises when API key is missing."""

--- a/tests/unit/test_parse_router.py
+++ b/tests/unit/test_parse_router.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -86,6 +87,25 @@ class TestParseEndpoint:
 
         assert response.status_code == 400
         assert "Message cannot be empty" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_parse_rate_limit_returns_429(self, app, mock_groq_client):
+        """Test that Groq rate limit returns 429."""
+        from groq import RateLimitError
+
+        resp = httpx.Response(429, request=httpx.Request("POST", "https://api.groq.com/test"))
+        with patch("routers.parse.parse_request", new_callable=AsyncMock) as mock_parse:
+            mock_parse.side_effect = RateLimitError(
+                message="Rate limit exceeded", response=resp, body=None
+            )
+
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post("/api/v1/parse", json={"message": "some message"})
+
+            assert response.status_code == 429
+            assert "Rate limit exceeded" in response.json()["detail"]
 
     @pytest.mark.asyncio
     async def test_parse_value_error_returns_500(self, app, mock_groq_client):


### PR DESCRIPTION
## Summary

- Catch `RateLimitError` in both `/request` and `/parse` endpoints and return HTTP 429 instead of 500
- Bump `max_retries` from 2 (default) to 4 so the SDK's built-in exponential backoff has more chances to resolve transient rate limits before raising

The free-tier Groq API has a 6000 TPM limit. When integration tests run many parse calls in sequence, the rate limit is hit and the SDK exhausts retries. Previously this surfaced as a misleading 500; now callers get a proper 429.

## Test plan

- [x] 183 unit tests pass (2 new: rate limit tests for both routers)
- [x] Ruff format + lint clean
- [x] Mypy type check clean
- [ ] CI passes