### PR TITLE
Generate Pydantic models from wxyc-shared/api.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ Request-O-Matic is a FastAPI service for WXYC radio that processes song requests
 4. **Slack**: Post enriched results with artwork to Slack
 
 ### Key Files
-- `models.py` - Shared DTOs: `LibraryItem`, `ReleaseMetadata`
+- `models.py` - Re-exports `LibraryItem` (alias for `LibraryCatalogItem`) and `ReleaseMetadata` (alias for `DiscogsMatchResult`) from `generated.api_models`, plus the `preview_url(metadata)` helper for streaming-priority logic.
+- `generated/api_models.py` - Pydantic v2 models generated from `wxyc-shared/api.yaml`. Do not edit by hand; regenerate via `bash scripts/generate_api_models.sh`. The script prefers a sibling `wxyc-shared/` directory and falls back to downloading `api.yaml` from GitHub.
+- `tests/factories.py` - `make_library_item` / `make_release_metadata` factories that supply the now-required `call_number`, `library_url`, and `release_url` fields with sensible defaults.
 - `routers/request.py` - Request handling: parse, delegate to lookup service, post to Slack
 - `routers/health.py` - Health check endpoints: `GET /health` (shallow liveness probe, no external calls) and `GET /health/ready` (deep readiness check: groq, lookup, slack services). Railway's `healthcheckPath` uses `/health` so the container becomes routable immediately on boot.
 - `services/parser.py` - Groq AI message parsing

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1,0 +1,1256 @@
+# Generated from wxyc-shared/api.yaml -- do not edit manually.
+# Regenerate with: bash scripts/generate_api_models.sh
+
+from __future__ import annotations
+
+from datetime import date as date_aliased
+from datetime import time as time_aliased
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import AwareDatetime, BaseModel, Field, RootModel, confloat, conint
+
+
+class ApiErrorResponse(BaseModel):
+    message: str
+    code: str | None = None
+    details: dict[str, Any] | None = None
+
+
+class PaginationParams(BaseModel):
+    page: conint(ge=1) | None = None
+    limit: conint(ge=1, le=100) | None = None
+
+
+class PaginationInfo(BaseModel):
+    page: int
+    limit: int
+    total: int | None = None
+    hasMore: bool | None = None
+
+
+class DateTimeEntry(BaseModel):
+    day: str = Field(..., description='Day string (e.g., "Monday")')
+    time: str = Field(..., description='Time string (e.g., "14:00")')
+
+
+class Genre(StrEnum):
+    Blues = "Blues"
+    Rock = "Rock"
+    Electronic = "Electronic"
+    Hiphop = "Hiphop"
+    Jazz = "Jazz"
+    Classical = "Classical"
+    Reggae = "Reggae"
+    Soundtracks = "Soundtracks"
+    OCS = "OCS"
+    Unknown = "Unknown"
+
+
+class Format(StrEnum):
+    Vinyl = "Vinyl"
+    CD = "CD"
+    Unknown = "Unknown"
+
+
+class RotationBin(StrEnum):
+    H = "H"
+    M = "M"
+    L = "L"
+    S = "S"
+
+
+class DayOfWeek(StrEnum):
+    Sunday = "Sunday"
+    Monday = "Monday"
+    Tuesday = "Tuesday"
+    Wednesday = "Wednesday"
+    Thursday = "Thursday"
+    Friday = "Friday"
+    Saturday = "Saturday"
+
+
+class FlowsheetEntryBase(BaseModel):
+    id: int
+    play_order: int
+    show_id: int
+
+
+class FlowsheetEntryResponse(FlowsheetEntryBase):
+    album_id: int | None = None
+    track_title: str | None = None
+    album_title: str | None = None
+    artist_name: str | None = None
+    record_label: str | None = None
+    label_id: int | None = None
+    rotation_id: int | None = None
+    rotation_bin: RotationBin | None = None
+    request_flag: bool
+    segue: bool | None = None
+    message: str | None = None
+    artwork_url: str | None = None
+    discogs_url: str | None = None
+    release_year: int | None = None
+    spotify_url: str | None = None
+    apple_music_url: str | None = None
+    youtube_music_url: str | None = None
+    bandcamp_url: str | None = None
+    soundcloud_url: str | None = None
+    artist_bio: str | None = None
+    artist_wikipedia_url: str | None = None
+
+
+class FlowsheetSongEntry(FlowsheetEntryBase):
+    track_title: str
+    artist_name: str
+    album_title: str
+    record_label: str
+    label_id: int | None = None
+    request_flag: bool
+    segue: bool | None = None
+    album_id: int | None = None
+    rotation_id: int | None = None
+    rotation_bin: RotationBin | None = None
+
+
+class FlowsheetShowBlockEntry(FlowsheetEntryBase, DateTimeEntry):
+    dj_name: str
+    isStart: bool
+
+
+class FlowsheetMessageEntry(FlowsheetEntryBase):
+    message: str
+
+
+class FlowsheetBreakpointEntry(FlowsheetMessageEntry, DateTimeEntry):
+    pass
+
+
+class FlowsheetCreateSongFromCatalog(BaseModel):
+    album_id: int
+    track_title: str
+    rotation_id: int | None = None
+    request_flag: bool
+    segue: bool | None = None
+    record_label: str | None = None
+
+
+class FlowsheetCreateSongFreeform(BaseModel):
+    artist_name: str
+    album_title: str
+    track_title: str
+    request_flag: bool
+    segue: bool | None = None
+    record_label: str | None = None
+    label_id: int | None = None
+
+
+class EntryType(StrEnum):
+    talkset = "talkset"
+    breakpoint = "breakpoint"
+    message = "message"
+
+
+class FlowsheetCreateMessage(BaseModel):
+    message: str
+    entry_type: EntryType | None = Field(
+        None,
+        description="Explicit entry type. If omitted, the backend infers from message content.",
+    )
+
+
+class FlowsheetUpdateRequest(BaseModel):
+    track_title: str | None = None
+    artist_name: str | None = None
+    album_title: str | None = None
+    record_label: str | None = None
+    label_id: int | None = None
+    request_flag: bool | None = None
+    segue: bool | None = None
+
+
+class FlowsheetQueryParams(BaseModel):
+    page: int | None = None
+    limit: int | None = None
+    start_id: int | None = None
+    end_id: int | None = None
+    shows_limit: int | None = None
+
+
+class Sort(StrEnum):
+    date = "date"
+    artist = "artist"
+    song = "song"
+    dj = "dj"
+
+
+class Order(StrEnum):
+    asc = "asc"
+    desc = "desc"
+
+
+class PlaylistSearchParams(BaseModel):
+    q: str | None = Field(None, description='Search query (supports AND, OR, NOT, "", *)')
+    page: conint(ge=0) | None = 0
+    limit: conint(ge=1, le=100) | None = 50
+    sort: Sort | None = "date"
+    order: Order | None = "desc"
+
+
+class PlaylistSearchResult(BaseModel):
+    id: int
+    play_date: AwareDatetime
+    artist_name: str
+    track_title: str
+    album_title: str
+    record_label: str
+    dj_name: str
+    show_id: int
+
+
+class PlaylistSearchResponse(BaseModel):
+    results: list[PlaylistSearchResult]
+    total: int
+    page: int
+    totalPages: int
+
+
+class FlowsheetEntryType(StrEnum):
+    track = "track"
+    show_start = "show_start"
+    show_end = "show_end"
+    dj_join = "dj_join"
+    dj_leave = "dj_leave"
+    talkset = "talkset"
+    breakpoint = "breakpoint"
+    message = "message"
+
+
+class FlowsheetV2Base(BaseModel):
+    id: int
+    show_id: int
+    play_order: int
+    add_time: AwareDatetime
+
+
+class EntryType1(StrEnum):
+    track = "track"
+
+
+class FlowsheetV2TrackEntry(FlowsheetV2Base):
+    entry_type: Literal["track"]
+    album_id: int | None = None
+    rotation_id: int | None = None
+    artist_name: str | None = None
+    album_title: str | None = None
+    track_title: str | None = None
+    record_label: str | None = None
+    request_flag: bool
+    segue: bool | None = None
+    rotation_bin: RotationBin | None = None
+    artwork_url: str | None = None
+    discogs_url: str | None = None
+    release_year: int | None = None
+    spotify_url: str | None = None
+    apple_music_url: str | None = None
+    youtube_music_url: str | None = None
+    bandcamp_url: str | None = None
+    soundcloud_url: str | None = None
+    artist_bio: str | None = None
+    artist_wikipedia_url: str | None = None
+    on_streaming: bool | None = Field(
+        None,
+        description="Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.",
+    )
+
+
+class EntryType2(StrEnum):
+    show_start = "show_start"
+
+
+class FlowsheetV2ShowStartEntry(FlowsheetV2Base):
+    entry_type: Literal["show_start"]
+    dj_name: str
+    timestamp: AwareDatetime
+
+
+class EntryType3(StrEnum):
+    show_end = "show_end"
+
+
+class FlowsheetV2ShowEndEntry(FlowsheetV2Base):
+    entry_type: Literal["show_end"]
+    dj_name: str
+    timestamp: AwareDatetime
+
+
+class EntryType4(StrEnum):
+    dj_join = "dj_join"
+
+
+class FlowsheetV2DJJoinEntry(FlowsheetV2Base):
+    entry_type: Literal["dj_join"]
+    dj_name: str
+
+
+class EntryType5(StrEnum):
+    dj_leave = "dj_leave"
+
+
+class FlowsheetV2DJLeaveEntry(FlowsheetV2Base):
+    entry_type: Literal["dj_leave"]
+    dj_name: str
+
+
+class EntryType6(StrEnum):
+    talkset = "talkset"
+
+
+class FlowsheetV2TalksetEntry(FlowsheetV2Base):
+    entry_type: Literal["talkset"]
+    message: str
+
+
+class EntryType7(StrEnum):
+    breakpoint = "breakpoint"
+
+
+class FlowsheetV2BreakpointEntry(FlowsheetV2Base):
+    entry_type: Literal["breakpoint"]
+    message: str | None = None
+
+
+class EntryType8(StrEnum):
+    message = "message"
+
+
+class FlowsheetV2MessageEntry(FlowsheetV2Base):
+    entry_type: Literal["message"]
+    message: str
+
+
+class Entries(
+    RootModel[
+        FlowsheetV2TrackEntry
+        | FlowsheetV2ShowStartEntry
+        | FlowsheetV2ShowEndEntry
+        | FlowsheetV2DJJoinEntry
+        | FlowsheetV2DJLeaveEntry
+        | FlowsheetV2TalksetEntry
+        | FlowsheetV2BreakpointEntry
+        | FlowsheetV2MessageEntry
+    ]
+):
+    root: (
+        FlowsheetV2TrackEntry
+        | FlowsheetV2ShowStartEntry
+        | FlowsheetV2ShowEndEntry
+        | FlowsheetV2DJJoinEntry
+        | FlowsheetV2DJLeaveEntry
+        | FlowsheetV2TalksetEntry
+        | FlowsheetV2BreakpointEntry
+        | FlowsheetV2MessageEntry
+    ) = Field(..., discriminator="entry_type")
+
+
+class FlowsheetV2PaginatedResponse(BaseModel):
+    entries: list[Entries]
+    page: int
+    limit: int
+    total: int = Field(..., description="Total number of entries")
+    totalPages: int = Field(..., description="Total number of pages")
+
+
+class OnAirDJ(BaseModel):
+    id: int
+    dj_name: str
+
+
+class OnAirStatusResponse(BaseModel):
+    djs: list[OnAirDJ]
+    onAir: str = Field(..., description='Status indicator - "on" or "off"')
+
+
+class Show(BaseModel):
+    id: int | None = None
+    primary_dj_id: int | None = None
+    specialty_id: int | None = None
+    show_name: str | None = None
+    start_time: AwareDatetime | None = None
+    end_time: AwareDatetime | None = None
+
+
+class ShowDJ(BaseModel):
+    show_id: int | None = None
+    dj_id: int | None = None
+    active: bool | None = None
+
+
+class ShowPlaylist(BaseModel):
+    show_name: str | None = None
+    specialty_show: str | None = None
+    start_time: AwareDatetime | None = None
+    end_time: AwareDatetime | None = None
+    show_djs: list[OnAirDJ] | None = None
+    entries: list[FlowsheetEntryResponse] | None = None
+
+
+class Dj(BaseModel):
+    dj_id: int | None = None
+    dj_name: str | None = None
+
+
+class ShowPeek(BaseModel):
+    show: int | None = None
+    show_name: str | None = None
+    date: AwareDatetime | None = None
+    djs: list[Dj] | None = None
+    specialty_show: str | None = None
+    preview: list[FlowsheetEntryResponse] | None = None
+
+
+class Artist(BaseModel):
+    id: int
+    artist_name: str
+    code_letters: str
+    code_artist_number: int
+    genre_id: int
+
+
+class ArtistWithGenre(Artist):
+    genre_name: Genre
+
+
+class Album(BaseModel):
+    id: int
+    artist_id: int
+    album_title: str
+    code_number: int
+    genre_id: int
+    format_id: int
+    label: str | None = None
+    label_id: int | None = None
+    add_date: AwareDatetime | None = None
+    disc_quantity: int | None = None
+    alternate_artist_name: str | None = None
+    album_artist: str | None = Field(
+        None,
+        description='Credited album artist for compilations (e.g., "Kruder & Dorfmeister" on a DJ-Kicks release filed under Various Artists).',
+    )
+
+
+class AlbumSearchResult(BaseModel):
+    id: int
+    add_date: AwareDatetime
+    album_title: str
+    artist_name: str
+    code_letters: str
+    code_number: int
+    code_artist_number: int
+    format_name: str
+    genre_name: str
+    label: str
+    label_id: int | None = None
+    album_dist: float | None = None
+    artist_dist: float | None = None
+    rotation_bin: RotationBin | None = None
+    rotation_id: int | None = None
+    plays: int | None = None
+    on_streaming: bool | None = Field(
+        None,
+        description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
+    )
+    album_artist: str | None = Field(None, description="Credited album artist for compilations.")
+    date_lost: AwareDatetime | None = Field(
+        None,
+        description="When the release was marked missing from the physical library. Null if in library.",
+    )
+    date_found: AwareDatetime | None = Field(
+        None, description="When a previously missing release was found. Null if never lost."
+    )
+    artwork_url: str | None = Field(
+        None,
+        description="Album cover artwork URL from Discogs. Null if artwork has not been fetched yet or is unavailable.",
+    )
+
+
+class AddAlbumRequest(BaseModel):
+    album_title: str
+    artist_name: str | None = None
+    artist_id: int | None = None
+    label: str
+    label_id: int | None = None
+    genre_id: int
+    format_id: int
+    disc_quantity: int | None = None
+    alternate_artist_name: str | None = None
+    album_artist: str | None = None
+
+
+class Label(BaseModel):
+    id: int
+    label_name: str
+    parent_label_id: int | None = None
+
+
+class CreateLabelRequest(BaseModel):
+    label_name: str
+    parent_label_id: int | None = None
+
+
+class AddArtistRequest(BaseModel):
+    artist_name: str
+    code_letters: str
+    genre_id: int
+
+
+class OrderDirection(StrEnum):
+    asc = "asc"
+    desc = "desc"
+
+
+class CatalogSearchParams(BaseModel):
+    artist_name: str | None = None
+    album_title: str | None = None
+    n: int | None = Field(None, description="Maximum number of results")
+    orderBy: str | None = None
+    orderDirection: OrderDirection | None = None
+
+
+class FormatEntry(BaseModel):
+    id: int
+    format_name: str
+
+
+class GenreEntry(BaseModel):
+    id: int
+    genre_name: Genre
+    code_letters: str
+
+
+class Rotation(BaseModel):
+    id: int | None = None
+    rotation_bin: RotationBin | None = None
+    add_date: date_aliased | None = None
+    kill_date: date_aliased | None = None
+
+
+class AlbumInfoResponse(Album):
+    artist_name: str
+    code_letters: str
+    format_name: str
+    genre_name: Genre
+    rotation: Rotation | None = None
+
+
+class Source(StrEnum):
+    discogs = "discogs"
+    flowsheet = "flowsheet"
+    bin = "bin"
+
+
+class TrackSearchResult(BaseModel):
+    track_id: int | None = None
+    title: str
+    position: str | None = None
+    duration: str | None = None
+    album_id: int | None = None
+    album_title: str
+    artist_name: str
+    label: str | None = None
+    rotation_id: int | None = None
+    rotation_bin: RotationBin | None = None
+    source: Source
+
+
+class TrackSearchParams(BaseModel):
+    song: str
+    artist: str | None = None
+    album: str | None = None
+    label: str | None = None
+    n: int | None = None
+
+
+class RotationEntry(BaseModel):
+    id: int
+    album_id: int
+    rotation_bin: RotationBin
+    add_date: date_aliased
+    kill_date: date_aliased | None = None
+
+
+class AddRotationRequest(BaseModel):
+    album_id: int
+    rotation_bin: RotationBin
+
+
+class KillRotationRequest(BaseModel):
+    rotation_id: int
+    kill_date: date_aliased | None = Field(None, description="ISO date string, defaults to today")
+
+
+class RotationWithAlbum(RotationEntry):
+    album_title: str
+    artist_name: str
+    code_letters: str
+    code_number: int
+
+
+class Rotation1(BaseModel):
+    id: int | None = None
+    code_letters: str | None = None
+    code_artist_number: int | None = None
+    code_number: int | None = None
+    artist_name: str | None = None
+    album_title: str | None = None
+    record_label: str | None = None
+    genre_name: str | None = None
+    format_name: str | None = None
+    rotation_id: int | None = None
+    add_date: date_aliased | None = None
+    play_freq: RotationBin | None = None
+    kill_date: date_aliased | None = None
+    plays: int | None = None
+
+
+class DJ(BaseModel):
+    id: int
+    dj_name: str
+    real_name: str | None = None
+    email: str | None = None
+
+
+class NewDJ(BaseModel):
+    cognito_user_name: str | None = None
+    real_name: str | None = None
+    dj_name: str | None = None
+
+
+class BinEntry(BaseModel):
+    id: int
+    dj_id: int
+    album_id: int
+    added_at: AwareDatetime
+    album_title: str
+    artist_name: str
+    code_letters: str
+    code_number: int
+
+
+class AddToBinRequest(BaseModel):
+    album_id: int
+
+
+class Playlist(BaseModel):
+    id: int
+    dj_id: int
+    name: str
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+
+
+class PlaylistEntry(BaseModel):
+    id: int
+    playlist_id: int
+    album_id: int
+    track_title: str | None = None
+    position: int
+    album_title: str
+    artist_name: str
+
+
+class PlaylistWithEntries(Playlist):
+    entries: list[PlaylistEntry]
+
+
+class DJBinResponse(BaseModel):
+    dj_id: int
+    entries: list[BinEntry]
+
+
+class DJPlaylistsResponse(BaseModel):
+    dj_id: int
+    playlists: list[Playlist]
+
+
+class BinLibraryDetails(BaseModel):
+    album_id: int | None = None
+    album_title: str | None = None
+    artist_name: str | None = None
+    label: str | None = None
+    code_letters: str | None = None
+    code_artist_number: int | None = None
+    code_number: int | None = None
+    format_name: str | None = None
+    genre_name: str | None = None
+
+
+class ScheduleShift(BaseModel):
+    id: int
+    dj_id: int
+    dj_name: str
+    day: DayOfWeek
+    start_time: str = Field(..., description="Time in HH:MM format")
+    end_time: str = Field(..., description="Time in HH:MM format")
+    show_name: str | None = None
+    specialty_id: int | None = None
+
+
+class AddScheduleShiftRequest(BaseModel):
+    dj_id: int
+    day: DayOfWeek
+    start_time: str
+    end_time: str
+    show_name: str | None = None
+    specialty_id: int | None = None
+
+
+class SpecialtyShow(BaseModel):
+    id: int
+    specialty_name: str
+    description: str | None = None
+
+
+class Schedule(BaseModel):
+    id: int | None = Field(None, description="Primary key")
+    day: conint(ge=0, le=6) | None = Field(
+        None, description="Day of the week 0 = Monday, 6 = Sunday"
+    )
+    start_time: time_aliased | None = Field(None, description="Show start time")
+    show_duration: conint(ge=1) | None = Field(None, description="Duration in minutes")
+    specialty_id: int | None = Field(
+        None, description="Reference to specialty show, null for regular shows"
+    )
+    assigned_dj_id: int | None = Field(None, description="Reference to primary DJ")
+    assigned_dj_id2: int | None = Field(None, description="Reference to secondary DJ")
+
+
+class RequestStatus(StrEnum):
+    pending = "pending"
+    played = "played"
+    rejected = "rejected"
+
+
+class SongRequest(BaseModel):
+    id: int
+    device_id: str
+    message: str
+    created_at: AwareDatetime
+    status: RequestStatus
+
+
+class SubmitRequestPayload(BaseModel):
+    message: str
+
+
+class ParsedSongRequest(BaseModel):
+    artist: str | None = None
+    song: str | None = None
+    album: str | None = None
+    confidence: confloat(ge=0.0, le=1.0)
+    interpretation: str | None = None
+
+
+class MatchType(StrEnum):
+    exact = "exact"
+    fuzzy = "fuzzy"
+    partial = "partial"
+
+
+class LibraryMatch(BaseModel):
+    album: AlbumSearchResult
+    confidence: confloat(ge=0.0, le=1.0)
+    matchType: MatchType
+    reasoning: str | None = None
+
+
+class EnhancedRequest(SongRequest):
+    parsed: ParsedSongRequest | None = None
+    matches: list[LibraryMatch] | None = None
+    artwork_url: str | None = None
+    discogs_url: str | None = None
+
+
+class DeviceRegistration(BaseModel):
+    device_id: str
+    registered_at: AwareDatetime
+
+
+class DeviceToken(BaseModel):
+    token: str
+    expires_at: AwareDatetime
+
+
+class RateLimitInfo(BaseModel):
+    remaining: int
+    reset_at: AwareDatetime
+    limit: int
+
+
+class RequestSubmissionResponse(BaseModel):
+    success: bool
+    request_id: int | None = None
+    rate_limit: RateLimitInfo | None = None
+    message: str | None = None
+
+
+class MetadataSource(StrEnum):
+    discogs = "discogs"
+    spotify = "spotify"
+    apple_music = "apple_music"
+    cache = "cache"
+    none = "none"
+
+
+class AlbumMetadata(BaseModel):
+    album_id: int
+    artwork_url: str | None = None
+    discogs_url: str | None = None
+    discogs_id: int | None = None
+    release_year: int | None = None
+    spotify_url: str | None = None
+    apple_music_url: str | None = None
+    youtube_music_url: str | None = None
+    bandcamp_url: str | None = None
+    soundcloud_url: str | None = None
+    last_fetched: AwareDatetime | None = None
+
+
+class ArtistMetadata(BaseModel):
+    artist_id: int
+    bio: str | None = None
+    wikipedia_url: str | None = None
+    discogs_url: str | None = None
+    discogs_id: int | None = None
+    image_url: str | None = None
+    last_fetched: AwareDatetime | None = None
+
+
+class MetadataFetchRequest(BaseModel):
+    album_id: int | None = None
+    artist_id: int | None = None
+    force_refresh: bool | None = None
+
+
+class MetadataFetchResponse(BaseModel):
+    album: AlbumMetadata | None = None
+    artist: ArtistMetadata | None = None
+    source: MetadataSource
+    cached: bool
+
+
+class Type(StrEnum):
+    release = "release"
+    master = "master"
+    artist = "artist"
+
+
+class DiscogsSearchResult(BaseModel):
+    id: int
+    title: str
+    year: int | None = None
+    thumb: str | None = None
+    cover_image: str | None = None
+    resource_url: str
+    type: Type
+
+
+class DiscogsArtistRef(BaseModel):
+    name: str
+    id: int
+
+
+class DiscogsLabelRef(BaseModel):
+    name: str
+    id: int
+
+
+class DiscogsTrack(BaseModel):
+    position: str
+    title: str
+    duration: str | None = None
+
+
+class DiscogsImage(BaseModel):
+    type: str
+    uri: str
+    width: int
+    height: int
+
+
+class DiscogsRelease(BaseModel):
+    id: int
+    title: str
+    year: int | None = None
+    artists: list[DiscogsArtistRef]
+    labels: list[DiscogsLabelRef]
+    genres: list[str]
+    styles: list[str]
+    tracklist: list[DiscogsTrack]
+    images: list[DiscogsImage] | None = None
+
+
+class StreamingLinks(BaseModel):
+    spotify_url: str | None = Field(None, description="Spotify album URL")
+    apple_music_url: str | None = Field(None, description="Apple Music album URL")
+    youtube_music_url: str | None = Field(None, description="YouTube Music search URL")
+    bandcamp_url: str | None = Field(None, description="Bandcamp album URL")
+    soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
+
+
+class LookupRequest(BaseModel):
+    artist: str | None = Field(None, description="Parsed artist name")
+    song: str | None = Field(None, description="Parsed song/track title")
+    album: str | None = Field(None, description="Parsed album name")
+    raw_message: str | None = Field(
+        None,
+        description="Original request message (used for ambiguous format detection). Optional when structured fields (artist, album, song) are provided.\n",
+    )
+
+
+class LibraryCatalogItem(BaseModel):
+    id: int = Field(..., description="Unique identifier in the library database")
+    title: str | None = Field(None, description="Album/release title")
+    artist: str | None = Field(None, description="Artist name")
+    call_letters: str | None = Field(None, description="Library call letter code")
+    artist_call_number: int | None = Field(
+        None, description="Numeric part of artist classification"
+    )
+    release_call_number: int | None = Field(
+        None, description="Numeric part of release classification"
+    )
+    genre: str | None = Field(None, description="Genre classification")
+    format: str | None = Field(None, description="Physical format (vinyl, CD, etc.)")
+    label: str | None = Field(None, description="Record label name from the library catalog")
+    call_number: str = Field(
+        ...,
+        description='Full call number for shelf lookup, e.g. "Rock CD ABC 123/45". Computed from genre, format, call_letters, artist_call_number, and release_call_number.\n',
+    )
+    library_url: str = Field(..., description="URL to view this release in the WXYC library")
+    on_streaming: bool | None = Field(
+        None,
+        description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
+    )
+
+
+class DiscogsMatchResult(BaseModel):
+    album: str | None = Field(None, description="Release title")
+    artist: str | None = Field(None, description="Release artist")
+    release_id: int = Field(..., description="Discogs release ID")
+    release_url: str = Field(..., description="URL to the release on Discogs")
+    artwork_url: str | None = Field(None, description="Artwork image URL")
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(0, description="Match confidence score")
+    release_year: int | None = Field(None, description="Release year from Discogs")
+    artist_bio: str | None = Field(None, description="Artist biography from Discogs profile")
+    wikipedia_url: str | None = Field(None, description="Wikipedia URL for the artist")
+    spotify_url: str | None = Field(None, description="Spotify album URL")
+    apple_music_url: str | None = Field(None, description="Apple Music album URL")
+    youtube_music_url: str | None = Field(None, description="YouTube Music search URL")
+    bandcamp_url: str | None = Field(None, description="Bandcamp album URL")
+    soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
+
+
+class LookupResultItem(BaseModel):
+    library_item: LibraryCatalogItem
+    artwork: DiscogsMatchResult | None = None
+
+
+class SearchType(StrEnum):
+    direct = "direct"
+    fallback = "fallback"
+    alternative = "alternative"
+    compilation = "compilation"
+    song_as_artist = "song_as_artist"
+    none = "none"
+
+
+class LookupResponse(BaseModel):
+    results: list[LookupResultItem] | None = Field([], validate_default=True)
+    search_type: SearchType | None = Field(
+        "none",
+        description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",
+    )
+    song_not_found: bool | None = Field(
+        False,
+        description="True if search fell back to artist-only (track not confirmed on results)",
+    )
+    found_on_compilation: bool | None = Field(
+        False, description="True if the track was found on a compilation album"
+    )
+    context_message: str | None = Field(
+        None, description="Human-readable context string for display"
+    )
+    corrected_artist: str | None = Field(
+        None, description="Fuzzy-corrected artist name if different from the original"
+    )
+    cache_stats: dict[str, Any] | None = Field(
+        None, description="Cache hit/miss statistics from the lookup"
+    )
+
+
+class DiscogsSearchRequest(BaseModel):
+    artist: str | None = None
+    album: str | None = None
+    track: str | None = None
+    label: str | None = None
+    format: str | None = None
+
+
+class DiscogsEnrichedSearchResult(BaseModel):
+    album: str | None = None
+    artist: str | None = None
+    release_id: int
+    release_url: str
+    artwork_url: str | None = None
+    confidence: float | None = 0
+    release_year: int | None = None
+    artist_bio: str | None = None
+    wikipedia_url: str | None = None
+    spotify_url: str | None = None
+    apple_music_url: str | None = None
+    youtube_music_url: str | None = None
+    bandcamp_url: str | None = None
+    soundcloud_url: str | None = None
+
+
+class DiscogsSearchResponse(BaseModel):
+    results: list[DiscogsEnrichedSearchResult] | None = Field([], validate_default=True)
+    total: int | None = 0
+    cached: bool | None = False
+
+
+class DiscogsTrackItem(BaseModel):
+    position: str
+    title: str
+    duration: str | None = None
+    artists: list[str] | None = []
+
+
+class DiscogsArtistCredit(BaseModel):
+    artist_id: int | None = None
+    name: str
+    join: str | None = Field("", description='Join phrase (e.g. " & ", ", ")')
+    role: str | None = Field(
+        None, description='Role for extra artists (e.g. "Producer", "Mixed By")'
+    )
+
+
+class DiscogsLabelCredit(BaseModel):
+    label_id: int | None = None
+    name: str
+    catno: str | None = Field(None, description="Catalog number")
+
+
+class DiscogsReleaseVideo(BaseModel):
+    src: str
+    title: str | None = None
+    duration: int | None = Field(None, description="Duration in seconds")
+    embed: bool | None = True
+
+
+class DiscogsReleaseMetadata(BaseModel):
+    release_id: int
+    title: str
+    artist: str
+    year: int | None = None
+    label: str | None = None
+    artist_id: int | None = None
+    label_id: int | None = None
+    genres: list[str] | None = []
+    styles: list[str] | None = []
+    tracklist: list[DiscogsTrackItem] | None = Field([], validate_default=True)
+    artwork_url: str | None = None
+    release_url: str
+    cached: bool | None = False
+    artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)
+    extra_artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)
+    labels: list[DiscogsLabelCredit] | None = Field([], validate_default=True)
+    released: str | None = Field(None, description="Release date as ISO string")
+    videos: list[DiscogsReleaseVideo] | None = Field([], validate_default=True)
+
+
+class Type1(StrEnum):
+    plainText = "plainText"
+    artistLink = "artistLink"
+    labelName = "labelName"
+    releaseLink = "releaseLink"
+    masterLink = "masterLink"
+    bold = "bold"
+    italic = "italic"
+    underline = "underline"
+    urlLink = "urlLink"
+
+
+class DiscogsResolvedToken(BaseModel):
+    type: Type1
+    text: str | None = Field(None, description="Content for plainText tokens")
+    name: str | None = Field(None, description="Name for artistLink and labelName tokens")
+    display_name: str | None = Field(
+        None, description="Display name for artistLink tokens (disambiguation suffix stripped)"
+    )
+    title: str | None = Field(None, description="Title for releaseLink and masterLink tokens")
+    url: str | None = Field(None, description="URL for artistLink, releaseLink, masterLink tokens")
+    href: str | None = Field(None, description="URL for urlLink tokens (null if URL is invalid)")
+    content: str | None = Field(
+        None, description="Content for bold, italic, underline, and urlLink tokens"
+    )
+
+
+class Alias(BaseModel):
+    id: int
+    name: str
+
+
+class Member(BaseModel):
+    id: int
+    name: str
+    active: bool | None = True
+
+
+class DiscogsArtistDetails(BaseModel):
+    artist_id: int
+    name: str
+    profile: str | None = None
+    profile_tokens: list[DiscogsResolvedToken] | None = Field(
+        None, description="Pre-parsed structured tokens from the Discogs profile markup"
+    )
+    image_url: str | None = None
+    name_variations: list[str] | None = []
+    aliases: list[Alias] | None = Field([], validate_default=True)
+    members: list[Member] | None = Field([], validate_default=True)
+    urls: list[str] | None = []
+    cached: bool | None = False
+
+
+class DiscogsReleaseInfo(BaseModel):
+    album: str
+    artist: str
+    release_id: int
+    release_url: str
+    is_compilation: bool | None = False
+
+
+class DiscogsTrackReleasesResponse(BaseModel):
+    track: str | None = None
+    artist: str | None = None
+    releases: list[DiscogsReleaseInfo] | None = Field([], validate_default=True)
+    total: int | None = 0
+    cached: bool | None = False
+
+
+class LibrarySearchItem(BaseModel):
+    id: int
+    title: str | None = None
+    artist: str | None = None
+    call_letters: str | None = None
+    artist_call_number: int | None = None
+    release_call_number: int | None = None
+    genre: str | None = None
+    format: str | None = None
+    alternate_artist_name: str | None = None
+    label: str | None = None
+    on_streaming: bool | None = None
+    call_number: str | None = Field(None, description='Computed call number (e.g. "Rock CD S 1/1")')
+    library_url: str | None = Field(None, description="URL to the release on wxyc.info")
+
+
+class LibrarySearchResponse(BaseModel):
+    results: list[LibrarySearchItem] | None = None
+    total: int | None = None
+    query: str | None = None
+
+
+class StreamingCheckRequest(BaseModel):
+    artist: str = Field(..., description="Artist name to search for")
+    title: str = Field(..., description="Album title to search for")
+
+
+class StreamingSourceMatch(BaseModel):
+    url: str = Field(..., description="URL to the matched album on the service")
+    confidence: float = Field(..., description="Match confidence score (0-100)")
+
+
+class StreamingCheckSources(BaseModel):
+    spotify: StreamingSourceMatch | None = None
+    deezer: StreamingSourceMatch | None = None
+    apple_music: StreamingSourceMatch | None = None
+    bandcamp: StreamingSourceMatch | None = None
+
+
+class StreamingCheckResponse(BaseModel):
+    on_streaming: bool = Field(
+        ...,
+        description="True if found on any service, false if absent on all, null if inconclusive.",
+    )
+    sources: StreamingCheckSources
+
+
+class AppConfig(BaseModel):
+    posthogApiKey: str = Field(..., description="PostHog analytics write key (public by design)")
+    posthogHost: str = Field(..., description="PostHog ingestion host")
+    requestOMaticUrl: str = Field(..., description="Request-o-matic service URL for song requests")
+    apiBaseUrl: str = Field(..., description="Backend API base URL")
+
+
+class TrackListItem(BaseModel):
+    position: str = Field(..., description='Track position (e.g. "1", "A1")')
+    title: str = Field(..., description="Track title")
+    duration: str | None = Field(None, description='Track duration (e.g. "5:23")')
+
+
+class AlbumMetadataResponse(BaseModel):
+    discogsReleaseId: int | None = Field(None, description="Discogs release ID")
+    discogsUrl: str | None = Field(None, description="Discogs release page URL")
+    releaseYear: int | None = Field(None, description="Release year from Discogs")
+    artworkUrl: str | None = Field(None, description="Album artwork image URL")
+    genres: list[str] | None = Field(None, description="Discogs genre classifications")
+    styles: list[str] | None = Field(
+        None, description="Discogs style classifications (more specific than genres)"
+    )
+    label: str | None = Field(None, description="Primary record label name")
+    discogsArtistId: int | None = Field(
+        None, description="Discogs artist ID, for linking to artist metadata"
+    )
+    fullReleaseDate: str | None = Field(
+        None, description='Full release date when available (e.g. "2024-03-15")'
+    )
+    tracklist: list[TrackListItem] | None = Field(None, description="Release tracklist")
+    spotifyUrl: str | None = Field(None, description="Spotify URL for the album or track")
+    appleMusicUrl: str | None = Field(None, description="Apple Music URL for the album or track")
+    youtubeMusicUrl: str | None = Field(None, description="YouTube Music search URL")
+    bandcampUrl: str | None = Field(None, description="Bandcamp search URL")
+    soundcloudUrl: str | None = Field(None, description="SoundCloud search URL")
+
+
+class ArtistMetadataResponse(BaseModel):
+    discogsArtistId: int | None = Field(None, description="Discogs artist ID")
+    bio: str | None = Field(None, description="Artist biography from Discogs")
+    wikipediaUrl: str | None = Field(None, description="Wikipedia URL for the artist")
+    imageUrl: str | None = Field(None, description="Artist image URL from Discogs")
+
+
+class ArtworkSearchResponse(BaseModel):
+    artworkUrl: str | None = Field(None, description="Best-match artwork image URL")
+    source: str | None = Field(
+        None, description='Provider that supplied the artwork (e.g. "discogs")'
+    )
+    confidence: float | None = Field(None, description="Confidence score of the match (0-1)")
+
+
+class Type2(StrEnum):
+    artist = "artist"
+    release = "release"
+    master = "master"
+
+
+class EntityResolveResponse(BaseModel):
+    name: str = Field(..., description="Entity name")
+    type: Type2 = Field(..., description="Discogs entity type")
+    id: int = Field(..., description="Discogs entity ID")
+
+
+class SpotifyTrackResponse(BaseModel):
+    title: str = Field(..., description="Track title")
+    artist: str = Field(..., description="Primary artist name")
+    album: str = Field(..., description="Album name")
+    artworkUrl: str | None = Field(None, description="Album artwork URL from Spotify")

--- a/models.py
+++ b/models.py
@@ -1,77 +1,29 @@
-"""Shared Pydantic models for library and release metadata.
+"""Shared DTOs for library and release metadata.
 
-These DTOs are used to deserialize responses from the library-metadata-lookup
-service. The full library and Discogs modules (search, caching, rate limiting)
-now live exclusively in that service.
+Types are generated from ``wxyc-shared/api.yaml`` (see ``scripts/generate_api_models.sh``)
+and re-exported here under their historical request-o-matic names. The free
+``preview_url`` helper supplies the streaming-priority logic that used to live
+on ``ReleaseMetadata`` as a ``@property`` — the shared schema is data-only.
 """
 
-from pydantic import BaseModel, computed_field
+from generated.api_models import DiscogsMatchResult, LibraryCatalogItem
+
+LibraryItem = LibraryCatalogItem
+ReleaseMetadata = DiscogsMatchResult
 
 
-class LibraryItem(BaseModel):
-    """A single item from the library catalog."""
-
-    id: int
-    title: str | None = None
-    artist: str | None = None
-    call_letters: str | None = None
-    artist_call_number: int | None = None
-    release_call_number: int | None = None
-    genre: str | None = None
-    format: str | None = None
-    alternate_artist_name: str | None = None
-
-    @property
-    def call_number(self) -> str:
-        """Full call number for shelf lookup: <Genre> <Format> <Letters> <ArtistNum>/<ReleaseNum>"""
-        parts = []
-        if self.genre:
-            parts.append(self.genre)
-        if self.format:
-            parts.append(self.format)
-        if self.call_letters:
-            parts.append(self.call_letters)
-        if self.artist_call_number is not None:
-            parts.append(str(self.artist_call_number))
-        if self.release_call_number is not None:
-            parts[-1] = f"{parts[-1]}/{self.release_call_number}"
-        return " ".join(parts)
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def library_url(self) -> str:
-        """URL to view this release in the WXYC library."""
-        return f"http://www.wxyc.info/wxycdb/libraryRelease?id={self.id}"
+def preview_url(metadata: DiscogsMatchResult) -> str | None:
+    """First available streaming URL, prioritizing Bandcamp."""
+    for url in (
+        metadata.bandcamp_url,
+        metadata.spotify_url,
+        metadata.apple_music_url,
+        metadata.youtube_music_url,
+        metadata.soundcloud_url,
+    ):
+        if url:
+            return url
+    return None
 
 
-class ReleaseMetadata(BaseModel):
-    """Metadata for a release: Discogs info, artwork, and streaming links.
-
-    Deserialized from the ``artwork`` field of library-metadata-lookup responses.
-    """
-
-    album: str | None = None
-    artist: str | None = None
-    release_id: int
-    artwork_url: str | None = None
-    confidence: float = 0.0
-    release_url: str = ""
-    spotify_url: str | None = None
-    apple_music_url: str | None = None
-    youtube_music_url: str | None = None
-    bandcamp_url: str | None = None
-    soundcloud_url: str | None = None
-
-    @property
-    def preview_url(self) -> str | None:
-        """First available streaming URL in priority order."""
-        for url in (
-            self.bandcamp_url,
-            self.spotify_url,
-            self.apple_music_url,
-            self.youtube_music_url,
-            self.soundcloud_url,
-        ):
-            if url:
-                return url
-        return None
+__all__ = ["LibraryItem", "ReleaseMetadata", "preview_url"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "datamodel-code-generator[http]>=0.26.0",
 ]
 
 [build-system]
@@ -39,7 +40,7 @@ requires = ["setuptools>=65.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["scripts*", "core*", "config*", "routers*", "services*"]
+include = ["scripts*", "core*", "config*", "routers*", "services*", "generated*"]
 
 [tool.black]
 line-length = 100
@@ -82,6 +83,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # imported but unused
+"generated/*" = ["N815"]  # mixed-case fields from openapi spec
 
 [tool.mypy]
 python_version = "3.12"
@@ -96,6 +98,10 @@ warn_unused_ignores = true
 warn_no_return = true
 plugins = ["pydantic.mypy"]
 exclude = []
+
+[[tool.mypy.overrides]]
+module = "generated.*"
+ignore_errors = true
 
 [tool.pydantic-mypy]
 init_forbid_extra = true

--- a/routers/request.py
+++ b/routers/request.py
@@ -220,12 +220,14 @@ async def handle_request(
         if lookup_response.corrected_artist:
             parsed.artist = lookup_response.corrected_artist
 
-        # Extract results for Slack posting
-        library_results = [item.library_item for item in lookup_response.results]
-        items_with_artwork = [(item.library_item, item.artwork) for item in lookup_response.results]
-        search_type = lookup_response.search_type
-        song_not_found = lookup_response.song_not_found
-        found_on_compilation = lookup_response.found_on_compilation
+        # Extract results for Slack posting. Generated LookupResponse fields
+        # are nullable in the schema; coerce to non-null defaults for callers.
+        results = lookup_response.results or []
+        library_results = [item.library_item for item in results]
+        items_with_artwork = [(item.library_item, item.artwork) for item in results]
+        search_type = str(lookup_response.search_type or "none")
+        song_not_found = bool(lookup_response.song_not_found)
+        found_on_compilation = bool(lookup_response.found_on_compilation)
         context = lookup_response.context_message
 
         # Prefer the lookup service's cache stats over local counters,

--- a/scripts/generate_api_models.sh
+++ b/scripts/generate_api_models.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Generate Python Pydantic v2 models from the wxyc-shared api.yaml OpenAPI spec.
+#
+# Looks for api.yaml in a sibling wxyc-shared directory first, then falls back
+# to downloading from GitHub. The generated file is committed to git so that
+# normal CI jobs don't need the codegen toolchain.
+#
+# Usage:
+#   bash scripts/generate_api_models.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT="$PROJECT_DIR/generated/api_models.py"
+
+# Resolve api.yaml source. Inside a git worktree, the sibling layout is rooted
+# at the main repo, not at the worktree path — use --git-common-dir to find it.
+SIBLING_PATH="$PROJECT_DIR/../wxyc-shared/api.yaml"
+if MAIN_GIT_DIR="$(cd "$PROJECT_DIR" && git rev-parse --git-common-dir 2>/dev/null)"; then
+    if [[ "$MAIN_GIT_DIR" != /* ]]; then
+        MAIN_GIT_DIR="$PROJECT_DIR/$MAIN_GIT_DIR"
+    fi
+    MAIN_REPO_ROOT="$(cd "$MAIN_GIT_DIR/.." && pwd)"
+    SIBLING_PATH="$MAIN_REPO_ROOT/../wxyc-shared/api.yaml"
+fi
+
+if [[ -f "$SIBLING_PATH" ]]; then
+    API_YAML="$SIBLING_PATH"
+    echo "Using local api.yaml: $API_YAML"
+else
+    API_YAML="$(mktemp)"
+    trap 'rm -f "$API_YAML"' EXIT
+    echo "Downloading api.yaml from GitHub..."
+    curl -sSfL "https://raw.githubusercontent.com/WXYC/wxyc-shared/main/api.yaml" -o "$API_YAML"
+    echo "Downloaded to $API_YAML"
+fi
+
+# Ensure output directory exists
+mkdir -p "$(dirname "$OUTPUT")"
+
+# Locate tools: prefer venv, fall back to PATH
+CODEGEN="${PROJECT_DIR}/.venv/bin/datamodel-codegen"
+if [[ ! -x "$CODEGEN" ]]; then
+    CODEGEN="$(command -v datamodel-codegen 2>/dev/null || true)"
+    if [[ -z "$CODEGEN" ]]; then
+        echo "Error: datamodel-codegen not found. Install with: uv pip install 'datamodel-code-generator[http]'" >&2
+        exit 1
+    fi
+fi
+
+RUFF="${PROJECT_DIR}/.venv/bin/ruff"
+if [[ ! -x "$RUFF" ]]; then
+    RUFF="$(command -v ruff 2>/dev/null || echo ruff)"
+fi
+
+# Generate models
+echo "Generating Python models..."
+"$CODEGEN" \
+    --input "$API_YAML" \
+    --input-file-type openapi \
+    --output "$OUTPUT" \
+    --output-model-type pydantic_v2.BaseModel \
+    --target-python-version 3.12 \
+    --use-standard-collections \
+    --use-union-operator \
+    --disable-timestamp \
+    --custom-file-header "# Generated from wxyc-shared/api.yaml -- do not edit manually.
+# Regenerate with: bash scripts/generate_api_models.sh"
+
+# Format with ruff
+echo "Formatting generated code..."
+"$RUFF" format "$OUTPUT" 2>/dev/null || true
+"$RUFF" check --fix "$OUTPUT" 2>/dev/null || true
+
+echo "Generated: $OUTPUT"

--- a/services/lookup_client.py
+++ b/services/lookup_client.py
@@ -4,39 +4,12 @@ import asyncio
 import logging
 
 import httpx
-from pydantic import BaseModel
 
-from models import LibraryItem, ReleaseMetadata
+from generated.api_models import LookupRequest, LookupResponse, LookupResultItem
+
+__all__ = ["LookupRequest", "LookupResponse", "LookupResultItem", "LookupServiceClient"]
 
 logger = logging.getLogger(__name__)
-
-
-class LookupRequest(BaseModel):
-    """Request body for the lookup service."""
-
-    artist: str | None = None
-    song: str | None = None
-    album: str | None = None
-    raw_message: str
-
-
-class LookupResultItem(BaseModel):
-    """A single lookup result: library item paired with optional artwork."""
-
-    library_item: LibraryItem
-    artwork: ReleaseMetadata | None = None
-
-
-class LookupResponse(BaseModel):
-    """Response from the lookup service."""
-
-    results: list[LookupResultItem] = []
-    search_type: str = "none"
-    song_not_found: bool = False
-    found_on_compilation: bool = False
-    context_message: str | None = None
-    corrected_artist: str | None = None
-    cache_stats: dict | None = None
 
 
 class LookupServiceClient:

--- a/services/slack.py
+++ b/services/slack.py
@@ -4,7 +4,7 @@ from typing import Any
 import httpx
 
 from config.settings import get_settings
-from models import LibraryItem, ReleaseMetadata
+from models import LibraryItem, ReleaseMetadata, preview_url
 
 logger = logging.getLogger(__name__)
 
@@ -66,8 +66,8 @@ def build_slack_blocks(
         ]
         if artwork and artwork.release_url:
             links = f"<{artwork.release_url}|Discogs> | <{item.library_url}|WXYC>"
-            if artwork.preview_url:
-                links += f" | <{artwork.preview_url}|Preview>"
+            if (preview := preview_url(artwork)) is not None:
+                links += f" | <{preview}|Preview>"
             text_lines.append(links)
 
         block: dict = {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(text_lines)}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ import httpx
 import pytest
 
 from config.settings import Settings
-from models import LibraryItem
 from services.parser import MessageType
+from tests.factories import make_library_item
 
 # =============================================================================
 # Environment Configuration
@@ -224,41 +224,20 @@ def mock_slack_service():
 @pytest.fixture
 def sample_library_item():
     """Create a sample library item for testing."""
-    return LibraryItem(
-        id=1,
-        artist="Stereolab",
-        title="Aluminum Tunes",
-        call_letters="S",
-        artist_call_number=1,
-        release_call_number=1,
-        genre="Rock",
-        format="CD",
-    )
+    return make_library_item()
 
 
 @pytest.fixture
 def sample_library_items():
     """Create multiple sample library items for testing."""
     return [
-        LibraryItem(
-            id=1,
-            artist="Stereolab",
-            title="Aluminum Tunes",
-            call_letters="S",
-            artist_call_number=1,
-            release_call_number=1,
-            genre="Rock",
-            format="CD",
-        ),
-        LibraryItem(
+        make_library_item(),
+        make_library_item(
             id=2,
             artist="Cat Power",
             title="Moon Pix",
             call_letters="C",
-            artist_call_number=1,
             release_call_number=2,
-            genre="Rock",
-            format="CD",
         ),
     ]
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,74 @@
+"""Test factories for shared API contract models.
+
+The generated ``LibraryCatalogItem`` and ``DiscogsMatchResult`` make several
+fields required that used to be optional or computed on the local types.
+These factories supply sensible WXYC-style defaults so unit tests don't have
+to spell out the full constructor each time.
+"""
+
+from generated.api_models import DiscogsMatchResult, LibraryCatalogItem
+
+
+def _compute_call_number(
+    genre: str | None,
+    format_: str | None,
+    call_letters: str | None,
+    artist_call_number: int | None,
+    release_call_number: int | None,
+) -> str:
+    """Mirror LML's server-side call-number computation."""
+    parts: list[str] = []
+    if genre:
+        parts.append(genre)
+    if format_:
+        parts.append(format_)
+    if call_letters:
+        parts.append(call_letters)
+    if artist_call_number is not None:
+        parts.append(str(artist_call_number))
+    if release_call_number is not None and parts:
+        parts[-1] = f"{parts[-1]}/{release_call_number}"
+    return " ".join(parts)
+
+
+def make_library_item(
+    *,
+    id: int = 1,
+    artist: str | None = "Stereolab",
+    title: str | None = "Aluminum Tunes",
+    call_letters: str | None = "S",
+    artist_call_number: int | None = 1,
+    release_call_number: int | None = 1,
+    genre: str | None = "Rock",
+    format: str | None = "CD",
+    **kwargs,
+) -> LibraryCatalogItem:
+    """Build a LibraryCatalogItem with computed call_number/library_url."""
+    kwargs.setdefault(
+        "call_number",
+        _compute_call_number(genre, format, call_letters, artist_call_number, release_call_number),
+    )
+    kwargs.setdefault("library_url", f"http://www.wxyc.info/wxycdb/libraryRelease?id={id}")
+    return LibraryCatalogItem(
+        id=id,
+        artist=artist,
+        title=title,
+        call_letters=call_letters,
+        artist_call_number=artist_call_number,
+        release_call_number=release_call_number,
+        genre=genre,
+        format=format,
+        **kwargs,
+    )
+
+
+def make_release_metadata(
+    *,
+    release_id: int = 123,
+    artist: str | None = "Stereolab",
+    album: str | None = "Aluminum Tunes",
+    **kwargs,
+) -> DiscogsMatchResult:
+    """Build a DiscogsMatchResult with a default release_url."""
+    kwargs.setdefault("release_url", f"https://www.discogs.com/release/{release_id}")
+    return DiscogsMatchResult(release_id=release_id, artist=artist, album=album, **kwargs)

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -13,10 +13,11 @@ from core.dependencies import (
     get_posthog_client,
     get_slack_service,
 )
-from models import LibraryItem, ReleaseMetadata
+from generated.api_models import SearchType
 from routers.request import router
 from services.lookup_client import LookupResponse, LookupResultItem, LookupServiceClient
 from tests.conftest import make_parsed_request
+from tests.factories import make_library_item, make_release_metadata
 
 # -- Fixtures -----------------------------------------------------------------
 
@@ -33,26 +34,22 @@ def sample_lookup_response():
     return LookupResponse(
         results=[
             LookupResultItem(
-                library_item=LibraryItem(
+                library_item=make_library_item(
                     id=42,
-                    title="The Game",
-                    artist="Queen",
-                    call_letters="Q",
-                    artist_call_number=1,
+                    title="Aluminum Tunes",
+                    artist="Stereolab",
                     release_call_number=2,
-                    genre="Rock",
-                    format="CD",
                 ),
-                artwork=ReleaseMetadata(
-                    album="The Game",
-                    artist="Queen",
+                artwork=make_release_metadata(
                     release_id=123,
+                    album="Aluminum Tunes",
+                    artist="Stereolab",
                     artwork_url="https://img.discogs.com/test.jpg",
                     confidence=0.95,
                 ),
             )
         ],
-        search_type="direct",
+        search_type=SearchType.direct,
         song_not_found=False,
         found_on_compilation=False,
         context_message=None,
@@ -79,9 +76,9 @@ def app(mock_lookup_client):
 
 
 SAMPLE_PARSED = make_parsed_request(
-    song="Crazy Little Thing Called Love",
-    artist="Queen",
-    raw_message="play crazy little thing called love by queen",
+    song="la paradoja",
+    artist="Juana Molina",
+    raw_message="play la paradoja by juana molina",
 )
 
 
@@ -115,7 +112,7 @@ class TestDelegationBranch:
         assert data["search_type"] == "direct"
         assert len(data["library_results"]) == 1
         assert data["library_results"][0]["id"] == 42
-        assert data["library_results"][0]["artist"] == "Queen"
+        assert data["library_results"][0]["artist"] == "Stereolab"
         assert data["artwork"]["artwork_url"] == "https://img.discogs.com/test.jpg"
         assert data["song_not_found"] is False
         assert data["found_on_compilation"] is False
@@ -125,7 +122,7 @@ class TestDelegationBranch:
         """All LookupResponse metadata fields map to UnifiedResponse correctly."""
         mock_lookup_client.lookup.return_value = LookupResponse(
             results=[],
-            search_type="compilation",
+            search_type=SearchType.compilation,
             song_not_found=True,
             found_on_compilation=True,
             context_message='Found "Abele Dance" by Manu Dibango on:',
@@ -283,7 +280,7 @@ class TestDelegationBranch:
         """Empty results from lookup service are handled correctly."""
         mock_lookup_client.lookup.return_value = LookupResponse(
             results=[],
-            search_type="none",
+            search_type=SearchType.none,
             song_not_found=True,
             found_on_compilation=False,
         )
@@ -311,39 +308,30 @@ class TestDelegationBranch:
         mock_lookup_client.lookup.return_value = LookupResponse(
             results=[
                 LookupResultItem(
-                    library_item=LibraryItem(
+                    library_item=make_library_item(
                         id=1,
-                        title="A Night at the Opera",
-                        artist="Queen",
-                        call_letters="Q",
-                        artist_call_number=1,
-                        release_call_number=1,
-                        genre="Rock",
-                        format="CD",
+                        title="Aluminum Tunes",
+                        artist="Stereolab",
                     ),
-                    artwork=ReleaseMetadata(
-                        album="A Night at the Opera",
-                        artist="Queen",
+                    artwork=make_release_metadata(
                         release_id=100,
-                        artwork_url="https://img.discogs.com/opera.jpg",
+                        album="Aluminum Tunes",
+                        artist="Stereolab",
+                        artwork_url="https://img.discogs.com/aluminum.jpg",
                         confidence=0.9,
                     ),
                 ),
                 LookupResultItem(
-                    library_item=LibraryItem(
+                    library_item=make_library_item(
                         id=2,
-                        title="The Game",
-                        artist="Queen",
-                        call_letters="Q",
-                        artist_call_number=1,
+                        title="Dots and Loops",
+                        artist="Stereolab",
                         release_call_number=2,
-                        genre="Rock",
-                        format="CD",
                     ),
                     artwork=None,
                 ),
             ],
-            search_type="artist_search",
+            search_type=SearchType.fallback,
         )
 
         with patch(
@@ -362,7 +350,7 @@ class TestDelegationBranch:
         assert data["library_results"][0]["id"] == 1
         assert data["library_results"][1]["id"] == 2
         # First artwork (non-null) is used as the top-level artwork
-        assert data["artwork"]["artwork_url"] == "https://img.discogs.com/opera.jpg"
+        assert data["artwork"]["artwork_url"] == "https://img.discogs.com/aluminum.jpg"
 
     @pytest.mark.asyncio
     async def test_lookup_request_built_from_parsed(
@@ -372,10 +360,10 @@ class TestDelegationBranch:
         mock_lookup_client.lookup.return_value = sample_lookup_response
 
         parsed = make_parsed_request(
-            song="Bohemian Rhapsody",
-            album="A Night at the Opera",
-            artist="Queen",
-            raw_message="play bohemian rhapsody by queen",
+            song="la paradoja",
+            album="DOGA",
+            artist="Juana Molina",
+            raw_message="play la paradoja by juana molina",
         )
 
         with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
@@ -385,16 +373,16 @@ class TestDelegationBranch:
                 await client.post(
                     "/api/v1/request",
                     json={
-                        "message": "play bohemian rhapsody by queen",
+                        "message": "play la paradoja by juana molina",
                         "skip_slack": True,
                     },
                 )
 
         lookup_req = mock_lookup_client.lookup.call_args[0][0]
-        assert lookup_req.artist == "Queen"
-        assert lookup_req.song == "Bohemian Rhapsody"
-        assert lookup_req.album == "A Night at the Opera"
-        assert lookup_req.raw_message == "play bohemian rhapsody by queen"
+        assert lookup_req.artist == "Juana Molina"
+        assert lookup_req.song == "la paradoja"
+        assert lookup_req.album == "DOGA"
+        assert lookup_req.raw_message == "play la paradoja by juana molina"
 
 
 class TestDelegatedCacheStats:

--- a/tests/unit/test_factories.py
+++ b/tests/unit/test_factories.py
@@ -1,0 +1,105 @@
+"""Unit tests for the test factories.
+
+The factories build ``LibraryCatalogItem`` and ``DiscogsMatchResult`` with
+fields the shared schema makes required (``call_number``, ``library_url``,
+``release_url``). The call-number computation has several conditional branches
+that no integration tests exercise individually, so they're pinned here.
+"""
+
+import pytest
+
+from tests.factories import _compute_call_number, make_library_item, make_release_metadata
+
+
+class TestComputeCallNumber:
+    """Branch coverage for ``_compute_call_number``."""
+
+    def test_all_fields_present(self):
+        assert _compute_call_number("Rock", "CD", "S", 1, 1) == "Rock CD S 1/1"
+
+    def test_no_release_call_number(self):
+        assert _compute_call_number("Rock", "CD", "S", 1, None) == "Rock CD S 1"
+
+    def test_no_genre(self):
+        assert _compute_call_number(None, "CD", "S", 1, 1) == "CD S 1/1"
+
+    def test_no_format(self):
+        assert _compute_call_number("Rock", None, "S", 1, 1) == "Rock S 1/1"
+
+    def test_no_call_letters(self):
+        assert _compute_call_number("Rock", "CD", None, 1, 1) == "Rock CD 1/1"
+
+    def test_only_artist_call_number(self):
+        assert _compute_call_number(None, None, None, 1, None) == "1"
+
+    def test_all_none_returns_empty_string(self):
+        assert _compute_call_number(None, None, None, None, None) == ""
+
+    def test_release_call_number_appends_to_last_part_when_artist_call_number_missing(self):
+        """When artist_call_number is None but release_call_number is set, the suffix
+        attaches to whatever the last part was — typically call_letters."""
+        assert _compute_call_number("Rock", "CD", "S", None, 2) == "Rock CD S/2"
+
+    def test_release_call_number_alone_is_dropped_when_no_other_parts(self):
+        """release_call_number requires a non-empty parts list; otherwise it has nothing
+        to suffix and is silently dropped."""
+        assert _compute_call_number(None, None, None, None, 99) == ""
+
+
+class TestMakeLibraryItem:
+    """Defaults and override behavior for the LibraryCatalogItem factory."""
+
+    def test_defaults_match_wxyc_canonical_artist(self):
+        item = make_library_item()
+        assert item.id == 1
+        assert item.artist == "Stereolab"
+        assert item.title == "Aluminum Tunes"
+        assert item.genre == "Rock"
+        assert item.format == "CD"
+
+    def test_default_call_number_is_computed_from_other_fields(self):
+        assert make_library_item().call_number == "Rock CD S 1/1"
+
+    def test_default_library_url_includes_id(self):
+        item = make_library_item(id=42)
+        assert item.library_url == "http://www.wxyc.info/wxycdb/libraryRelease?id=42"
+
+    def test_call_number_recomputed_when_components_change(self):
+        item = make_library_item(genre=None, format=None, release_call_number=None)
+        assert item.call_number == "S 1"
+
+    def test_explicit_call_number_overrides_computed(self):
+        item = make_library_item(call_number="Custom 99")
+        assert item.call_number == "Custom 99"
+
+    def test_explicit_library_url_overrides_default(self):
+        item = make_library_item(library_url="https://example.com/custom")
+        assert item.library_url == "https://example.com/custom"
+
+
+class TestMakeReleaseMetadata:
+    """Defaults and overrides for the DiscogsMatchResult factory."""
+
+    def test_default_release_url_uses_release_id(self):
+        metadata = make_release_metadata(release_id=12345)
+        assert metadata.release_url == "https://www.discogs.com/release/12345"
+
+    def test_explicit_release_url_overrides_default(self):
+        metadata = make_release_metadata(release_url="https://example.com/r/1")
+        assert metadata.release_url == "https://example.com/r/1"
+
+    def test_streaming_urls_default_to_none(self):
+        metadata = make_release_metadata()
+        assert metadata.spotify_url is None
+        assert metadata.bandcamp_url is None
+        assert metadata.apple_music_url is None
+        assert metadata.youtube_music_url is None
+        assert metadata.soundcloud_url is None
+
+    @pytest.mark.parametrize(
+        "field",
+        ["spotify_url", "apple_music_url", "youtube_music_url", "bandcamp_url", "soundcloud_url"],
+    )
+    def test_streaming_url_pass_through(self, field: str) -> None:
+        metadata = make_release_metadata(**{field: "https://example.com/s"})  # type: ignore[arg-type]
+        assert getattr(metadata, field) == "https://example.com/s"

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -27,17 +27,19 @@ SAMPLE_RESPONSE = {
         {
             "library_item": {
                 "id": 42,
-                "title": "The Game",
-                "artist": "Queen",
-                "call_letters": "Q",
+                "title": "Aluminum Tunes",
+                "artist": "Stereolab",
+                "call_letters": "S",
                 "artist_call_number": 1,
                 "release_call_number": 2,
                 "genre": "Rock",
                 "format": "CD",
+                "call_number": "Rock CD S 1/2",
+                "library_url": "http://www.wxyc.info/wxycdb/libraryRelease?id=42",
             },
             "artwork": {
-                "album": "The Game",
-                "artist": "Queen",
+                "album": "Aluminum Tunes",
+                "artist": "Stereolab",
                 "release_id": 123,
                 "release_url": "https://discogs.com/release/123",
                 "artwork_url": "https://img.discogs.com/test.jpg",
@@ -65,25 +67,26 @@ class TestLookupServiceClient:
             assert request.url.path == "/api/v1/lookup"
             assert request.method == "POST"
             body = json.loads(request.content)
-            assert body["artist"] == "Queen"
-            assert body["song"] == "Crazy Little Thing Called Love"
-            assert body["raw_message"] == "play crazy little thing called love by queen"
+            assert body["artist"] == "Stereolab"
+            assert body["song"] == "Ping Pong"
+            assert body["raw_message"] == "play ping pong by stereolab"
             assert "album" not in body  # exclude_none=True
             return httpx.Response(200, json=SAMPLE_RESPONSE)
 
         client = _make_client(handler)
         response = await client.lookup(
             LookupRequest(
-                artist="Queen",
-                song="Crazy Little Thing Called Love",
-                raw_message="play crazy little thing called love by queen",
+                artist="Stereolab",
+                song="Ping Pong",
+                raw_message="play ping pong by stereolab",
             )
         )
 
         assert isinstance(response, LookupResponse)
+        assert response.results is not None
         assert len(response.results) == 1
         assert response.results[0].library_item.id == 42
-        assert response.results[0].library_item.artist == "Queen"
+        assert response.results[0].library_item.artist == "Stereolab"
         assert response.results[0].artwork is not None
         assert response.results[0].artwork.artwork_url == "https://img.discogs.com/test.jpg"
         assert response.search_type == "direct"
@@ -96,18 +99,18 @@ class TestLookupServiceClient:
 
         async def handler(request: httpx.Request) -> httpx.Response:
             body = json.loads(request.content)
-            assert body["artist"] == "Queen"
-            assert body["song"] == "Bohemian Rhapsody"
-            assert body["album"] == "A Night at the Opera"
+            assert body["artist"] == "Juana Molina"
+            assert body["song"] == "la paradoja"
+            assert body["album"] == "DOGA"
             return httpx.Response(200, json=SAMPLE_RESPONSE)
 
         client = _make_client(handler)
         await client.lookup(
             LookupRequest(
-                artist="Queen",
-                song="Bohemian Rhapsody",
-                album="A Night at the Opera",
-                raw_message="play bohemian rhapsody",
+                artist="Juana Molina",
+                song="la paradoja",
+                album="DOGA",
+                raw_message="play la paradoja",
             )
         )
 
@@ -160,7 +163,7 @@ class TestLookupServiceClient:
 
         client = _make_client(handler)
         with pytest.raises(httpx.HTTPStatusError) as exc_info:
-            await client.lookup(LookupRequest(artist="Queen", raw_message="play queen"))
+            await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
         assert exc_info.value.response.status_code == 500
 
     @pytest.mark.asyncio
@@ -172,7 +175,7 @@ class TestLookupServiceClient:
 
         client = _make_client(handler)
         with pytest.raises(httpx.HTTPStatusError):
-            await client.lookup(LookupRequest(artist="Queen", raw_message="play queen"))
+            await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
 
     @pytest.mark.asyncio
     async def test_connection_error_propagates(self):
@@ -183,7 +186,7 @@ class TestLookupServiceClient:
 
         client = _make_client(handler)
         with pytest.raises(httpx.ConnectError):
-            await client.lookup(LookupRequest(artist="Queen", raw_message="play queen"))
+            await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
 
     @pytest.mark.asyncio
     async def test_timeout_propagates(self):
@@ -194,7 +197,7 @@ class TestLookupServiceClient:
 
         client = _make_client(handler)
         with pytest.raises(httpx.ReadTimeout):
-            await client.lookup(LookupRequest(artist="Queen", raw_message="play queen"))
+            await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
 
     @pytest.mark.asyncio
     async def test_base_url_trailing_slash_stripped(self):
@@ -220,7 +223,7 @@ class TestLookupServiceClient:
 
         client = _make_client(handler)
         await client.lookup(
-            LookupRequest(artist="Queen", raw_message="play queen"),
+            LookupRequest(artist="Stereolab", raw_message="play stereolab"),
             skip_cache=True,
         )
 
@@ -241,7 +244,7 @@ class TestLookupModels:
 
     def test_lookup_request_exclude_none(self):
         """LookupRequest excludes None fields when dumped."""
-        req = LookupRequest(artist="Queen", raw_message="play queen")
+        req = LookupRequest(artist="Stereolab", raw_message="play stereolab")
         dumped = req.model_dump(exclude_none=True)
         assert "artist" in dumped
         assert "raw_message" in dumped
@@ -251,13 +254,13 @@ class TestLookupModels:
     def test_lookup_request_all_fields(self):
         """LookupRequest includes all fields when set."""
         req = LookupRequest(
-            artist="Queen", song="Bohemian Rhapsody", album="Opera", raw_message="msg"
+            artist="Juana Molina", song="la paradoja", album="DOGA", raw_message="msg"
         )
         dumped = req.model_dump(exclude_none=True)
         assert dumped == {
-            "artist": "Queen",
-            "song": "Bohemian Rhapsody",
-            "album": "Opera",
+            "artist": "Juana Molina",
+            "song": "la paradoja",
+            "album": "DOGA",
             "raw_message": "msg",
         }
 
@@ -274,9 +277,9 @@ class TestLookupModels:
 
     def test_lookup_result_item_without_artwork(self):
         """LookupResultItem works without artwork."""
-        from models import LibraryItem
+        from tests.factories import make_library_item
 
-        item = LookupResultItem(library_item=LibraryItem(id=1, title="Test", artist="Test Artist"))
+        item = LookupResultItem(library_item=make_library_item(id=1))
         assert item.artwork is None
         assert item.library_item.id == 1
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,86 @@
+"""Unit tests for the ``preview_url`` helper.
+
+The helper supplies the streaming-priority logic that used to live on
+``ReleaseMetadata`` as a ``@property``. The shared ``DiscogsMatchResult``
+schema is data-only, so this behavior lives in ``models.py`` now.
+"""
+
+import pytest
+
+from models import preview_url
+from tests.factories import make_release_metadata
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        # Single source set
+        ({"bandcamp_url": "https://b.example/1"}, "https://b.example/1"),
+        ({"spotify_url": "https://s.example/1"}, "https://s.example/1"),
+        ({"apple_music_url": "https://a.example/1"}, "https://a.example/1"),
+        ({"youtube_music_url": "https://y.example/1"}, "https://y.example/1"),
+        ({"soundcloud_url": "https://sc.example/1"}, "https://sc.example/1"),
+    ],
+)
+def test_returns_the_only_set_url(kwargs, expected):
+    metadata = make_release_metadata(**kwargs)
+    assert preview_url(metadata) == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        # Bandcamp wins over everything
+        (
+            {
+                "bandcamp_url": "https://b.example",
+                "spotify_url": "https://s.example",
+                "apple_music_url": "https://a.example",
+                "youtube_music_url": "https://y.example",
+                "soundcloud_url": "https://sc.example",
+            },
+            "https://b.example",
+        ),
+        # Spotify beats Apple/YouTube/SoundCloud when no Bandcamp
+        (
+            {
+                "spotify_url": "https://s.example",
+                "apple_music_url": "https://a.example",
+                "youtube_music_url": "https://y.example",
+                "soundcloud_url": "https://sc.example",
+            },
+            "https://s.example",
+        ),
+        # Apple beats YouTube/SoundCloud when no Bandcamp/Spotify
+        (
+            {
+                "apple_music_url": "https://a.example",
+                "youtube_music_url": "https://y.example",
+                "soundcloud_url": "https://sc.example",
+            },
+            "https://a.example",
+        ),
+        # YouTube beats SoundCloud
+        (
+            {
+                "youtube_music_url": "https://y.example",
+                "soundcloud_url": "https://sc.example",
+            },
+            "https://y.example",
+        ),
+    ],
+)
+def test_priority_order(kwargs, expected):
+    metadata = make_release_metadata(**kwargs)
+    assert preview_url(metadata) == expected
+
+
+def test_returns_none_when_no_streaming_urls_set():
+    metadata = make_release_metadata()
+    assert preview_url(metadata) is None
+
+
+def test_skips_empty_string_urls():
+    """Empty strings are falsy, so the helper should fall through to the next source."""
+    metadata = make_release_metadata(bandcamp_url="", spotify_url="https://s.example")
+    assert preview_url(metadata) == "https://s.example"

--- a/tests/unit/test_slack_service.py
+++ b/tests/unit/test_slack_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 
-from models import LibraryItem, ReleaseMetadata
+from models import ReleaseMetadata
 from services.slack import (
     build_simple_slack_blocks,
     build_slack_blocks,
@@ -13,32 +13,21 @@ from services.slack import (
     post_to_slack,
     shutdown_slack_service,
 )
+from tests.factories import make_library_item, make_release_metadata
 
 
 @pytest.fixture
 def sample_library_item():
     """Create a sample library item."""
-    return LibraryItem(
-        id=1,
-        artist="Queen",
-        title="A Night at the Opera",
-        call_letters="Q",
-        artist_call_number=1,
-        release_call_number=1,
-        genre="Rock",
-        format="CD",
-    )
+    return make_library_item()
 
 
 @pytest.fixture
 def sample_discogs_result():
     """Create a sample Discogs search result."""
-    return ReleaseMetadata(
-        artist="Queen",
-        album="A Night at the Opera",
-        artwork_url="https://example.com/artwork.jpg",
+    return make_release_metadata(
         release_id=12345,
-        release_url="https://www.discogs.com/release/12345",
+        artwork_url="https://example.com/artwork.jpg",
     )
 
 
@@ -58,8 +47,8 @@ class TestBuildSlackBlocks:
 
         # Check item block has artist and title
         item_block = blocks[1]
-        assert "Queen" in item_block["text"]["text"]
-        assert "A Night at the Opera" in item_block["text"]["text"]
+        assert "Stereolab" in item_block["text"]["text"]
+        assert "Aluminum Tunes" in item_block["text"]["text"]
 
         # Check artwork is included
         assert "accessory" in item_block
@@ -91,15 +80,12 @@ class TestBuildSlackBlocks:
 
     def test_builds_blocks_with_multiple_items(self, sample_library_item):
         """Test building blocks with multiple items."""
-        item2 = LibraryItem(
+        item2 = make_library_item(
             id=2,
-            artist="Queen",
-            title="The Game",
-            call_letters="Q",
-            artist_call_number=1,
+            artist="Cat Power",
+            title="Moon Pix",
+            call_letters="C",
             release_call_number=2,
-            genre="Rock",
-            format="CD",
         )
 
         blocks = build_slack_blocks(
@@ -183,13 +169,13 @@ class TestBuildSlackBlocks:
 
     def test_builds_blocks_handles_missing_artist(self):
         """Test building blocks when artist is None."""
-        item = LibraryItem(
+        item = make_library_item(
             id=1,
             artist=None,
             title="Unknown Album",
             call_letters="X",
-            artist_call_number=1,
-            release_call_number=1,
+            genre=None,
+            format=None,
         )
 
         blocks = build_slack_blocks(


### PR DESCRIPTION
## Summary

- Adopts `datamodel-code-generator` to produce `generated/api_models.py` from `wxyc-shared/api.yaml`, mirroring the codegen pattern already in use by library-metadata-lookup. The generated file is committed so normal CI doesn't need the codegen toolchain.
- `models.py` becomes thin: `LibraryItem` aliases `LibraryCatalogItem`, `ReleaseMetadata` aliases `DiscogsMatchResult`, and the streaming-priority logic moves to a free `preview_url(metadata)` helper (the shared schema is data-only).
- `services/lookup_client.py` drops its local `LookupRequest` / `LookupResponse` / `LookupResultItem` and imports the generated versions instead.
- Drops the unused `alternate_artist_name` field — that's an LML-internal detail that was incorrectly mirrored here. `call_number` and `library_url` that used to be `@property` / `@computed_field` are now regular fields populated server-side by LML.
- Adds `tests/factories.py` (`make_library_item`, `make_release_metadata`) since the generated types make `call_number`, `library_url`, and `release_url` required. Test fixtures route through the factories.
- Locks down the `preview_url` priority order and `_compute_call_number` branch behavior with direct unit tests (34 new tests in `test_models.py` + `test_factories.py`).
- Test fixtures previously using mainstream artists (Queen) switch to WXYC-canonical artists (Stereolab, Juana Molina, Cat Power) per repo conventions.
- Codegen script's worktree detection fixed: uses `--git-common-dir` to find the main repo root instead of the broken `--show-toplevel` check.

Closes #79. Part of [Shared Types Consolidation project #16](https://github.com/orgs/WXYC/projects/16), Phase 1. Unblocks #80 (regenerate after StreamingLinks lands) and wxyc-shared#69 (remove deprecated DiscogsSearch* schemas).

## Test plan

- [x] `uv run pytest tests/unit/` — 217 pass (was 183; 34 new tests added)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy .` clean across 55 source files
- [x] `bash scripts/generate_api_models.sh` is idempotent (no diff on re-run)
- [ ] Staging smoke test after merge: confirm `/api/v1/request` still returns artwork + library_url + preview links in Slack output