### PR TITLE
Fall back to Slack when Groq or LML are unavailable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,16 @@ Request-O-Matic is a FastAPI service for WXYC radio that processes song requests
 ### Request Flow
 1. **Parse**: Groq AI (`llama-3.1-8b-instant`) extracts artist/song/album from message
 2. **Early return**: Non-request messages (feedback, DJ messages) are posted to Slack without search
-3. **Delegate**: Search is delegated to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) via HTTP (`LOOKUP_SERVICE_URL`). If not configured, returns HTTP 503.
+3. **Delegate**: Search is delegated to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) via HTTP (`LOOKUP_SERVICE_URL`).
 4. **Slack**: Post enriched results with artwork to Slack
+
+### Degraded Modes
+Slack is the only hard dependency. When Groq or LML are unavailable the listener's message still reaches Slack, with a context line explaining what's missing. The response is `200` with a `degraded_mode` field:
+
+- **`parsing_unavailable`** — Groq failed (rate limit, timeout, parse error, etc.). The raw listener message is posted to Slack with a `_Parsing unavailable_` context line. No classification, no search.
+- **`search_unavailable`** — LML is down or `LOOKUP_SERVICE_URL` is unset. The parsed message is posted to Slack with a `_Search unavailable_` context line containing any artist/song/album fields Groq extracted. Empty `library_results`.
+
+If Slack itself fails the endpoint returns `502` — there is no further fallback. PostHog events for degraded requests carry `degraded_mode` and `degraded_reason` (the exception class name) so outages are visible in telemetry.
 
 ### Key Files
 - `models.py` - Re-exports `LibraryItem` (alias for `LibraryCatalogItem`) and `ReleaseMetadata` (alias for `DiscogsMatchResult`) from `generated.api_models`, plus the `preview_url(metadata)` helper for streaming-priority logic.
@@ -160,7 +168,7 @@ Search logic (artist matching, ambiguous format handling, compilation search) li
 
 Required:
 - `GROQ_API_KEY` - For AI parsing
-- `LOOKUP_SERVICE_URL` - Base URL of library-metadata-lookup service (e.g., `https://library-metadata-lookup-staging.up.railway.app/api/v1`). All search is delegated to this service. If unset, song requests return HTTP 503.
+- `LOOKUP_SERVICE_URL` - Base URL of library-metadata-lookup service (e.g., `https://library-metadata-lookup-staging.up.railway.app/api/v1`). All search is delegated to this service. If unset, requests still post to Slack via the `search_unavailable` degraded mode (see "Degraded Modes" above).
 - `LML_API_KEY` - Bearer token sent on every call to LML. Required when LML has `LML_REQUIRE_AUTH=true` (production). Without it, `/lookup` calls 401 and `/request` returns 502.
 
 Optional:

--- a/routers/request.py
+++ b/routers/request.py
@@ -5,13 +5,21 @@ Flow:
 2. Early return for non-requests (feedback, DJ messages, etc.)
 3. Delegate search to library-metadata-lookup service via HTTP
 4. Post enriched results to Slack
+
+Degraded modes:
+- "parsing_unavailable": Groq parsing failed. Slack receives the raw listener
+  message with a "_Parsing unavailable_" note. No classification, no search.
+- "search_unavailable": LML is down or unconfigured. Slack receives the parsed
+  metadata with a "_Search unavailable_" note. No library results.
+
+Slack remains the only hard dependency: if it fails, the endpoint returns 502.
 """
 
 import logging
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from groq import AsyncGroq, RateLimitError
+from groq import AsyncGroq
 from posthog import Posthog
 from pydantic import BaseModel
 
@@ -39,6 +47,17 @@ MESSAGE_TYPE_LABELS = {
     MessageType.OTHER: "Other",
 }
 
+# Degraded-mode identifiers surfaced in the response and telemetry.
+DEGRADED_PARSING = "parsing_unavailable"
+DEGRADED_SEARCH = "search_unavailable"
+
+# httpx exceptions that count as an LML outage rather than a programming error.
+_LML_TRANSIENT_ERRORS = (
+    httpx.HTTPStatusError,
+    httpx.ConnectError,
+    httpx.TimeoutException,
+)
+
 router = APIRouter(tags=["request"])
 
 
@@ -53,7 +72,7 @@ class RequestBody(BaseModel):
 class UnifiedResponse(BaseModel):
     """Combined response from parsing, artwork lookup, and library search."""
 
-    parsed: ParsedRequest
+    parsed: ParsedRequest | None = None
     artwork: ReleaseMetadata | None = None
     library_results: list[LibraryItem] = []
     # Search metadata
@@ -62,6 +81,20 @@ class UnifiedResponse(BaseModel):
     found_on_compilation: bool = False
     context_message: str | None = None
     cache_stats: dict | None = None
+    # When set, indicates a degraded path. See DEGRADED_* constants.
+    degraded_mode: str | None = None
+
+
+def _parsed_context_parts(parsed: ParsedRequest) -> list[str]:
+    """Build a human-readable summary of parsed fields for Slack context lines."""
+    parts: list[str] = []
+    if parsed.artist:
+        parts.append(f"Artist: {parsed.artist}")
+    if parsed.album:
+        parts.append(f"Album: {parsed.album}")
+    if parsed.song:
+        parts.append(f"Song: {parsed.song}")
+    return parts
 
 
 async def post_results_to_slack(
@@ -94,20 +127,41 @@ async def post_results_to_slack(
         blocks = build_simple_slack_blocks(message, f"_{label}_")
     else:
         # Request but no results found
-        context_parts = []
-        if parsed.artist:
-            context_parts.append(f"Artist: {parsed.artist}")
-        if parsed.album:
-            context_parts.append(f"Album: {parsed.album}")
-        if parsed.song:
-            context_parts.append(f"Song: {parsed.song}")
-        ctx = " | ".join(context_parts) if context_parts else None
+        ctx = " | ".join(_parsed_context_parts(parsed)) or None
         blocks = build_simple_slack_blocks(message, f"_No results found_ {ctx or ''}")
 
     try:
         await slack_service.post_blocks(blocks)
     except Exception as e:
         logger.error(f"Failed to post to Slack: {e}")
+        raise HTTPException(status_code=502, detail=f"Failed to post to Slack: {e}") from e
+
+
+async def _post_degraded_to_slack(
+    slack_service: SlackService | None,
+    message: str,
+    parsed: ParsedRequest | None,
+    note: str,
+) -> None:
+    """Post a degraded-mode message to Slack.
+
+    The header is the raw listener message; the context line carries the
+    italicized reason and (when available) any parsed fields the DJ can use.
+    """
+    if not slack_service:
+        logger.info("Slack integration disabled, skipping degraded post")
+        return
+
+    context_segments = [f"_{note}_"]
+    if parsed is not None:
+        context_segments.extend(_parsed_context_parts(parsed))
+    context = " | ".join(context_segments)
+    blocks = build_simple_slack_blocks(message, context)
+
+    try:
+        await slack_service.post_blocks(blocks)
+    except Exception as e:
+        logger.error(f"Failed to post degraded message to Slack: {e}")
         raise HTTPException(status_code=502, detail=f"Failed to post to Slack: {e}") from e
 
 
@@ -136,13 +190,13 @@ async def post_results_to_slack(
     - Parsed metadata (song, artist, album, request type)
     - Library search results with catalog info
     - Album artwork URLs where available
+    - degraded_mode field when an upstream dependency was unavailable
+      ("parsing_unavailable" if Groq failed; "search_unavailable" if LML failed)
     """,
     responses={
-        200: {"description": "Request processed successfully"},
+        200: {"description": "Request processed (possibly via a degraded fallback)"},
         400: {"description": "Invalid request (empty message)"},
-        500: {"description": "Processing error"},
-        502: {"description": "Lookup service or Slack unavailable"},
-        503: {"description": "Search service not configured"},
+        502: {"description": "Slack unavailable"},
     },
 )
 async def handle_request(
@@ -152,14 +206,10 @@ async def handle_request(
     posthog_client: Posthog | None = Depends(get_posthog_client),
     lookup_client: LookupServiceClient | None = Depends(get_lookup_client),
 ):
-    """
-    Unified endpoint: parse a song request, find artwork, search the library, and post to Slack.
+    """Parse a request, search the library, and post to Slack.
 
-    1. Parses the message to extract song/album/artist
-    2. Searches the library catalog
-    3. Fetches artwork for each library result in parallel
-    4. Posts enriched results to Slack
-    5. Returns combined results
+    On Groq or LML failure, fall back to posting the raw / parsed message with
+    a degraded-mode note rather than returning an error.
     """
     if not request.message.strip():
         raise HTTPException(status_code=400, detail="Message cannot be empty")
@@ -167,40 +217,84 @@ async def handle_request(
     # Initialize telemetry
     init_cache_stats()
     telemetry = RequestTelemetry()
-    search_type = "none"
 
+    # ------------------------------------------------------------------
+    # Step 1: Parse the message. Any failure here -> degraded "parsing" path.
+    # ------------------------------------------------------------------
     try:
-        # Step 1: Parse the message
         with telemetry.track_step("parse"):
             telemetry.record_api_call("groq")
             parsed = await parse_request(request.message, groq_client)
             logger.info(
                 f"Parsed request: is_request={parsed.is_request}, type={parsed.message_type}"
             )
-
-        # Early return for non-requests (feedback, DJ messages, etc.)
-        # No point running the search pipeline for messages that aren't song requests.
-        if not parsed.is_request:
-            if not request.skip_slack:
-                await post_results_to_slack(
-                    slack_service, request.message, parsed, [], context=None
-                )
-            return UnifiedResponse(
-                parsed=parsed,
-                cache_stats=get_cache_stats(),
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(
+            "Parsing unavailable (%s: %s); posting raw message to Slack",
+            type(e).__name__,
+            e,
+        )
+        if not request.skip_slack:
+            telemetry.record_api_call("slack")
+            await _post_degraded_to_slack(
+                slack_service,
+                request.message,
+                parsed=None,
+                note="Parsing unavailable",
             )
+        if posthog_client:
+            telemetry.send_to_posthog(
+                posthog_client,
+                {
+                    "results_count": 0,
+                    "search_type": "none",
+                    "had_artist": False,
+                    "had_album": False,
+                    "had_song": False,
+                    "is_request": None,
+                    "message_type": None,
+                    "degraded_mode": DEGRADED_PARSING,
+                    "degraded_reason": type(e).__name__,
+                },
+            )
+        return UnifiedResponse(
+            parsed=None,
+            cache_stats=get_cache_stats(),
+            degraded_mode=DEGRADED_PARSING,
+        )
 
-        if not lookup_client:
-            raise HTTPException(status_code=503, detail="Search service not configured")
+    # ------------------------------------------------------------------
+    # Non-requests skip the search pipeline entirely.
+    # ------------------------------------------------------------------
+    if not parsed.is_request:
+        if not request.skip_slack:
+            await post_results_to_slack(slack_service, request.message, parsed, [], context=None)
+        return UnifiedResponse(
+            parsed=parsed,
+            cache_stats=get_cache_stats(),
+        )
 
-        library_results: list[LibraryItem] = []
-        items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]] = []
-        song_not_found = False
-        found_on_compilation = False
-        context: str | None = None
-        cache_stats_override: dict | None = None
+    # ------------------------------------------------------------------
+    # Step 2: Search via LML. Failures or missing config -> degraded "search" path.
+    # ------------------------------------------------------------------
+    library_results: list[LibraryItem] = []
+    items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]] = []
+    song_not_found = False
+    found_on_compilation = False
+    context: str | None = None
+    cache_stats_override: dict | None = None
+    search_type = "none"
+    lookup_response = None
+    lookup_failure: Exception | None = None
 
-        # Delegate search to library-metadata-lookup service
+    if lookup_client is None:
+        # Treat missing LOOKUP_SERVICE_URL as a permanent LML outage rather than
+        # a hard 503. Operators see the degraded_mode signal in telemetry.
+        logger.warning("LOOKUP_SERVICE_URL not configured; entering search-degraded mode")
+        lookup_failure = RuntimeError("LOOKUP_SERVICE_URL not configured")
+    else:
         with telemetry.track_step("lookup_service"):
             lookup_request = LookupRequest(
                 artist=parsed.artist,
@@ -212,10 +306,15 @@ async def handle_request(
                 lookup_response = await lookup_client.lookup(
                     lookup_request, skip_cache=request.skip_cache
                 )
-            except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException) as e:
-                logger.error(f"Lookup service error: {e}")
-                raise HTTPException(status_code=502, detail="Lookup service unavailable") from e
+            except _LML_TRANSIENT_ERRORS as e:
+                logger.warning(
+                    "Search unavailable (%s: %s); posting parsed message to Slack",
+                    type(e).__name__,
+                    e,
+                )
+                lookup_failure = e
 
+    if lookup_response is not None:
         # Apply corrected artist for Slack display
         if lookup_response.corrected_artist:
             parsed.artist = lookup_response.corrected_artist
@@ -235,55 +334,54 @@ async def handle_request(
         if lookup_response.cache_stats:
             cache_stats_override = lookup_response.cache_stats
 
-        # Step 5: Post to Slack (unless skip_slack is set)
-        with telemetry.track_step("slack_post"):
-            if not request.skip_slack:
-                telemetry.record_api_call("slack")
+    # ------------------------------------------------------------------
+    # Step 3: Post to Slack (search-success path or search-degraded path).
+    # ------------------------------------------------------------------
+    with telemetry.track_step("slack_post"):
+        if not request.skip_slack:
+            telemetry.record_api_call("slack")
+            if lookup_failure is not None:
+                await _post_degraded_to_slack(
+                    slack_service,
+                    request.message,
+                    parsed=parsed,
+                    note="Search unavailable",
+                )
+            else:
                 await post_results_to_slack(
                     slack_service, request.message, parsed, items_with_artwork, context
                 )
 
-        # Extract main artwork from first result
-        artwork = (
-            next((art for _, art in items_with_artwork if art), None)
-            if items_with_artwork
-            else None
-        )
+    # Extract main artwork from first result
+    artwork = (
+        next((art for _, art in items_with_artwork if art), None) if items_with_artwork else None
+    )
 
-        # Send telemetry
-        if posthog_client:
-            telemetry.send_to_posthog(
-                posthog_client,
-                {
-                    "results_count": len(library_results),
-                    "search_type": search_type,
-                    "had_artist": bool(parsed.artist),
-                    "had_album": bool(parsed.album),
-                    "had_song": bool(parsed.song),
-                    "is_request": parsed.is_request,
-                    "message_type": parsed.message_type.value if parsed.message_type else None,
-                },
-            )
+    # Send telemetry
+    degraded_mode = DEGRADED_SEARCH if lookup_failure is not None else None
+    if posthog_client:
+        properties: dict = {
+            "results_count": len(library_results),
+            "search_type": search_type,
+            "had_artist": bool(parsed.artist),
+            "had_album": bool(parsed.album),
+            "had_song": bool(parsed.song),
+            "is_request": parsed.is_request,
+            "message_type": parsed.message_type.value if parsed.message_type else None,
+        }
+        if degraded_mode:
+            properties["degraded_mode"] = degraded_mode
+            properties["degraded_reason"] = type(lookup_failure).__name__
+        telemetry.send_to_posthog(posthog_client, properties)
 
-        return UnifiedResponse(
-            parsed=parsed,
-            artwork=artwork,
-            library_results=library_results,
-            search_type=search_type,
-            song_not_found=song_not_found,
-            found_on_compilation=found_on_compilation,
-            context_message=context,
-            cache_stats=cache_stats_override or get_cache_stats(),
-        )
-
-    except HTTPException:
-        raise
-    except RateLimitError as e:
-        logger.warning(f"Groq rate limit exceeded: {e}")
-        raise HTTPException(status_code=429, detail="Rate limit exceeded, please retry") from e
-    except ValueError as e:
-        logger.error(f"Parsing error: {e}")
-        raise HTTPException(status_code=500, detail=str(e)) from e
-    except Exception as e:
-        logger.error(f"Unexpected error: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    return UnifiedResponse(
+        parsed=parsed,
+        artwork=artwork,
+        library_results=library_results,
+        search_type=search_type,
+        song_not_found=song_not_found,
+        found_on_compilation=found_on_compilation,
+        context_message=context,
+        cache_stats=cache_stats_override or get_cache_stats(),
+        degraded_mode=degraded_mode,
+    )

--- a/routers/request.py
+++ b/routers/request.py
@@ -139,11 +139,6 @@ async def _post_degraded_to_slack(
     parsed: ParsedRequest | None,
     note: str,
 ) -> None:
-    """Post a degraded-mode message to Slack.
-
-    The header is the raw listener message; the context line carries the
-    italicized reason and (when available) any parsed fields the DJ can use.
-    """
     if not slack_service:
         logger.info("Slack integration disabled, skipping degraded post")
         return
@@ -210,13 +205,9 @@ async def handle_request(
     if not request.message.strip():
         raise HTTPException(status_code=400, detail="Message cannot be empty")
 
-    # Initialize telemetry
     init_cache_stats()
     telemetry = RequestTelemetry()
 
-    # ------------------------------------------------------------------
-    # Step 1: Parse the message. Any failure here -> degraded "parsing" path.
-    # ------------------------------------------------------------------
     try:
         with telemetry.track_step("parse"):
             telemetry.record_api_call("groq")
@@ -261,9 +252,6 @@ async def handle_request(
             degraded_mode=DEGRADED_PARSING,
         )
 
-    # ------------------------------------------------------------------
-    # Non-requests skip the search pipeline entirely.
-    # ------------------------------------------------------------------
     if not parsed.is_request:
         if not request.skip_slack:
             await post_results_to_slack(slack_service, request.message, parsed, [], context=None)
@@ -272,9 +260,6 @@ async def handle_request(
             cache_stats=get_cache_stats(),
         )
 
-    # ------------------------------------------------------------------
-    # Step 2: Search via LML. Failures or missing config -> degraded "search" path.
-    # ------------------------------------------------------------------
     library_results: list[LibraryItem] = []
     items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]] = []
     song_not_found = False
@@ -330,9 +315,6 @@ async def handle_request(
         if lookup_response.cache_stats:
             cache_stats_override = lookup_response.cache_stats
 
-    # ------------------------------------------------------------------
-    # Step 3: Post to Slack (search-success path or search-degraded path).
-    # ------------------------------------------------------------------
     with telemetry.track_step("slack_post"):
         if not request.skip_slack:
             telemetry.record_api_call("slack")

--- a/routers/request.py
+++ b/routers/request.py
@@ -47,11 +47,9 @@ MESSAGE_TYPE_LABELS = {
     MessageType.OTHER: "Other",
 }
 
-# Degraded-mode identifiers surfaced in the response and telemetry.
 DEGRADED_PARSING = "parsing_unavailable"
 DEGRADED_SEARCH = "search_unavailable"
 
-# httpx exceptions that count as an LML outage rather than a programming error.
 _LML_TRANSIENT_ERRORS = (
     httpx.HTTPStatusError,
     httpx.ConnectError,
@@ -81,12 +79,10 @@ class UnifiedResponse(BaseModel):
     found_on_compilation: bool = False
     context_message: str | None = None
     cache_stats: dict | None = None
-    # When set, indicates a degraded path. See DEGRADED_* constants.
     degraded_mode: str | None = None
 
 
 def _parsed_context_parts(parsed: ParsedRequest) -> list[str]:
-    """Build a human-readable summary of parsed fields for Slack context lines."""
     parts: list[str] = []
     if parsed.artist:
         parts.append(f"Artist: {parsed.artist}")

--- a/tests/unit/test_degraded_mode.py
+++ b/tests/unit/test_degraded_mode.py
@@ -1,0 +1,472 @@
+"""Unit tests for degraded-mode fallbacks when external dependencies fail.
+
+Goal: when Groq (parsing) or LML (search) is unavailable, the service must
+still post the listener's message to Slack rather than returning an error.
+Slack remains the only required dependency for a successful request.
+
+Behavior matrix:
+- Groq down: post raw message with "_Parsing unavailable_" context, no parse fields.
+- LML down (or unconfigured): post parsed message with "_Search unavailable_" context.
+- Both down: post raw message with "_Parsing unavailable_" context.
+- Slack down: surface the error (502) since we cannot fall back further.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from groq import RateLimitError
+from httpx import ASGITransport, AsyncClient
+
+from core.dependencies import (
+    get_groq_client,
+    get_lookup_client,
+    get_posthog_client,
+    get_slack_service,
+)
+from routers.request import router
+from services.lookup_client import LookupServiceClient
+from tests.conftest import make_parsed_request
+
+SAMPLE_PARSED = make_parsed_request(
+    song="la paradoja",
+    artist="Juana Molina",
+    raw_message="play la paradoja by juana molina",
+)
+
+
+def _make_app(
+    *,
+    lookup_client: LookupServiceClient | None,
+    slack_service: AsyncMock | None,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[get_groq_client] = lambda: Mock()
+    app.dependency_overrides[get_slack_service] = lambda: slack_service
+    app.dependency_overrides[get_posthog_client] = lambda: None
+    app.dependency_overrides[get_lookup_client] = lambda: lookup_client
+    return app
+
+
+@pytest.fixture
+def mock_lookup_client():
+    return AsyncMock(spec=LookupServiceClient)
+
+
+@pytest.fixture
+def mock_slack_service():
+    svc = AsyncMock()
+    svc.post_blocks = AsyncMock()
+    svc.webhook_url = "https://hooks.slack.com/test"
+    return svc
+
+
+def _slack_text_at(call, index: int) -> str:
+    """Extract the text from the i-th block of a captured `post_blocks` call."""
+    blocks = call.args[0]
+    block = blocks[index]
+    if block.get("type") == "context":
+        return str(block["elements"][0]["text"])
+    return str(block["text"]["text"])
+
+
+# -----------------------------------------------------------------------------
+# LML degraded-mode tests
+# -----------------------------------------------------------------------------
+
+
+class TestLMLDegradedMode:
+    """When LML fails, post the parsed message to Slack with a Search-unavailable note."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.HTTPStatusError(
+                "500",
+                request=httpx.Request("POST", "http://lml/lookup"),
+                response=httpx.Response(500),
+            ),
+            httpx.ConnectError("Connection refused"),
+            httpx.TimeoutException("Read timed out"),
+        ],
+        ids=["http_500", "connect_error", "timeout"],
+    )
+    @pytest.mark.asyncio
+    async def test_lml_failure_returns_200_and_posts_to_slack(
+        self, mock_lookup_client, mock_slack_service, exc
+    ):
+        mock_lookup_client.lookup.side_effect = exc
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=mock_slack_service)
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja by juana molina"},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["degraded_mode"] == "search_unavailable"
+        assert data["library_results"] == []
+        assert data["search_type"] == "none"
+        # Parsed metadata is preserved — Groq still worked.
+        assert data["parsed"]["artist"] == "Juana Molina"
+        assert data["parsed"]["song"] == "la paradoja"
+
+        mock_slack_service.post_blocks.assert_awaited_once()
+        context_text = _slack_text_at(mock_slack_service.post_blocks.call_args, 1)
+        assert "Search unavailable" in context_text
+        # Parsed fields surfaced in the context for the DJ
+        assert "Juana Molina" in context_text
+
+    @pytest.mark.asyncio
+    async def test_lml_not_configured_returns_200_and_posts_to_slack(self, mock_slack_service):
+        """Missing LOOKUP_SERVICE_URL is treated as a permanently degraded LML."""
+        app = _make_app(lookup_client=None, slack_service=mock_slack_service)
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja by juana molina"},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["degraded_mode"] == "search_unavailable"
+        mock_slack_service.post_blocks.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_lml_failure_skip_slack_does_not_post(
+        self, mock_lookup_client, mock_slack_service
+    ):
+        """skip_slack=True still suppresses the Slack post in the degraded path."""
+        mock_lookup_client.lookup.side_effect = httpx.ConnectError("boom")
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=mock_slack_service)
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja", "skip_slack": True},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "search_unavailable"
+        mock_slack_service.post_blocks.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_lml_failure_for_non_request_does_not_use_search_unavailable(
+        self, mock_lookup_client, mock_slack_service
+    ):
+        """Non-requests never call LML, so a broken LML must not change their flow."""
+        from services.parser import MessageType
+
+        parsed = make_parsed_request(
+            is_request=False,
+            message_type=MessageType.FEEDBACK,
+            raw_message="love the show!",
+        )
+        # Setting side_effect would only matter if .lookup were called; verify it's not.
+        mock_lookup_client.lookup.side_effect = httpx.ConnectError("boom")
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=mock_slack_service)
+
+        with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "love the show!"},
+                )
+
+        assert response.status_code == 200
+        assert response.json().get("degraded_mode") is None
+        mock_lookup_client.lookup.assert_not_awaited()
+
+
+# -----------------------------------------------------------------------------
+# Groq degraded-mode tests
+# -----------------------------------------------------------------------------
+
+
+class TestGroqDegradedMode:
+    """When Groq fails, post the raw message with no classification."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RateLimitError(
+                message="Rate limit exceeded",
+                response=httpx.Response(429, request=httpx.Request("POST", "https://api.groq.com")),
+                body=None,
+            ),
+            ValueError("Invalid JSON response from Groq"),
+            httpx.ConnectError("Groq is unreachable"),
+            RuntimeError("unexpected groq error"),
+        ],
+        ids=["rate_limit", "value_error", "connect_error", "runtime_error"],
+    )
+    @pytest.mark.asyncio
+    async def test_groq_failure_returns_200_and_posts_raw_to_slack(
+        self, mock_lookup_client, mock_slack_service, exc
+    ):
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=mock_slack_service)
+
+        with patch("routers.request.parse_request", new_callable=AsyncMock, side_effect=exc):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja by juana molina"},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["degraded_mode"] == "parsing_unavailable"
+        assert data["parsed"] is None
+        assert data["library_results"] == []
+        assert data["search_type"] == "none"
+
+        mock_slack_service.post_blocks.assert_awaited_once()
+        # Header block contains the raw listener message verbatim.
+        header_text = _slack_text_at(mock_slack_service.post_blocks.call_args, 0)
+        assert "play la paradoja by juana molina" in header_text
+        context_text = _slack_text_at(mock_slack_service.post_blocks.call_args, 1)
+        assert "Parsing unavailable" in context_text
+
+        # We never even attempted LML when parsing failed.
+        mock_lookup_client.lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_groq_failure_skip_slack_does_not_post(
+        self, mock_lookup_client, mock_slack_service
+    ):
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=mock_slack_service)
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            side_effect=ValueError("broken"),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja", "skip_slack": True},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "parsing_unavailable"
+        mock_slack_service.post_blocks.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_groq_failure_with_no_lookup_client(self, mock_slack_service):
+        """Both Groq down AND LML unconfigured: still post the raw message."""
+        app = _make_app(lookup_client=None, slack_service=mock_slack_service)
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("groq down"),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "parsing_unavailable"
+        mock_slack_service.post_blocks.assert_awaited_once()
+
+
+# -----------------------------------------------------------------------------
+# Slack-down: still surfaces as 502.
+# -----------------------------------------------------------------------------
+
+
+class TestSlackStillFailsLoudly:
+    """Slack remains the only hard dependency: failures there are not silenced."""
+
+    @pytest.mark.asyncio
+    async def test_slack_post_failure_returns_502_in_lml_degraded_path(
+        self, mock_lookup_client, mock_slack_service
+    ):
+        mock_lookup_client.lookup.side_effect = httpx.ConnectError("lml down")
+        mock_slack_service.post_blocks.side_effect = httpx.HTTPError("slack down")
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=mock_slack_service)
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                )
+
+        assert response.status_code == 502
+        assert "Slack" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_slack_post_failure_returns_502_in_groq_degraded_path(
+        self, mock_lookup_client, mock_slack_service
+    ):
+        mock_slack_service.post_blocks.side_effect = httpx.HTTPError("slack down")
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=mock_slack_service)
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            side_effect=ValueError("groq down"),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                )
+
+        assert response.status_code == 502
+        assert "Slack" in response.json()["detail"]
+
+
+# -----------------------------------------------------------------------------
+# Slack disabled (None service): degraded path stays a no-op for posting.
+# -----------------------------------------------------------------------------
+
+
+class TestDegradedTelemetry:
+    """PostHog events must carry the degraded_mode signal so we can alert on outages."""
+
+    def _make_app_with_posthog(self, *, lookup_client, slack_service, posthog_client):
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+        app.dependency_overrides[get_groq_client] = lambda: Mock()
+        app.dependency_overrides[get_slack_service] = lambda: slack_service
+        app.dependency_overrides[get_posthog_client] = lambda: posthog_client
+        app.dependency_overrides[get_lookup_client] = lambda: lookup_client
+        return app
+
+    @pytest.mark.asyncio
+    async def test_lml_degraded_records_search_unavailable_in_posthog(
+        self, mock_lookup_client, mock_slack_service
+    ):
+        mock_lookup_client.lookup.side_effect = httpx.ConnectError("boom")
+        posthog = Mock()
+        posthog.capture = Mock()
+        app = self._make_app_with_posthog(
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                await client.post("/api/v1/request", json={"message": "play queen"})
+
+        posthog.capture.assert_called()
+        properties = posthog.capture.call_args.kwargs.get("properties") or (
+            posthog.capture.call_args.args[2] if len(posthog.capture.call_args.args) >= 3 else {}
+        )
+        assert properties.get("degraded_mode") == "search_unavailable"
+        assert properties.get("degraded_reason") == "ConnectError"
+
+    @pytest.mark.asyncio
+    async def test_groq_degraded_records_parsing_unavailable_in_posthog(
+        self, mock_lookup_client, mock_slack_service
+    ):
+        posthog = Mock()
+        posthog.capture = Mock()
+        app = self._make_app_with_posthog(
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            side_effect=ValueError("groq down"),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                await client.post("/api/v1/request", json={"message": "play queen"})
+
+        posthog.capture.assert_called()
+        properties = posthog.capture.call_args.kwargs.get("properties") or (
+            posthog.capture.call_args.args[2] if len(posthog.capture.call_args.args) >= 3 else {}
+        )
+        assert properties.get("degraded_mode") == "parsing_unavailable"
+        assert properties.get("degraded_reason") == "ValueError"
+
+
+class TestSlackDisabled:
+    """When Slack integration is off, degraded paths still return 200 with no post."""
+
+    @pytest.mark.asyncio
+    async def test_lml_degraded_with_slack_off(self, mock_lookup_client):
+        mock_lookup_client.lookup.side_effect = httpx.ConnectError("boom")
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=None)
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "search_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_groq_degraded_with_slack_off(self, mock_lookup_client):
+        app = _make_app(lookup_client=mock_lookup_client, slack_service=None)
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            side_effect=ValueError("broken"),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "parsing_unavailable"

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -167,8 +167,8 @@ class TestDelegationBranch:
         assert data["parsed"]["artist"] == "Living Colour"
 
     @pytest.mark.asyncio
-    async def test_groq_rate_limit_returns_429(self, app, mock_lookup_client):
-        """Groq rate limit returns 429 instead of 500."""
+    async def test_groq_rate_limit_falls_back_to_parsing_unavailable(self, app, mock_lookup_client):
+        """Groq rate limit no longer fails the request — it falls back to parsing-unavailable."""
         from groq import RateLimitError
 
         resp = httpx.Response(429, request=httpx.Request("POST", "https://api.groq.com/test"))
@@ -185,12 +185,12 @@ class TestDelegationBranch:
                     json={"message": "play queen", "skip_slack": True},
                 )
 
-        assert response.status_code == 429
-        assert "Rate limit exceeded" in response.json()["detail"]
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "parsing_unavailable"
 
     @pytest.mark.asyncio
-    async def test_http_error_returns_502(self, app, mock_lookup_client):
-        """HTTP error from lookup service returns 502."""
+    async def test_http_error_falls_back_to_search_unavailable(self, app, mock_lookup_client):
+        """HTTP error from lookup service no longer 502s — it degrades to search-unavailable."""
         mock_response = Mock()
         mock_response.status_code = 500
         mock_response.request = Mock()
@@ -209,12 +209,12 @@ class TestDelegationBranch:
                     json={"message": "play queen", "skip_slack": True},
                 )
 
-        assert response.status_code == 502
-        assert "Lookup service unavailable" in response.json()["detail"]
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "search_unavailable"
 
     @pytest.mark.asyncio
-    async def test_connect_error_returns_502(self, app, mock_lookup_client):
-        """Connection error to lookup service returns 502."""
+    async def test_connect_error_falls_back_to_search_unavailable(self, app, mock_lookup_client):
+        """Connection error to lookup service no longer 502s — it degrades."""
         mock_lookup_client.lookup.side_effect = httpx.ConnectError("Connection refused")
 
         with patch(
@@ -228,12 +228,12 @@ class TestDelegationBranch:
                     json={"message": "play queen", "skip_slack": True},
                 )
 
-        assert response.status_code == 502
-        assert "Lookup service unavailable" in response.json()["detail"]
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "search_unavailable"
 
     @pytest.mark.asyncio
-    async def test_timeout_returns_502(self, app, mock_lookup_client):
-        """Timeout from lookup service returns 502."""
+    async def test_timeout_falls_back_to_search_unavailable(self, app, mock_lookup_client):
+        """Timeout from lookup service no longer 502s — it degrades."""
         mock_lookup_client.lookup.side_effect = httpx.TimeoutException("Read timed out")
 
         with patch(
@@ -247,8 +247,8 @@ class TestDelegationBranch:
                     json={"message": "play queen", "skip_slack": True},
                 )
 
-        assert response.status_code == 502
-        assert "Lookup service unavailable" in response.json()["detail"]
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "search_unavailable"
 
     @pytest.mark.asyncio
     async def test_skip_cache_forwarded(self, app, mock_lookup_client, sample_lookup_response):

--- a/tests/unit/test_non_request_early_return.py
+++ b/tests/unit/test_non_request_early_return.py
@@ -119,12 +119,12 @@ class TestNonRequestEarlyReturn:
         assert data["library_results"] == []
 
     @pytest.mark.asyncio
-    async def test_actual_request_returns_503_without_lookup_client(self, app):
-        """An actual request returns 503 when no lookup service is configured."""
+    async def test_actual_request_degrades_without_lookup_client(self, app):
+        """A request with no lookup service configured falls back to search-unavailable."""
         parsed = make_parsed_request(
-            song="Bohemian Rhapsody",
-            artist="Queen",
-            raw_message="play bohemian rhapsody by queen",
+            song="la paradoja",
+            artist="Juana Molina",
+            raw_message="play la paradoja by juana molina",
         )
 
         with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
@@ -133,8 +133,10 @@ class TestNonRequestEarlyReturn:
             ) as client:
                 response = await client.post(
                     "/api/v1/request",
-                    json={"message": "play bohemian rhapsody by queen", "skip_slack": True},
+                    json={"message": "play la paradoja by juana molina", "skip_slack": True},
                 )
 
-        assert response.status_code == 503
-        assert "Search service not configured" in response.json()["detail"]
+        assert response.status_code == 200
+        data = response.json()
+        assert data["degraded_mode"] == "search_unavailable"
+        assert data["library_results"] == []


### PR DESCRIPTION
Closes #104

## Summary

- Wrap Groq parsing and LML lookup in try/except so that listener messages still reach Slack when those services are down. Slack is the only hard dependency now.
- Add a `degraded_mode` field to `UnifiedResponse` (`"parsing_unavailable"` or `"search_unavailable"`) and emit it on PostHog events for alerting. Make `parsed` optional so the Groq-down path can return a structured response without inventing a placeholder.
- Treat missing `LOOKUP_SERVICE_URL` as a permanent search-degraded mode (used to be a hard 503).
- Slack failures still return 502 — there is no further fallback.

## Behavior matrix

| Failure | Result |
|---|---|
| Groq fails (rate limit, parse error, network) | `200`, `degraded_mode: "parsing_unavailable"`, `parsed: null`. Slack gets the raw message + `_Parsing unavailable_` context. |
| LML fails or unset | `200`, `degraded_mode: "search_unavailable"`. Slack gets parsed metadata + `_Search unavailable_`. |
| Both fail | `parsing_unavailable`. |
| Slack fails | `502`. |

## Test plan

- [x] `pytest tests/unit/` (239 passing, includes 18 new tests in `test_degraded_mode.py`)
- [x] `ruff format --check .` and `ruff check .` clean
- [x] `mypy . --ignore-missing-imports` clean
- [x] Coverage on `routers/request.py` ≥ 90% (92%)
- [ ] Verify on staging: simulate LML outage by pointing `LOOKUP_SERVICE_URL` at an unreachable host; submit a request and confirm Slack receives it with `_Search unavailable_`.
- [ ] Verify on staging: simulate Groq outage by setting an invalid `GROQ_API_KEY`; submit a request and confirm Slack receives the raw message with `_Parsing unavailable_`.