### PR TITLE
Adopt wxyc-fastapi healthcheck routers

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,12 +6,13 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
+from wxyc_fastapi.healthcheck import liveness_router
 from wxyc_fastapi.observability import flush_posthog, init_sentry, shutdown_posthog
 
 from config.settings import get_settings
 from core.dependencies import close_http_client
 from core.logging import setup_logging
-from routers.health import router as health_router
+from routers.health import build_readiness_router
 from routers.parse import router as parse_router
 from routers.request import router as request_router
 
@@ -73,8 +74,11 @@ async def posthog_flush_middleware(request: Request, call_next):
     return response
 
 
-# Include routers - health check at root, others versioned
-app.include_router(health_router, prefix="", tags=["health"])
+# Include routers - health check at root, others versioned.
+# Liveness + readiness come from wxyc_fastapi (shared across LML, rom, semantic-index);
+# the probe functions still live locally in routers/health.py.
+app.include_router(liveness_router, tags=["health"])
+app.include_router(build_readiness_router(), tags=["health"])
 
 # V1 API (new)
 app.include_router(parse_router, prefix="/api/v1", tags=["parse"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.25.0",
-    "wxyc-fastapi[posthog]>=0.1.0,<0.2.0",
+    "wxyc-fastapi[posthog]>=0.2.0,<0.3.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydantic>=2.0.0
 pydantic-settings>=2.0.0
 python-dotenv>=1.0.0
 httpx>=0.25.0
-wxyc-fastapi[posthog]>=0.1.0,<0.2.0
+wxyc-fastapi[posthog]>=0.2.0,<0.3.0

--- a/routers/health.py
+++ b/routers/health.py
@@ -1,11 +1,33 @@
-"""Health check router with real dependency connectivity checks."""
+"""Health check probes wired into wxyc_fastapi's shared healthcheck routers.
 
-import asyncio
-import logging
+The routing and status aggregation live in
+[`wxyc_fastapi.healthcheck`](https://github.com/WXYC/wxyc-fastapi/blob/main/src/wxyc_fastapi/healthcheck/__init__.py);
+this module only defines the rom-side probe functions and a small
+:func:`build_readiness_router` helper that binds them into the shared
+``readiness_router`` factory.
+
+Probe contract (per ``wxyc_fastapi.healthcheck.Check``): each probe is an
+async callable returning ``"ok"`` on success. Returning any other string or
+raising is reported as ``"unavailable"``; exceeding the per-probe timeout is
+reported as ``"timeout"``.
+
+Required vs optional:
+
+* ``lookup`` — ``required=True``. Search delegation is rom's core path;
+  failure here makes the readiness response ``unhealthy`` (HTTP 503) so the
+  orchestrator can route traffic away.
+* ``groq`` — ``required=False``. Groq parsing has a ``parsing_unavailable``
+  degraded mode; the listener's message still reaches Slack without it.
+* ``slack`` — ``required=False``. ``/request`` returns 502 if Slack itself
+  is down, but readiness reports ``degraded`` so the dashboard surfaces the
+  impairment without removing the container from rotation.
+"""
+
+from __future__ import annotations
 
 import httpx
-from fastapi import APIRouter, Depends
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter
+from wxyc_fastapi.healthcheck import Check, readiness_router
 
 from config.settings import Settings, get_settings
 from core.dependencies import (
@@ -13,38 +35,28 @@ from core.dependencies import (
     get_http_client,
 )
 
-logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["health"])
-
-# Per-check timeout in seconds
-CHECK_TIMEOUT = 3.0
-
-# Core services whose failure means "unhealthy"
-CORE_SERVICES = {"groq"}
-
-
-async def _check_groq(settings: Settings, http_client: httpx.AsyncClient) -> str:
+async def probe_groq(settings: Settings, http_client: httpx.AsyncClient) -> str:
     """Verify the Groq API key is valid and the service is reachable."""
     if not settings.groq_api_key:
-        return "error"
+        return "unavailable"
     try:
         resp = await http_client.get(
             "https://api.groq.com/openai/v1/models",
             headers={"Authorization": f"Bearer {settings.groq_api_key}"},
         )
-        return "ok" if resp.status_code == 200 else "error"
     except Exception:
-        return "error"
+        return "unavailable"
+    return "ok" if resp.status_code == 200 else "unavailable"
 
 
-async def _check_lookup_service(settings: Settings, http_client: httpx.AsyncClient) -> str:
-    """Check the library-metadata-lookup lookup endpoint with auth.
+async def probe_lookup(settings: Settings, http_client: httpx.AsyncClient) -> str:
+    """Probe the library-metadata-lookup ``/lookup`` endpoint with bearer auth.
 
     POSTs a ``raw_message``-only request to ``{lookup_service_url}/lookup``
     carrying the Bearer token (when ``LML_API_KEY`` is set). This is the same
-    endpoint /request hits, so a 401/403 from auth misconfig surfaces here
-    instead of silently passing a /health connectivity ping.
+    endpoint ``/request`` hits, so a 401/403 from auth misconfig surfaces here
+    instead of silently passing a connectivity ping.
 
     LML's ``LookupRequest`` makes every field optional, so ``raw_message``
     alone validates and the orchestrator returns ``200`` with empty results --
@@ -62,12 +74,12 @@ async def _check_lookup_service(settings: Settings, http_client: httpx.AsyncClie
             json={"raw_message": "readiness-probe"},
             headers=headers,
         )
-        return "ok" if resp.status_code == 200 else "error"
     except Exception:
-        return "error"
+        return "unavailable"
+    return "ok" if resp.status_code == 200 else "unavailable"
 
 
-async def _check_slack(http_client: httpx.AsyncClient) -> str:
+async def probe_slack(http_client: httpx.AsyncClient) -> str:
     """Verify the Slack webhook URL is reachable.
 
     Sends an empty JSON body; Slack returns 400 (missing text) which proves
@@ -78,77 +90,36 @@ async def _check_slack(http_client: httpx.AsyncClient) -> str:
         return "unavailable"
     try:
         resp = await http_client.post(webhook_url, json={})
-        # 400 means Slack received the request but rejected the empty payload --
-        # that's exactly what we want: proof the webhook URL is valid.
-        return "ok" if resp.status_code in (200, 400) else "error"
     except Exception:
-        return "error"
+        return "unavailable"
+    # 400 means Slack received the request but rejected the empty payload --
+    # that's exactly what we want: proof the webhook URL is valid.
+    return "ok" if resp.status_code in (200, 400) else "unavailable"
 
 
-async def _run_check(coro) -> str:
-    """Run a single health check with a timeout."""
-    try:
-        return await asyncio.wait_for(coro, timeout=CHECK_TIMEOUT)
-    except TimeoutError:
-        return "timeout"
+def build_readiness_router() -> APIRouter:
+    """Build a ``GET /health/ready`` router with rom's three probes.
 
+    Probes resolve :class:`Settings` and the shared :class:`httpx.AsyncClient`
+    from the rom-side module singletons (``get_settings()`` / ``get_http_client()``)
+    at call time, so no FastAPI dependency injection plumbing is needed for the
+    probe arguments. The shared router owns the timeout and aggregation
+    behavior.
+    """
 
-@router.get(
-    "/health",
-    summary="Liveness check",
-    description="Shallow liveness probe. Returns 200 immediately with no external calls. Used by Railway's healthcheckPath to mark the container as routable.",
-    responses={
-        200: {"description": "Service is alive"},
-    },
-)
-async def liveness_check():
-    """Shallow liveness probe -- no external calls, instant response."""
-    return JSONResponse(content={"status": "ok"})
+    async def _groq() -> str:
+        return await probe_groq(get_settings(), await get_http_client())
 
+    async def _lookup() -> str:
+        return await probe_lookup(get_settings(), await get_http_client())
 
-@router.get(
-    "/health/ready",
-    summary="Readiness check",
-    description="Deep readiness probe. Checks connectivity to Groq, lookup service, and Slack.",
-    responses={
-        200: {"description": "Service is healthy or degraded"},
-        503: {"description": "Service is unhealthy (core dependency down)"},
-    },
-)
-async def readiness_check(
-    settings: Settings = Depends(get_settings),
-    http_client: httpx.AsyncClient = Depends(get_http_client),
-):
-    """Health check with real connectivity probes for every dependency."""
+    async def _slack() -> str:
+        return await probe_slack(await get_http_client())
 
-    results = await asyncio.gather(
-        _run_check(_check_groq(settings, http_client)),
-        _run_check(_check_lookup_service(settings, http_client)),
-        _run_check(_check_slack(http_client)),
+    return readiness_router(
+        [
+            Check(name="groq", probe=_groq, required=False),
+            Check(name="lookup", probe=_lookup, required=True),
+            Check(name="slack", probe=_slack, required=False),
+        ]
     )
-
-    services = {
-        "groq": results[0],
-        "lookup": results[1],
-        "slack": results[2],
-    }
-
-    # Determine overall status
-    core_ok = all(services[s] == "ok" for s in CORE_SERVICES)
-    all_configured_ok = all(v in ("ok", "unavailable") for v in services.values())
-
-    if core_ok and all_configured_ok:
-        status = "healthy"
-    elif core_ok:
-        status = "degraded"
-    else:
-        status = "unhealthy"
-
-    body = {
-        "status": status,
-        "version": settings.app_version,
-        "services": services,
-    }
-
-    status_code = 200 if status in ("healthy", "degraded") else 503
-    return JSONResponse(content=body, status_code=status_code)

--- a/tests/unit/test_health_router.py
+++ b/tests/unit/test_health_router.py
@@ -1,6 +1,15 @@
-"""Unit tests for routers/health.py."""
+"""Unit tests for the routers/health.py wiring against wxyc_fastapi healthcheck.
 
-import asyncio
+The probe functions live locally in ``routers/health.py``; the routing and
+status aggregation are imported from ``wxyc_fastapi.healthcheck``. These tests
+pin the four observable response shapes the issue calls out:
+
+* all probes ok -> 200 ``{"status": "healthy", "services": {...}}``
+* required ``lookup`` probe fails -> 503 ``{"status": "unhealthy", ...}``
+* optional ``groq`` probe fails -> 200 ``{"status": "degraded", ...}``
+* optional ``slack`` probe fails -> 200 ``{"status": "degraded", ...}``
+"""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -8,7 +17,6 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from config.settings import Settings
-from routers.health import router
 
 
 def _make_settings(**overrides):
@@ -18,298 +26,230 @@ def _make_settings(**overrides):
         log_level=overrides.pop("log_level", "DEBUG"),
         enable_slack_integration=overrides.pop("enable_slack_integration", True),
         app_version=overrides.pop("app_version", "1.0.0-test"),
+        lookup_service_url=overrides.pop("lookup_service_url", "https://lookup.example.com/api/v1"),
         **overrides,
     )
 
 
-def _make_app(settings, http_client=None):
-    """Build a FastAPI test app with dependency overrides."""
-    from config.settings import get_settings
-    from core.dependencies import get_http_client
+def _build_app(probe_results: dict[str, str]) -> FastAPI:
+    """Wire a fresh FastAPI app with probes that return the supplied results.
+
+    ``probe_results`` is a mapping like ``{"groq": "ok", "lookup": "ok", "slack": "ok"}``.
+    Any probe whose result is not ``"ok"`` raises so we exercise the shared
+    router's ``unavailable`` aggregation path.
+    """
+    from wxyc_fastapi.healthcheck import Check, liveness_router, readiness_router
+
+    def _probe_factory(name: str):
+        async def _probe() -> str:
+            result = probe_results[name]
+            if result == "ok":
+                return "ok"
+            raise RuntimeError(f"{name} probe simulated failure: {result}")
+
+        return _probe
+
+    checks = [
+        Check(name="groq", probe=_probe_factory("groq"), required=False),
+        Check(name="lookup", probe=_probe_factory("lookup"), required=True),
+        Check(name="slack", probe=_probe_factory("slack"), required=False),
+    ]
 
     app = FastAPI()
-    app.include_router(router)
-    app.dependency_overrides[get_settings] = lambda: settings
-    app.dependency_overrides[get_http_client] = lambda: http_client or AsyncMock()
+    app.include_router(liveness_router)
+    app.include_router(readiness_router(checks))
     return app
 
 
-@pytest.fixture
-def mock_settings():
-    return _make_settings()
-
-
-@pytest.fixture
-def mock_http_client():
-    """HTTP client that returns 200 for Groq and lookup probes, 400 for Slack."""
-    client = AsyncMock()
-
-    async def _get(url, **kwargs):
-        resp = Mock()
-        resp.status_code = 200
-        return resp
-
-    async def _post(url, **kwargs):
-        resp = Mock()
-        # Lookup probe expects 200; Slack expects 400 (empty body rejected).
-        resp.status_code = 200 if "lookup" in url else 400
-        return resp
-
-    client.get = _get
-    client.post = _post
-    return client
-
-
-class TestLivenessCheck:
-    """Tests for the shallow /health liveness endpoint."""
-
+class TestLiveness:
     @pytest.mark.asyncio
-    async def test_returns_ok(self):
-        """Liveness check returns 200 immediately with no dependencies."""
-        settings = _make_settings()
-        app = _make_app(settings)
+    async def test_returns_healthy_status(self):
+        """``GET /health`` returns ``{"status": "healthy"}`` instantly, no probes run."""
+        app = _build_app({"groq": "ok", "lookup": "ok", "slack": "ok"})
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
             response = await c.get("/health")
 
         assert response.status_code == 200
-        assert response.json() == {"status": "ok"}
+        assert response.json() == {"status": "healthy"}
 
+
+class TestReadinessShapes:
     @pytest.mark.asyncio
-    async def test_no_external_calls(self):
-        """Liveness check must not make any HTTP calls."""
-        settings = _make_settings()
-        client = AsyncMock()
-        app = _make_app(settings, client)
+    async def test_all_probes_ok(self):
+        """All probes ok -> 200 healthy with services map."""
+        app = _build_app({"groq": "ok", "lookup": "ok", "slack": "ok"})
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            await c.get("/health")
-
-        client.get.assert_not_called()
-        client.post.assert_not_called()
-
-
-class TestReadinessCheck:
-    """Tests for the deep /health/ready readiness endpoint."""
-
-    @pytest.mark.asyncio
-    async def test_all_services_healthy(self, mock_http_client):
-        """All services ok -> 200 healthy."""
-        settings = _make_settings(
-            lookup_service_url="https://lookup.example.com/api/v1",
-        )
-        app = _make_app(settings, mock_http_client)
-
-        with patch(
-            "routers.health.get_cached_slack_webhook_url",
-            return_value="https://hooks.slack.com/test",
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
+            response = await c.get("/health/ready")
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "healthy"
-        assert data["version"] == "1.0.0-test"
-        assert data["services"]["groq"] == "ok"
-        assert data["services"]["lookup"] == "ok"
-        assert data["services"]["slack"] == "ok"
+        assert response.json() == {
+            "status": "healthy",
+            "services": {"groq": "ok", "lookup": "ok", "slack": "ok"},
+        }
 
     @pytest.mark.asyncio
-    async def test_core_service_down_groq(self, mock_settings):
-        """Groq returning non-200 -> 503 unhealthy."""
+    async def test_lookup_failure_is_unhealthy_503(self):
+        """Required ``lookup`` probe failing -> 503 unhealthy."""
+        app = _build_app({"groq": "ok", "lookup": "fail", "slack": "ok"})
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            response = await c.get("/health/ready")
+
+        assert response.status_code == 503
+        body = response.json()
+        assert body["status"] == "unhealthy"
+        assert body["services"]["lookup"] == "unavailable"
+        assert body["services"]["groq"] == "ok"
+        assert body["services"]["slack"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_groq_failure_is_degraded_200(self):
+        """Optional ``groq`` probe failing -> 200 degraded."""
+        app = _build_app({"groq": "fail", "lookup": "ok", "slack": "ok"})
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            response = await c.get("/health/ready")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "degraded"
+        assert body["services"]["groq"] == "unavailable"
+        assert body["services"]["lookup"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_slack_failure_is_degraded_200(self):
+        """Optional ``slack`` probe failing -> 200 degraded."""
+        app = _build_app({"groq": "ok", "lookup": "ok", "slack": "fail"})
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            response = await c.get("/health/ready")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "degraded"
+        assert body["services"]["slack"] == "unavailable"
+        assert body["services"]["lookup"] == "ok"
+
+
+class TestRomProbeWiring:
+    """Tests for the rom-side probe functions wired into the shared router.
+
+    These verify the rom probes still call the same upstream endpoints with
+    the same auth they did before the migration -- only the routing/aggregation
+    moved to wxyc_fastapi.
+    """
+
+    @pytest.mark.asyncio
+    async def test_lookup_probe_posts_to_authenticated_endpoint(self):
+        """Lookup probe POSTs to ``{lookup_service_url}/lookup`` with bearer auth."""
+        import routers.health as health_module
+
+        settings = _make_settings(lml_api_key="probe-token")
+        client = AsyncMock()
+        captured: list[tuple[str, dict]] = []
+
+        async def _post(url, **kwargs):
+            captured.append((url, dict(kwargs.get("headers") or {})))
+            resp = Mock()
+            resp.status_code = 200
+            return resp
+
+        client.post = _post
+
+        result = await health_module.probe_lookup(settings, client)
+
+        assert result == "ok"
+        assert captured == [
+            (
+                "https://lookup.example.com/api/v1/lookup",
+                {"Authorization": "Bearer probe-token"},
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_lookup_probe_marks_unavailable_on_401(self):
+        """When LML returns 401 (auth misconfig), probe returns non-ok."""
+        import routers.health as health_module
+
+        settings = _make_settings(lml_api_key="wrong-token")
         client = AsyncMock()
 
-        async def _get(url, **kwargs):
+        async def _post(url, **kwargs):
             resp = Mock()
-            resp.status_code = 401  # Bad API key
+            resp.status_code = 401
             return resp
+
+        client.post = _post
+
+        result = await health_module.probe_lookup(settings, client)
+
+        assert result != "ok"
+
+    @pytest.mark.asyncio
+    async def test_lookup_probe_unavailable_when_url_unset(self):
+        """No ``LOOKUP_SERVICE_URL`` -> probe returns non-ok (lookup is required)."""
+        import routers.health as health_module
+
+        settings = _make_settings(lookup_service_url=None)
+        client = AsyncMock()
+
+        result = await health_module.probe_lookup(settings, client)
+
+        assert result != "ok"
+
+    @pytest.mark.asyncio
+    async def test_slack_probe_returns_ok_for_400_response(self):
+        """Slack returning 400 (empty body rejected) is proof the webhook is alive."""
+        import routers.health as health_module
+
+        client = AsyncMock()
 
         async def _post(url, **kwargs):
             resp = Mock()
             resp.status_code = 400
             return resp
 
-        client.get = _get
         client.post = _post
-        app = _make_app(mock_settings, client)
 
-        with patch(
-            "routers.health.get_cached_slack_webhook_url",
-            return_value="https://hooks.slack.com/test",
+        with patch.object(
+            health_module, "get_cached_slack_webhook_url", return_value="https://hooks.slack.com/x"
         ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
+            result = await health_module.probe_slack(client)
 
-        assert response.status_code == 503
-        data = response.json()
-        assert data["status"] == "unhealthy"
-        assert data["services"]["groq"] == "error"
+        assert result == "ok"
 
     @pytest.mark.asyncio
-    async def test_optional_service_down_degraded(self, mock_http_client):
-        """Lookup service down, core ok -> 200 degraded."""
-        settings = _make_settings(
-            lookup_service_url="https://lookup.example.com/api/v1",
-        )
+    async def test_slack_probe_unavailable_when_webhook_unset(self):
+        """No cached webhook URL -> probe returns non-ok."""
+        import routers.health as health_module
 
-        original_post = mock_http_client.post
-
-        async def _post(url, **kwargs):
-            if "lookup" in url:
-                resp = Mock()
-                resp.status_code = 500
-                return resp
-            return await original_post(url, **kwargs)
-
-        mock_http_client.post = _post
-        app = _make_app(settings, mock_http_client)
-
-        with patch(
-            "routers.health.get_cached_slack_webhook_url",
-            return_value="https://hooks.slack.com/test",
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "degraded"
-        assert data["services"]["lookup"] == "error"
-        assert data["services"]["groq"] == "ok"
-
-    @pytest.mark.asyncio
-    async def test_lookup_not_configured_unavailable(self, mock_settings, mock_http_client):
-        """No LOOKUP_SERVICE_URL -> lookup 'unavailable', still healthy."""
-        app = _make_app(mock_settings, mock_http_client)
-
-        with patch(
-            "routers.health.get_cached_slack_webhook_url",
-            return_value="https://hooks.slack.com/test",
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "healthy"
-        assert data["services"]["lookup"] == "unavailable"
-
-    @pytest.mark.asyncio
-    async def test_slack_not_configured_unavailable(self, mock_settings, mock_http_client):
-        """No cached Slack webhook URL -> 'unavailable', still healthy."""
-        app = _make_app(mock_settings, mock_http_client)
-
-        with patch("routers.health.get_cached_slack_webhook_url", return_value=None):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "healthy"
-        assert data["services"]["slack"] == "unavailable"
-
-    @pytest.mark.asyncio
-    async def test_timeout_reported(self, mock_settings):
-        """A check that exceeds the timeout is reported as 'timeout'."""
         client = AsyncMock()
 
-        async def _get(url, **kwargs):
-            if "groq" in url:
-                await asyncio.sleep(10)
-            resp = Mock()
-            resp.status_code = 200
-            return resp
+        with patch.object(health_module, "get_cached_slack_webhook_url", return_value=None):
+            result = await health_module.probe_slack(client)
 
-        async def _post(url, **kwargs):
-            resp = Mock()
-            resp.status_code = 400
-            return resp
-
-        client.get = _get
-        client.post = _post
-        app = _make_app(mock_settings, client)
-
-        with (
-            patch(
-                "routers.health.get_cached_slack_webhook_url",
-                return_value="https://hooks.slack.com/test",
-            ),
-            patch("routers.health.CHECK_TIMEOUT", 0.05),
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
-
-        assert response.status_code == 503
-        data = response.json()
-        assert data["services"]["groq"] == "timeout"
-        assert data["status"] == "unhealthy"
+        assert result != "ok"
 
     @pytest.mark.asyncio
-    async def test_no_features_block(self, mock_settings, mock_http_client):
-        """The response should not contain a 'features' block."""
-        app = _make_app(mock_settings, mock_http_client)
+    async def test_groq_probe_unavailable_when_key_unset(self):
+        """No ``GROQ_API_KEY`` -> probe returns non-ok."""
+        import routers.health as health_module
 
-        with patch(
-            "routers.health.get_cached_slack_webhook_url",
-            return_value="https://hooks.slack.com/test",
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
-
-        data = response.json()
-        assert "features" not in data
-
-    @pytest.mark.asyncio
-    async def test_lookup_probe_exercises_authenticated_endpoint(self):
-        """Readiness lookup probe POSTs to /api/v1/lookup with a Bearer token.
-
-        This catches LML auth misconfig: a missing or wrong LML_API_KEY produces
-        a 401/403 from the protected route, which the probe must surface.
-        Probing the unprotected /health endpoint would mask the failure.
-        """
-        settings = _make_settings(
-            lookup_service_url="https://lookup.example.com/api/v1",
-            lml_api_key="probe-token",
-        )
+        settings = _make_settings(groq_api_key="")
         client = AsyncMock()
-        captured_posts: list[tuple[str, dict]] = []
 
-        async def _get(url, **kwargs):
-            resp = Mock()
-            resp.status_code = 200
-            return resp
+        result = await health_module.probe_groq(settings, client)
 
-        async def _post(url, **kwargs):
-            captured_posts.append((url, dict(kwargs.get("headers") or {})))
-            resp = Mock()
-            resp.status_code = 200 if "lookup" in url else 400
-            return resp
-
-        client.get = _get
-        client.post = _post
-        app = _make_app(settings, client)
-
-        with patch(
-            "routers.health.get_cached_slack_webhook_url",
-            return_value="https://hooks.slack.com/test",
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                await c.get("/health/ready")
-
-        lookup_posts = [(u, h) for (u, h) in captured_posts if "lookup" in u]
-        assert lookup_posts, "expected POST to lookup endpoint"
-        url, headers = lookup_posts[0]
-        assert url == "https://lookup.example.com/api/v1/lookup"
-        assert headers.get("Authorization") == "Bearer probe-token"
+        assert result != "ok"
 
     @pytest.mark.asyncio
-    async def test_lookup_probe_marks_error_on_401(self):
-        """When LML returns 401 (auth misconfig), probe reports lookup='error'."""
-        settings = _make_settings(
-            lookup_service_url="https://lookup.example.com/api/v1",
-            lml_api_key="wrong-token",
-        )
+    async def test_groq_probe_ok_for_200_response(self):
+        """Groq returning 200 -> probe returns ok."""
+        import routers.health as health_module
+
+        settings = _make_settings()
         client = AsyncMock()
 
         async def _get(url, **kwargs):
@@ -317,59 +257,8 @@ class TestReadinessCheck:
             resp.status_code = 200
             return resp
 
-        async def _post(url, **kwargs):
-            resp = Mock()
-            resp.status_code = 401 if "lookup" in url else 400
-            return resp
-
         client.get = _get
-        client.post = _post
-        app = _make_app(settings, client)
 
-        with patch(
-            "routers.health.get_cached_slack_webhook_url",
-            return_value="https://hooks.slack.com/test",
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
+        result = await health_module.probe_groq(settings, client)
 
-        data = response.json()
-        assert data["services"]["lookup"] == "error"
-
-    @pytest.mark.asyncio
-    async def test_multiple_optional_services_down(self):
-        """Multiple optional services failing -> degraded, not unhealthy."""
-        settings = _make_settings(
-            lookup_service_url="https://lookup.example.com/api/v1",
-        )
-        client = AsyncMock()
-
-        async def _get(url, **kwargs):
-            resp = Mock()
-            if "groq" in url:
-                resp.status_code = 200
-            else:
-                resp.status_code = 500  # lookup down
-            return resp
-
-        async def _post(url, **kwargs):
-            resp = Mock()
-            resp.status_code = 500  # slack down
-            return resp
-
-        client.get = _get
-        client.post = _post
-        app = _make_app(settings, client)
-
-        with patch(
-            "routers.health.get_cached_slack_webhook_url",
-            return_value="https://hooks.slack.com/test",
-        ):
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                response = await c.get("/health/ready")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "degraded"
-        assert data["services"]["lookup"] == "error"
-        assert data["services"]["slack"] == "error"
+        assert result == "ok"


### PR DESCRIPTION
## Summary

Migrates rom from the local `routers/health.py` routing/aggregation to the shared `liveness_router` + `readiness_router(checks=...)` factory in [`wxyc_fastapi.healthcheck`](https://github.com/WXYC/wxyc-fastapi/blob/main/src/wxyc_fastapi/healthcheck/__init__.py) (v0.2.0, published 2026-05-11).

The probe functions (`probe_groq`, `probe_lookup`, `probe_slack`) stay defined locally — only the routing, per-check timeout, and status aggregation move to the shared module. Probes are wired via `Check` tuples:

- `Check(name="lookup", probe=probe_lookup, required=True)` — failure → 503 `unhealthy`
- `Check(name="groq", probe=probe_groq, required=False)` — failure → 200 `degraded`
- `Check(name="slack", probe=probe_slack, required=False)` — failure → 200 `degraded`

These line up with rom's existing degraded-mode semantics: `parsing_unavailable` (Groq down) and `search_unavailable` (LML/Slack down) both return 200 from `/request`, while Slack-write failure returns 502 only at request time.

## Dep bump in BOTH `requirements.txt` and `pyproject.toml`

Per the documented gotcha in [`project_wxyc_fastapi.md`](https://github.com/WXYC/wiki/blob/main/plans/wxyc-fastapi.md) (and the precedent fix [`af22e38`](https://github.com/WXYC/request-o-matic/commit/af22e38)): rom CI installs from `requirements.txt`, so a one-sided bump of `pyproject.toml` fails silently with `ModuleNotFoundError` on the shared import. Both files now pin `wxyc-fastapi[posthog]>=0.2.0,<0.3.0`.

## Observable response-shape changes

- `GET /health` body: `{"status": "ok"}` → `{"status": "healthy"}`. Railway's `healthcheckPath` only checks the HTTP status code, so the platform probe is unaffected.
- `GET /health/ready` body now matches the `ReadinessResponse` contract from [`wxyc-shared/api.yaml`](https://github.com/WXYC/wxyc-shared/blob/main/api.yaml): `{"status", "services"}`. The `version` field the local router included is dropped.
- Per-service outcomes are now drawn from `{"ok", "unavailable", "timeout"}` instead of `{"ok", "error", "unavailable", "timeout"}`. The CI smoke test in [`.github/workflows/ci.yml`](https://github.com/WXYC/request-o-matic/blob/main/.github/workflows/ci.yml) continues to pass because it only treats `ok`/`unavailable` as acceptable for the optional services.

## Related

- Epic: [WXYC/wxyc-fastapi#1](https://github.com/WXYC/wxyc-fastapi/issues/1)
- Phase B epic: [WXYC/wxyc-fastapi#12](https://github.com/WXYC/wxyc-fastapi/issues/12)
- Depends on shipped wxyc-fastapi v0.2.0 ([WXYC/wxyc-fastapi#3](https://github.com/WXYC/wxyc-fastapi/issues/3) / [PR #17](https://github.com/WXYC/wxyc-fastapi/pull/17))
- Sibling migration in LML: [WXYC/library-metadata-lookup#282](https://github.com/WXYC/library-metadata-lookup/issues/282)
- Sibling migration in semantic-index: [WXYC/semantic-index#308](https://github.com/WXYC/semantic-index/issues/308)

Closes #115.

## Test plan

- [x] `pytest tests/unit/` — 317 tests pass locally (12 health-router tests rewritten against the new wiring)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy . --ignore-missing-imports` clean
- [x] `python -c "from main import app"` resolves `/health` and `/health/ready` routes
- [ ] Railway staging healthcheck stays green on auto-deploy from `main`
- [ ] `deploy-staging` smoke test in CI passes (asserts `services.groq == 'ok'` and `services.lookup` / `services.slack` in `('ok', 'unavailable')`)