### PR TITLE
ci: pin workflow-level GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -12,6 +12,13 @@ on:
   schedule:
     - cron: "17 8 * * 1"
 
+# The reusable workflow runs `npm pack @wxyc/shared` against npm.pkg.github.com,
+# so the GITHUB_TOKEN we pass in as `npm-token` needs packages:read. Other jobs
+# get no token writes by default.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   drift:
     uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches: [main, prod]
   workflow_dispatch:
 
+# Default GITHUB_TOKEN scope for every job in this workflow. None of these
+# jobs push code, comment on PRs, or create releases; the deploy jobs use
+# RAILWAY_TOKEN_* secrets, not GITHUB_TOKEN. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format

--- a/.github/workflows/external-api.yml
+++ b/.github/workflows/external-api.yml
@@ -21,6 +21,9 @@ on:
     # requests. To test against prod, run pytest locally with
     # TEST_ENV=production after disabling Slack posting.
 
+permissions:
+  contents: read
+
 jobs:
   external_api:
     name: External API Tests


### PR DESCRIPTION
Closes #131.

Adds a top-level `permissions:` block to every workflow so the GITHUB_TOKEN runs with a least-privilege scope pinned in code, instead of inheriting whatever the repo-wide default happens to be.

- `ci.yml`, `external-api.yml`: `contents: read`. Deploy jobs authenticate to Railway via `RAILWAY_TOKEN_*`; codecov uses `CODECOV_TOKEN`; no GITHUB_TOKEN writes anywhere.
- `charset-corpus-drift.yml`: `contents: read` + `packages: read`. The reusable workflow runs `npm pack @wxyc/shared` against npm.pkg.github.com using the token forwarded as `npm-token`.

Behavior-neutral today (no job writes via GITHUB_TOKEN) but pins the safe posture so future jobs can't silently inherit write scopes.

Part of the org-wide GitHub Actions hardening project (Phase 3).