### PR TITLE
PostHog: WARN on misconfig and refresh dashboard for delegated step names

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -94,7 +94,11 @@ def get_posthog_client(settings: Settings = Depends(get_settings)) -> Posthog | 
         return None
 
     if not settings.posthog_api_key:
-        logger.debug("POSTHOG_API_KEY not set - telemetry disabled")
+        logger.warning(
+            "POSTHOG_API_KEY not set but ENABLE_TELEMETRY is true — "
+            "telemetry will not be sent. Set POSTHOG_API_KEY to enable, "
+            "or set ENABLE_TELEMETRY=false to silence this warning."
+        )
         return None
 
     if _posthog_client is None:

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 _http_client: httpx.AsyncClient | None = None
 _posthog_client: Posthog | None = None
 _slack_webhook_url: str | None = None
+# One-shot guard so the missing-POSTHOG_API_KEY warning fires once per process,
+# not once per FastAPI request. See get_posthog_client().
+_warned_missing_posthog_key: bool = False
 
 
 async def get_http_client() -> httpx.AsyncClient:
@@ -87,18 +90,20 @@ def get_posthog_client(settings: Settings = Depends(get_settings)) -> Posthog | 
     Returns:
         Optional[Posthog]: PostHog client if configured and enabled, None otherwise
     """
-    global _posthog_client
+    global _posthog_client, _warned_missing_posthog_key
 
     if not settings.enable_telemetry:
         logger.debug("Telemetry disabled")
         return None
 
     if not settings.posthog_api_key:
-        logger.warning(
-            "POSTHOG_API_KEY not set but ENABLE_TELEMETRY is true — "
-            "telemetry will not be sent. Set POSTHOG_API_KEY to enable, "
-            "or set ENABLE_TELEMETRY=false to silence this warning."
-        )
+        if not _warned_missing_posthog_key:
+            logger.warning(
+                "POSTHOG_API_KEY not set but ENABLE_TELEMETRY is true — "
+                "telemetry will not be sent. Set POSTHOG_API_KEY to enable, "
+                "or set ENABLE_TELEMETRY=false to silence this warning."
+            )
+            _warned_missing_posthog_key = True
         return None
 
     if _posthog_client is None:

--- a/scripts/create_posthog_dashboard.py
+++ b/scripts/create_posthog_dashboard.py
@@ -131,24 +131,10 @@ def build_insights() -> list[dict]:
                         },
                         {
                             "kind": "EventsNode",
-                            "event": "request_album_lookup",
+                            "event": "request_lookup_service",
                             "math": "avg",
                             "math_property": "duration_ms",
-                            "name": "Album Lookup",
-                        },
-                        {
-                            "kind": "EventsNode",
-                            "event": "request_library_search",
-                            "math": "avg",
-                            "math_property": "duration_ms",
-                            "name": "Library Search",
-                        },
-                        {
-                            "kind": "EventsNode",
-                            "event": "request_artwork_fetch",
-                            "math": "avg",
-                            "math_property": "duration_ms",
-                            "name": "Artwork Fetch",
+                            "name": "Lookup Service (LML)",
                         },
                         {
                             "kind": "EventsNode",

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -151,6 +151,44 @@ class TestGetPosthogClient:
         client = get_posthog_client(settings)
         assert client is None
 
+    def test_logs_warning_when_telemetry_enabled_but_key_missing(self, caplog):
+        """When the operator wanted telemetry (enable_telemetry=True) but the key
+        is missing, that's a misconfiguration — log at WARNING so it shows up in
+        normal log scraping. PostHog telemetry has been silently dead in
+        production for ~2.5 months because this was DEBUG. (#111)"""
+        settings = Settings(
+            groq_api_key="test_key",
+            enable_telemetry=True,
+            posthog_api_key=None,
+        )
+
+        with caplog.at_level("WARNING", logger="core.dependencies"):
+            client = get_posthog_client(settings)
+
+        assert client is None
+        assert any(
+            "POSTHOG_API_KEY" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        ), (
+            f"expected a WARNING about POSTHOG_API_KEY, got: {[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+    def test_logs_debug_when_telemetry_explicitly_disabled(self, caplog):
+        """When telemetry is explicitly disabled, that's the operator's intent
+        — keep the log at DEBUG to avoid noise."""
+        settings = Settings(
+            groq_api_key="test_key",
+            enable_telemetry=False,
+        )
+
+        with caplog.at_level("DEBUG", logger="core.dependencies"):
+            client = get_posthog_client(settings)
+
+        assert client is None
+        # No WARNING-level records should have been emitted by this path.
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings == [], f"unexpected warnings: {[r.message for r in warnings]}"
+
 
 class TestFlushPosthog:
     """Tests for flush_posthog function."""

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -41,11 +41,13 @@ def reset_module_state():
     original_http_client = deps._http_client
     original_posthog_client = deps._posthog_client
     original_slack_webhook_url = deps._slack_webhook_url
+    original_warned_missing_posthog_key = deps._warned_missing_posthog_key
 
     # Reset state
     deps._http_client = None
     deps._posthog_client = None
     deps._slack_webhook_url = None
+    deps._warned_missing_posthog_key = False
 
     yield
 
@@ -53,6 +55,7 @@ def reset_module_state():
     deps._http_client = original_http_client
     deps._posthog_client = original_posthog_client
     deps._slack_webhook_url = original_slack_webhook_url
+    deps._warned_missing_posthog_key = original_warned_missing_posthog_key
 
 
 class TestGetHttpClient:
@@ -162,6 +165,7 @@ class TestGetPosthogClient:
             posthog_api_key=None,
         )
 
+        caplog.clear()
         with caplog.at_level("WARNING", logger="core.dependencies"):
             client = get_posthog_client(settings)
 
@@ -173,6 +177,29 @@ class TestGetPosthogClient:
             f"expected a WARNING about POSTHOG_API_KEY, got: {[(r.levelname, r.message) for r in caplog.records]}"
         )
 
+    def test_warning_is_one_shot_per_process(self, caplog):
+        """``get_posthog_client`` is a per-request FastAPI dependency; if the
+        WARN fired on every call it would flood the log stream. Subsequent
+        calls within the same process must stay silent until the module-level
+        ``_warned_missing_posthog_key`` flag is reset (e.g. by a process
+        restart). (#111 review feedback)"""
+        settings = Settings(
+            groq_api_key="test_key",
+            enable_telemetry=True,
+            posthog_api_key=None,
+        )
+
+        caplog.clear()
+        with caplog.at_level("WARNING", logger="core.dependencies"):
+            for _ in range(5):
+                assert get_posthog_client(settings) is None
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1, (
+            f"expected exactly one WARNING across 5 calls, got {len(warnings)}: "
+            f"{[r.message for r in warnings]}"
+        )
+
     def test_logs_debug_when_telemetry_explicitly_disabled(self, caplog):
         """When telemetry is explicitly disabled, that's the operator's intent
         — keep the log at DEBUG to avoid noise."""
@@ -181,6 +208,7 @@ class TestGetPosthogClient:
             enable_telemetry=False,
         )
 
+        caplog.clear()
         with caplog.at_level("DEBUG", logger="core.dependencies"):
             client = get_posthog_client(settings)
 


### PR DESCRIPTION
Closes #111.

## Summary

- `core/dependencies.py:97` — promote the `POSTHOG_API_KEY not set` log from DEBUG to WARNING when `ENABLE_TELEMETRY=true`. The opt-out path (`enable_telemetry=False`) keeps its DEBUG line so silencing telemetry stays quiet.
- `scripts/create_posthog_dashboard.py` — replace the three pre-delegation step-event tiles (`request_album_lookup`, `request_library_search`, `request_artwork_fetch`) with `request_lookup_service`. After the LML delegation refactor these old events stopped being emitted; the dashboard's "Average Duration by Step" tile has been showing only Parse and Slack Post.

## Operational follow-up (not in this PR)

`POSTHOG_API_KEY` must be re-added to the Railway service (staging + production) for any of this to do anything. The code change is a no-op until then; the WARN line will fire on the next deploy and surface the misconfig in the existing log stream so we don't drift again.

Re-running `scripts/create_posthog_dashboard.py` (with `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_PROJECT_ID` set locally) will refresh the dashboard insights with the new tile definitions.

## Test plan
- [x] `pytest tests/unit/` — 355 pass (2 new caplog-based assertions covering both branches)
- [x] `ruff format --check .` — clean
- [x] `ruff check .` — clean
- [x] `mypy . --ignore-missing-imports` — clean
- [ ] After Railway env var is restored: confirm the WARN line stops appearing and `request_completed` events arrive in PostHog