### PR TITLE
Expose per-item artwork on /request; show Discogs URL per library result

### DIFF
--- a/routers/request.py
+++ b/routers/request.py
@@ -73,6 +73,7 @@ class UnifiedResponse(BaseModel):
     parsed: ParsedRequest | None = None
     artwork: ReleaseMetadata | None = None
     library_results: list[LibraryItem] = []
+    result_artworks: list[ReleaseMetadata | None] = []
     # Search metadata
     search_type: str = "none"
     song_not_found: bool = False
@@ -356,6 +357,7 @@ async def handle_request(
         parsed=parsed,
         artwork=artwork,
         library_results=library_results,
+        result_artworks=[art for _, art in items_with_artwork],
         search_type=search_type,
         song_not_found=song_not_found,
         found_on_compilation=found_on_compilation,

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -74,6 +74,7 @@ def print_library_results(
     results: list[dict],
     artwork: dict | None,
     context_message: str | None = None,
+    result_artworks: list[dict | None] | None = None,
 ) -> None:
     """Print library search results."""
     print_section("Library Results")
@@ -87,6 +88,7 @@ def print_library_results(
             print("  No results found in library.")
         return
 
+    artworks = result_artworks or []
     for i, item in enumerate(results, 1):
         title = item.get("title", "")
         artist = item.get("artist", "")
@@ -103,6 +105,9 @@ def print_library_results(
         else:
             print("      Location: (none)")
         print(f"      WXYC:     {item.get('library_url') or '(none)'}")
+        item_artwork = artworks[i - 1] if i - 1 < len(artworks) else None
+        discogs_url = item_artwork.get("release_url") if item_artwork else None
+        print(f"      Discogs:  {discogs_url or '(none)'}")
         print()
 
     if artwork and artwork.get("artwork_url"):
@@ -189,6 +194,7 @@ async def run_lookup(
                 library_results,
                 data.get("artwork"),
                 data.get("context_message"),
+                data.get("result_artworks"),
             )
 
             # Display cache stats if present

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -351,6 +351,11 @@ class TestDelegationBranch:
         assert data["library_results"][1]["id"] == 2
         # First artwork (non-null) is used as the top-level artwork
         assert data["artwork"]["artwork_url"] == "https://img.discogs.com/aluminum.jpg"
+        # Per-item artwork is exposed parallel to library_results so callers can
+        # render each release's Discogs URL alongside its library entry.
+        assert len(data["result_artworks"]) == 2
+        assert data["result_artworks"][0]["release_url"] == "https://www.discogs.com/release/100"
+        assert data["result_artworks"][1] is None
 
     @pytest.mark.asyncio
     async def test_lookup_request_built_from_parsed(


### PR DESCRIPTION
Closes #108.

## Summary
- Adds `result_artworks: list[ReleaseMetadata | None]` to `UnifiedResponse`, parallel-indexed with `library_results`. Populated from the existing `items_with_artwork` pairing — no new LML calls, just stop dropping the data.
- `scripts/lookup.py` renders a `Discogs:` line under each library result (falls back to `(none)` for items LML did not match).
- Extends `tests/unit/test_delegation.py::test_multiple_results_with_artwork` to cover the new field.

## Test plan
- [x] `pytest tests/unit/` — 353 passed
- [x] `ruff format --check .` — clean
- [x] `ruff check .` — clean
- [x] `mypy . --ignore-missing-imports` — clean
- [ ] After merge to `main` (staging deploy), verify `lookup --staging "bucky skank by lee scratch perry"` shows a `Discogs:` line under each Lee 'Scratch' Perry album

## Compatibility
- `library_results` and the top-level `artwork` are unchanged — Slack formatter and any other consumers keep their current contract.
- `result_artworks` defaults to `[]` so existing clients that ignore the field see no behavior change.