### PR TITLE
#116 migrate get_http_client to wxyc-fastapi async_singleton

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import httpx
 from fastapi import Depends
 from groq import AsyncGroq
+from wxyc_fastapi.http import async_singleton
 from wxyc_fastapi.observability import get_posthog_client as _shared_posthog_client
 
 from config.settings import Settings, get_settings
@@ -19,28 +20,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_http_client: httpx.AsyncClient | None = None
 _slack_webhook_url: str | None = None
 
 
-async def get_http_client() -> httpx.AsyncClient:
-    """Get or create HTTP client for async requests.
-
-    Returns:
-        httpx.AsyncClient: Shared async HTTP client
-    """
-    global _http_client
-    if _http_client is None:
-        _http_client = httpx.AsyncClient(timeout=30.0)
-    return _http_client
+async def _make_http_client() -> httpx.AsyncClient:
+    """Construct the shared httpx.AsyncClient used across rom services."""
+    return httpx.AsyncClient(timeout=30.0)
 
 
-async def close_http_client() -> None:
-    """Close the HTTP client."""
-    global _http_client
-    if _http_client:
-        await _http_client.aclose()
-        _http_client = None
+# Lazy singleton: ``async_singleton`` wraps ``_make_http_client`` with a
+# double-check-lock so concurrent first-callers see one factory invocation
+# (LML#241 / LML#242 — the FD-leak race the helper exists to prevent).
+get_http_client, close_http_client = async_singleton(_make_http_client)
 
 
 def get_groq_client(settings: Settings = Depends(get_settings)) -> AsyncGroq:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.25.0",
-    "wxyc-fastapi[posthog]>=0.2.0,<0.3.0",
+    "wxyc-fastapi[posthog]>=0.3.0,<0.4.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydantic>=2.0.0
 pydantic-settings>=2.0.0
 python-dotenv>=1.0.0
 httpx>=0.25.0
-wxyc-fastapi[posthog]>=0.2.0,<0.3.0
+wxyc-fastapi[posthog]>=0.3.0,<0.4.0

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,5 +1,6 @@
 """Unit tests for core/dependencies.py."""
 
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -32,18 +33,26 @@ def mock_settings():
 
 @pytest.fixture(autouse=True)
 def reset_module_state():
-    """Reset module-level state before and after each test."""
+    """Reset module-level state before and after each test.
+
+    The HTTP client singleton lives inside the closure returned by
+    ``async_singleton``; we reset it via its public closer (which clears the
+    cached instance and invokes ``aclose`` if one was built). The Slack webhook
+    URL remains a plain module global, reset directly.
+    """
     import core.dependencies as deps
 
-    original_http_client = deps._http_client
+    async def _close() -> None:
+        await deps.close_http_client()
+
     original_slack_webhook_url = deps._slack_webhook_url
 
-    deps._http_client = None
+    asyncio.run(_close())
     deps._slack_webhook_url = None
 
     yield
 
-    deps._http_client = original_http_client
+    asyncio.run(_close())
     deps._slack_webhook_url = original_slack_webhook_url
 
 
@@ -65,30 +74,106 @@ class TestGetHttpClient:
         assert client1 is client2
         await client1.aclose()
 
+    @pytest.mark.asyncio
+    async def test_get_http_client_factory_invoked_once_under_concurrency(self):
+        """Concurrent first-callers must see exactly one underlying httpx client.
+
+        Port of the LML#241 / LML#242 FD-leak reproducer adapted to rom. The
+        rom-side wiring is ``get_http_client = async_singleton(_make_http_client)[0]``;
+        we exercise the same race against a freshly-built ``async_singleton``
+        wrapping ``_make_http_client`` so the test is independent of any cached
+        module state and works regardless of whether other tests have already
+        warmed the rom-level singleton.
+
+        Without the ``asyncio.Lock`` inside ``async_singleton``, concurrent
+        first-callers each pass the outer ``is None`` check, each invoke the
+        factory, and only one survives as the cached value — the rest are
+        orphaned with their connections (and FDs) still open. With the lock,
+        the factory runs exactly once.
+        """
+        from wxyc_fastapi.http import async_singleton
+
+        from core.dependencies import _make_http_client
+
+        invocations = 0
+
+        async def counting_factory() -> httpx.AsyncClient:
+            nonlocal invocations
+            invocations += 1
+            await asyncio.sleep(0)  # yield, let other concurrent callers race
+            return await _make_http_client()
+
+        getter, closer = async_singleton(counting_factory)
+        try:
+            results = await asyncio.gather(*(getter() for _ in range(50)))
+            assert invocations == 1, (
+                f"Expected exactly one factory invocation under concurrent "
+                f"first-callers, saw {invocations}. This is the LML#241 FD-leak "
+                f"race — get_http_client needs an asyncio.Lock guard (via "
+                f"wxyc_fastapi.http.async_singleton)."
+            )
+            assert all(r is results[0] for r in results)
+        finally:
+            await closer()
+
+    @pytest.mark.asyncio
+    async def test_get_http_client_is_wired_via_async_singleton(self):
+        """Pin the wiring: rom's ``get_http_client`` and ``close_http_client``
+        must be the (getter, closer) pair returned by ``async_singleton``.
+
+        This catches a future regression where someone reverts to a hand-rolled
+        ``global _http_client`` pattern without the lock — the race-regression
+        test above would still pass (it tests the helper in isolation), but
+        rom would silently lose the FD-leak guard.
+        """
+        from wxyc_fastapi.http.singleton import async_singleton
+
+        import core.dependencies as deps
+
+        # The helper returns local closures defined in
+        # ``wxyc_fastapi.http.singleton`` with qualnames
+        # ``async_singleton.<locals>.getter`` / ``...closer``; both invariants
+        # together pin rom's getter/closer to this exact helper.
+        probe_getter, probe_closer = async_singleton(deps._make_http_client)
+        try:
+            assert deps.get_http_client.__module__ == probe_getter.__module__
+            assert deps.get_http_client.__qualname__ == probe_getter.__qualname__
+            assert deps.close_http_client.__module__ == probe_closer.__module__
+            assert deps.close_http_client.__qualname__ == probe_closer.__qualname__
+        finally:
+            await probe_closer()
+
 
 class TestCloseHttpClient:
     """Tests for close_http_client function."""
 
     @pytest.mark.asyncio
     async def test_closes_client(self):
-        """Test that close_http_client closes the client."""
-        import core.dependencies as deps
+        """Test that close_http_client closes the client and clears the singleton.
 
-        mock_client = AsyncMock()
-        deps._http_client = mock_client
+        After ``close_http_client()`` returns, the next ``get_http_client()``
+        call must build a fresh client via the factory — not return the
+        torn-down one. This is the closer-resets-state contract from
+        ``async_singleton``.
+        """
+        first = await get_http_client()
+        assert isinstance(first, httpx.AsyncClient)
+        assert first.is_closed is False
 
         await close_http_client()
+        assert first.is_closed is True
 
-        mock_client.aclose.assert_called_once()
-        assert deps._http_client is None
+        second = await get_http_client()
+        assert second is not first
+        assert second.is_closed is False
+        await close_http_client()
 
     @pytest.mark.asyncio
     async def test_handles_no_client(self):
-        """Test that close_http_client handles None client."""
-        import core.dependencies as deps
-
-        deps._http_client = None
-        await close_http_client()  # Should not raise
+        """Test that close_http_client is a no-op when never initialized."""
+        # The autouse fixture has already reset state; closer-before-getter
+        # must not raise.
+        await close_http_client()
 
 
 class TestGetGroqClient:


### PR DESCRIPTION
## Summary

Replaces rom's hand-rolled `_http_client` global + bare `is None` check with the `(getter, closer)` pair from `wxyc_fastapi.http.async_singleton(_make_http_client)` (v0.3.0). The helper enforces a double-check-lock so concurrent first-callers see exactly one factory invocation — preventing the FD-leak race that fired in [LML#241](https://github.com/WXYC/library-metadata-lookup/issues/241) and was first fixed in [LML#242](https://github.com/WXYC/library-metadata-lookup/pull/242).

This is **latent bug #2 of 3** from the [wxyc-fastapi plan §1.3](https://github.com/WXYC/wiki/blob/main/plans/wxyc-fastapi.md#13-latent-bugs-found-during-investigation). rom's pre-migration construction was synchronous so the race window was empty in practice, but the moment a future change adds an `await` between the `is None` check and the assignment (Sentry probe, custom auth, lazy DNS warmup), the race becomes real. Migrating now is preventive.

The shutdown wiring at `main.py:57` is unchanged: `await close_http_client()` now refers to the closer returned by the helper, which clears the cached instance and invokes `aclose` on the httpx client.

The autouse `reset_module_state` fixture in `tests/unit/test_dependencies.py` no longer pokes the removed `_http_client` global; it calls the new closer via a small `asyncio.run` wrapper. Two new tests pin the migration:

- `test_get_http_client_factory_invoked_once_under_concurrency` — port of the LML#241 reproducer adapted to rom: 50 concurrent first-callers must see one factory invocation. Removing the lock from `wxyc_fastapi.http.singleton` makes it report 50 invocations, confirming the test exercises the real race (verified locally).
- `test_get_http_client_is_wired_via_async_singleton` — pins the wiring itself: rom's `get_http_client` and `close_http_client` must be the `(getter, closer)` pair returned by the helper, guarding against a future revert to a hand-rolled global without the lock.

## Test plan

- [x] Local: `pytest tests/unit/` — 319 passed (was 317; +2 new regression tests)
- [x] Local: `ruff check .` — pass
- [x] Local: `ruff format --check .` — pass
- [x] Local: `mypy . --ignore-missing-imports` — pass
- [x] Local race verification: removed `async with lock:` from `wxyc_fastapi.http.singleton` and confirmed `test_get_http_client_factory_invoked_once_under_concurrency` reports 50 factory invocations; restored the lock and confirmed it reports 1.
- [x] Local: `import main` — module loads, `main.close_http_client.__qualname__ == 'async_singleton.<locals>.closer'`
- [ ] CI green
- [ ] Post-merge: production FD count remains stable for 7 days (acceptance criterion from #116)

## Related

- Closes #116
- Upstream helper: WXYC/wxyc-fastapi#5 (v0.3.0)
- Original race fix this propagates: WXYC/library-metadata-lookup#242
- Original incident: WXYC/library-metadata-lookup#241
- Plan: [wxyc-fastapi plan, §1.3 latent bugs](https://github.com/WXYC/wiki/blob/main/plans/wxyc-fastapi.md#13-latent-bugs-found-during-investigation)