### PR TITLE
Re-pin wxyc-fastapi to 1.0.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.25.0",
-    "wxyc-fastapi[posthog]>=0.3.0,<0.4.0",
+    "wxyc-fastapi[posthog]>=1.0.0,<2.0.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydantic>=2.0.0
 pydantic-settings>=2.0.0
 python-dotenv>=1.0.0
 httpx>=0.25.0
-wxyc-fastapi[posthog]>=0.3.0,<0.4.0
+wxyc-fastapi[posthog]>=1.0.0,<2.0.0


### PR DESCRIPTION
## Summary

Re-pin from `wxyc-fastapi[posthog]>=0.3.0,<0.4.0` to `>=1.0.0,<2.0.0` in both `pyproject.toml` and `requirements.txt`.

The wxyc-fastapi package [cut v1.0.0](https://github.com/WXYC/wxyc-fastapi/releases/tag/v1.0.0) alongside Phase E (db.lazy_pg) as a SemVer-stability signal — the package surface (observability, healthcheck, http.singleton, db.lazy_pg) is now considered settled. Per the [v1.0.0 CHANGELOG](https://github.com/WXYC/wxyc-fastapi/blob/main/CHANGELOG.md), the recommended consumer pin moves to `>=1.0.0,<2.0.0`.

## Why now

Closes the [wxyc-fastapi epic](https://github.com/WXYC/wxyc-fastapi/issues/1)'s "all three consumers depend on wxyc-fastapi 1.0.x" definition-of-done item. The http.singleton API rom uses is unchanged across the version bump — this is purely a pin update, no behavior change.

## Test plan

- [x] `uv sync --all-extras` — resolves to `wxyc-fastapi==1.0.0`
- [x] `uv run pytest tests/unit/` — 319 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — clean
- [ ] Post-deploy: confirm staging is healthy (Railway deploys aren't atomic).