### PR TITLE
Bump Railway healthcheckTimeout from 30s to 300s

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,6 @@ builder = "dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary

Staging deploys have been failing on healthcheck since 2026-04-25 — the new container's `/health` endpoint doesn't bind within the 30s window. The deploy step exits 1 and Railway keeps the previous image running, so staging has been stuck on the 2026-04-19 build (`925c0e83`) despite four merges to main.

Bumping the window to 300s gives the new container time to import `generated.api_models` and bind. The shallow `/health` endpoint still returns instantly once the route is loaded; the increased timeout only matters during the cold-start window.

## Test plan

- [ ] CI deploy step succeeds on this branch's PR (currently fails for the same reason)
- [ ] After merge: staging container picks up the new image; `curl /health` returns 200
- [ ] After merge: `curl POST /request` returns 200 (this also unblocks PR #99's bearer-auth fix from being live on staging)