### PR TITLE
Send LML_API_KEY bearer token to library-metadata-lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 GROQ_API_KEY=gsk_your-api-key-here
 DISCOGS_TOKEN=your-discogs-token-here
 
+# Lookup service (library-metadata-lookup)
+LOOKUP_SERVICE_URL=https://library-metadata-lookup-staging.up.railway.app/api/v1
+# Bearer token sent to LML. Required when LML has LML_REQUIRE_AUTH=true.
+LML_API_KEY=
+
 # Error tracking (optional)
 SENTRY_DSN=
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ Search logic (artist matching, ambiguous format handling, compilation search) li
 Required:
 - `GROQ_API_KEY` - For AI parsing
 - `LOOKUP_SERVICE_URL` - Base URL of library-metadata-lookup service (e.g., `https://library-metadata-lookup-staging.up.railway.app/api/v1`). All search is delegated to this service. If unset, song requests return HTTP 503.
+- `LML_API_KEY` - Bearer token sent on every call to LML. Required when LML has `LML_REQUIRE_AUTH=true` (production). Without it, `/lookup` calls 401 and `/request` returns 502.
 
 Optional:
 - `SLACK_WEBHOOK_URL` - For posting results

--- a/config/settings.py
+++ b/config/settings.py
@@ -40,6 +40,10 @@ class Settings(BaseSettings):
         None,
         description="Base URL of library-metadata-lookup service. When set, delegates search to this service.",
     )
+    lml_api_key: str | None = Field(
+        None,
+        description="Bearer token sent to library-metadata-lookup. Required when LML has LML_REQUIRE_AUTH=true.",
+    )
 
     # Application Metadata
     app_name: str = Field(default="Request-O-Matic", description="Application name")

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -71,7 +71,11 @@ async def get_lookup_client(
     """
     if not settings.lookup_service_url:
         return None
-    return LookupServiceClient(settings.lookup_service_url, http_client)
+    return LookupServiceClient(
+        settings.lookup_service_url,
+        http_client,
+        api_key=settings.lml_api_key,
+    )
 
 
 def get_posthog_client(settings: Settings = Depends(get_settings)) -> Posthog | None:

--- a/routers/health.py
+++ b/routers/health.py
@@ -41,10 +41,14 @@ async def _check_groq(settings: Settings, http_client: httpx.AsyncClient) -> str
 async def _check_lookup_service(settings: Settings, http_client: httpx.AsyncClient) -> str:
     """Check the library-metadata-lookup lookup endpoint with auth.
 
-    POSTs an empty-payload request to ``{lookup_service_url}/lookup`` carrying
-    the Bearer token (when ``LML_API_KEY`` is set). This is the same endpoint
-    /request hits, so a 401/403 from auth misconfig surfaces here instead of
-    silently passing a /health connectivity ping.
+    POSTs a ``raw_message``-only request to ``{lookup_service_url}/lookup``
+    carrying the Bearer token (when ``LML_API_KEY`` is set). This is the same
+    endpoint /request hits, so a 401/403 from auth misconfig surfaces here
+    instead of silently passing a /health connectivity ping.
+
+    LML's ``LookupRequest`` makes every field optional, so ``raw_message``
+    alone validates and the orchestrator returns ``200`` with empty results --
+    cheap enough to run on every readiness check.
     """
     if not settings.lookup_service_url:
         return "unavailable"

--- a/routers/health.py
+++ b/routers/health.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends
@@ -40,13 +39,25 @@ async def _check_groq(settings: Settings, http_client: httpx.AsyncClient) -> str
 
 
 async def _check_lookup_service(settings: Settings, http_client: httpx.AsyncClient) -> str:
-    """Check the library-metadata-lookup service health."""
+    """Check the library-metadata-lookup lookup endpoint with auth.
+
+    POSTs an empty-payload request to ``{lookup_service_url}/lookup`` carrying
+    the Bearer token (when ``LML_API_KEY`` is set). This is the same endpoint
+    /request hits, so a 401/403 from auth misconfig surfaces here instead of
+    silently passing a /health connectivity ping.
+    """
     if not settings.lookup_service_url:
         return "unavailable"
+    headers: dict[str, str] = {}
+    if settings.lml_api_key:
+        headers["Authorization"] = f"Bearer {settings.lml_api_key}"
     try:
-        parsed = urlparse(settings.lookup_service_url)
-        base_url = f"{parsed.scheme}://{parsed.netloc}"
-        resp = await http_client.get(f"{base_url}/health")
+        url = f"{settings.lookup_service_url.rstrip('/')}/lookup"
+        resp = await http_client.post(
+            url,
+            json={"raw_message": "readiness-probe"},
+            headers=headers,
+        )
         return "ok" if resp.status_code == 200 else "error"
     except Exception:
         return "error"

--- a/services/lookup_client.py
+++ b/services/lookup_client.py
@@ -18,6 +18,9 @@ class LookupServiceClient:
     Args:
         base_url: Base URL of the lookup service (e.g. ``http://host:8080/api/v1``)
         http_client: Shared ``httpx.AsyncClient``
+        api_key: Optional ``LML_API_KEY``. When set, every request includes
+            ``Authorization: Bearer <api_key>``. Required when LML has
+            ``LML_REQUIRE_AUTH=true``.
         max_attempts: Total attempts per lookup (1 = no retry, 2 = one retry)
         retry_delay: Seconds to wait between retries
         per_attempt_timeout: Per-attempt timeout in seconds (overrides the client default)
@@ -30,15 +33,20 @@ class LookupServiceClient:
         base_url: str,
         http_client: httpx.AsyncClient,
         *,
+        api_key: str | None = None,
         max_attempts: int = 2,
         retry_delay: float = 1.0,
         per_attempt_timeout: float = 10.0,
     ):
         self.base_url = base_url.rstrip("/")
         self.http_client = http_client
+        self.api_key = api_key
         self.max_attempts = max_attempts
         self.retry_delay = retry_delay
         self.per_attempt_timeout = per_attempt_timeout
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
 
     async def lookup(self, request: LookupRequest, skip_cache: bool = False) -> LookupResponse:
         """Call the lookup service and return parsed response.
@@ -67,6 +75,7 @@ class LookupServiceClient:
                     f"{self.base_url}/lookup",
                     json=request.model_dump(exclude_none=True),
                     params=params,
+                    headers=self._auth_headers(),
                     timeout=self.per_attempt_timeout,
                 )
                 response.raise_for_status()

--- a/tests/unit/test_health_router.py
+++ b/tests/unit/test_health_router.py
@@ -41,7 +41,7 @@ def mock_settings():
 
 @pytest.fixture
 def mock_http_client():
-    """HTTP client that returns 200 for Groq and lookup, 400 for Slack."""
+    """HTTP client that returns 200 for Groq and lookup probes, 400 for Slack."""
     client = AsyncMock()
 
     async def _get(url, **kwargs):
@@ -51,7 +51,8 @@ def mock_http_client():
 
     async def _post(url, **kwargs):
         resp = Mock()
-        resp.status_code = 400  # Slack returns 400 for empty body
+        # Lookup probe expects 200; Slack expects 400 (empty body rejected).
+        resp.status_code = 200 if "lookup" in url else 400
         return resp
 
     client.get = _get
@@ -152,16 +153,16 @@ class TestReadinessCheck:
             lookup_service_url="https://lookup.example.com/api/v1",
         )
 
-        original_get = mock_http_client.get
+        original_post = mock_http_client.post
 
-        async def _get(url, **kwargs):
+        async def _post(url, **kwargs):
             if "lookup" in url:
                 resp = Mock()
                 resp.status_code = 500
                 return resp
-            return await original_get(url, **kwargs)
+            return await original_post(url, **kwargs)
 
-        mock_http_client.get = _get
+        mock_http_client.post = _post
         app = _make_app(settings, mock_http_client)
 
         with patch(
@@ -260,23 +261,29 @@ class TestReadinessCheck:
         assert "features" not in data
 
     @pytest.mark.asyncio
-    async def test_lookup_health_check_uses_base_url(self):
-        """Health check should hit /health at the host root, not under /api/v1."""
+    async def test_lookup_probe_exercises_authenticated_endpoint(self):
+        """Readiness lookup probe POSTs to /api/v1/lookup with a Bearer token.
+
+        This catches LML auth misconfig: a missing or wrong LML_API_KEY produces
+        a 401/403 from the protected route, which the probe must surface.
+        Probing the unprotected /health endpoint would mask the failure.
+        """
         settings = _make_settings(
             lookup_service_url="https://lookup.example.com/api/v1",
+            lml_api_key="probe-token",
         )
         client = AsyncMock()
-        captured_urls = []
+        captured_posts: list[tuple[str, dict]] = []
 
         async def _get(url, **kwargs):
-            captured_urls.append(url)
             resp = Mock()
             resp.status_code = 200
             return resp
 
         async def _post(url, **kwargs):
+            captured_posts.append((url, dict(kwargs.get("headers") or {})))
             resp = Mock()
-            resp.status_code = 400
+            resp.status_code = 200 if "lookup" in url else 400
             return resp
 
         client.get = _get
@@ -290,8 +297,44 @@ class TestReadinessCheck:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 await c.get("/health/ready")
 
-        lookup_urls = [u for u in captured_urls if "lookup" in u]
-        assert lookup_urls == ["https://lookup.example.com/health"]
+        lookup_posts = [(u, h) for (u, h) in captured_posts if "lookup" in u]
+        assert lookup_posts, "expected POST to lookup endpoint"
+        url, headers = lookup_posts[0]
+        assert url == "https://lookup.example.com/api/v1/lookup"
+        assert headers.get("Authorization") == "Bearer probe-token"
+
+    @pytest.mark.asyncio
+    async def test_lookup_probe_marks_error_on_401(self):
+        """When LML returns 401 (auth misconfig), probe reports lookup='error'."""
+        settings = _make_settings(
+            lookup_service_url="https://lookup.example.com/api/v1",
+            lml_api_key="wrong-token",
+        )
+        client = AsyncMock()
+
+        async def _get(url, **kwargs):
+            resp = Mock()
+            resp.status_code = 200
+            return resp
+
+        async def _post(url, **kwargs):
+            resp = Mock()
+            resp.status_code = 401 if "lookup" in url else 400
+            return resp
+
+        client.get = _get
+        client.post = _post
+        app = _make_app(settings, client)
+
+        with patch(
+            "routers.health.get_cached_slack_webhook_url",
+            return_value="https://hooks.slack.com/test",
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                response = await c.get("/health/ready")
+
+        data = response.json()
+        assert data["services"]["lookup"] == "error"
 
     @pytest.mark.asyncio
     async def test_multiple_optional_services_down(self):

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -238,6 +238,43 @@ class TestLookupServiceClient:
         client = _make_client(handler)
         await client.lookup(LookupRequest(artist="Queen", raw_message="play queen"))
 
+    @pytest.mark.asyncio
+    async def test_bearer_header_sent_when_api_key_configured(self):
+        """When api_key is configured, every lookup sends Authorization: Bearer <key>."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.headers.get("authorization") == "Bearer test-token-abc123"
+            return httpx.Response(200, json=SAMPLE_RESPONSE)
+
+        client = _make_client(handler, api_key="test-token-abc123")
+        await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
+
+    @pytest.mark.asyncio
+    async def test_no_authorization_header_when_api_key_unset(self):
+        """When api_key is None, no Authorization header is sent (back-compat)."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert "authorization" not in {k.lower() for k in request.headers.keys()}
+            return httpx.Response(200, json=SAMPLE_RESPONSE)
+
+        client = _make_client(handler)  # api_key omitted -> None
+        await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
+
+    @pytest.mark.asyncio
+    async def test_bearer_header_sent_on_retry(self):
+        """The Authorization header is sent on every attempt, not just the first."""
+        calls = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request.headers.get("authorization"))
+            if len(calls) == 1:
+                raise httpx.ConnectError("Connection refused")
+            return httpx.Response(200, json=SAMPLE_RESPONSE)
+
+        client = _make_client(handler, api_key="retry-token")
+        await client.lookup(LookupRequest(artist="Cat Power", raw_message="play cat power"))
+        assert calls == ["Bearer retry-token", "Bearer retry-token"]
+
 
 class TestLookupModels:
     """Tests for lookup models."""


### PR DESCRIPTION
## Summary

- Add `LML_API_KEY` to `Settings`; `LookupServiceClient` sends `Authorization: Bearer <key>` on every attempt (including retries).
- `_check_lookup_service` POSTs the protected `/lookup` endpoint with the bearer token instead of the unprotected `/health`, so an auth break trips `/health/ready`.
- `LookupRequest` makes every field optional, so the probe payload `{"raw_message": "readiness-probe"}` validates and LML returns 200 with empty results — verified empirically against LML production before merging.
- 14 new/updated unit tests; 221 unit tests pass.

## Why

Every `/request` to production has been failing with 502 since LML flipped `LML_REQUIRE_AUTH=true` on 2026-04-30 — request-o-matic was missed in the auth rollout (the originating commit only listed tubafrenzy and Backend-Service as consumers to update). See #98.

## Test plan

- [x] `pytest tests/unit/` — 221 passing
- [x] `ruff check .` — clean
- [x] Empirical: `curl POST /api/v1/lookup` with `{"raw_message": "..."}` returns 200 against LML prod
- [ ] After merge: `main` deploys to staging; verify `curl POST /request` returns 200 with library results
- [ ] Merge `main` → `prod`; verify production
- [ ] Re-enable `LML_REQUIRE_AUTH=true` on LML prod; verify all consumers (request-o-matic + tubafrenzy + Backend-Service) still work

Closes #98