### PR TITLE
Dockerfile: COPY generated/ into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY main.py ./
 COPY models.py ./
 COPY config/ ./config/
 COPY core/ ./core/
+COPY generated/ ./generated/
 COPY routers/ ./routers/
 COPY services/ ./services/
 

--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,6 @@ builder = "dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary

Add `COPY generated/ ./generated/` to the Dockerfile.

## Why

The codegen commit on 2026-04-25 ([e8e346e](https://github.com/WXYC/request-o-matic/commit/e8e346e)) introduced `generated/api_models.py` and made `models.py` and `services/lookup_client.py` import from it. The Dockerfile was never updated. Every staging deploy since then has failed identically: the new container crashes on `from generated.api_models import ...` before `/health` can bind, Railway gives up on healthcheck, and the previous image (the 2026-04-19 build, `925c0e83`) keeps serving — including through PR #99's bearer-auth fix and PR #100's healthcheck-window bump.

## Test plan

- [x] Verified `from main import app` works locally with the new code
- [ ] After merge: staging deploy reaches a healthy new container; `curl /health` returns 200 from the new image
- [ ] After merge: PR #99's fix is finally live on staging; `curl POST /request` returns 200