### PR TITLE
Notify Slack when CI fails on `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,35 @@ jobs:
       workflows-dir: ".github/workflows"
       tests-dir: "tests"
 
+  notify-failure:
+    # Posts to Slack when any gating job fails on a `main` push, so a red CI
+    # run gets noticed in minutes instead of weeks (issue #123). Mirrors the
+    # `if: failure()` + raw-curl + skip-if-secret-unset pattern from
+    # discogs-etl/.github/workflows/rebuild-cache.yml. Scoped to `main` to
+    # match the issue; prod-deploy failures aren't covered yet.
+    name: Notify on CI failure
+    needs: [lint, typecheck, test, marker-sync, deploy-staging]
+    if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MONITORING_WEBHOOK }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMIT_URL: "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+          COMMIT_SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "SLACK_MONITORING_WEBHOOK unset; skipping Slack post."
+            exit 0
+          fi
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\":\":x: *request-o-matic CI failed on \`main\`*\nCommit: <$COMMIT_URL|$SHORT_SHA> by $ACTOR\nRun: $RUN_URL\"}" \
+            || true
+
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a `notify-failure` job to `ci.yml` that posts to Slack via `SLACK_MONITORING_WEBHOOK` whenever any gating job (lint, typecheck, test, marker-sync, deploy-staging) fails on a `main` push. Closes #123 — CI on `main` will no longer fail silently the way it did during the two-month `external_api` red-streak that prompted #118.

## Why this shape

- **Pattern reuse, not invention.** `discogs-etl/.github/workflows/rebuild-cache.yml` already established the `if: failure()` + raw-curl + skip-if-`SLACK_MONITORING_WEBHOOK`-unset shape (lines 208-225). Same secret name, same payload shell, same fail-soft behavior. Keeping it curl-only avoids adding a new GitHub Actions dependency to the supply-chain surface — relevant to #124's hardening menu.
- **Scope.** Issue #123 is scoped to `main`. The `if:` guard is `failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'`, so PR runs and `prod` pushes don't fire and a fully-green `main` run produces nothing.
- **Payload.** Short commit SHA + commit link + actor + run URL — the "better" payload called out in the issue. Actionable from Slack without first opening the Actions tab.
- **Open question deferred.** #123 also asked whether to extract this into a reusable workflow in `wxyc-shared` so other deploy-gated repos (Backend-Service, library-metadata-lookup, semantic-index, dj-site) can opt in with one line. Skipped for now — landing it in one repo first lets us see whether the payload + condition shape is right before forking it across five repos.

## Acceptance criteria mapping

- [x] Push to `main` that produces a red CI run triggers a notification within ~5 minutes of failure → `notify-failure` runs as soon as a `needs:` job fails; only added latency is the runner-allocation + curl round-trip (~30s typical).
- [x] Push to `main` that is green produces no notification → `if: failure()` only evaluates true when at least one needed job failed.
- [x] Notification includes a direct link to the failing run → `RUN_URL` env var built from `github.run_id`.
- [ ] Forced-failure smoke test confirming the alert fires and lands in the chosen channel → out of scope for this PR; recommend running a `workflow_dispatch` after the secret is wired.

## Open follow-ups (not in this PR)

- **Wire the secret.** This PR is no-op until `SLACK_MONITORING_WEBHOOK` is set as a repo or org secret. The skip-if-unset branch makes that a safe default.
- **Cover `prod` too?** A red production deploy is arguably more important than a red `main`. If the answer is "yes, both", the `if:` guard becomes `(github.ref == 'refs/heads/main' || github.ref == 'refs/heads/prod')`. Holding off because #123 is explicit about `main` scope.
- **Extract reusable workflow** into `wxyc-shared` if/when the second repo wants this — single-source-of-truth for the payload format.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses.
- [x] `actionlint .github/workflows/ci.yml` — clean.
- [x] Local sim of the unset-secret branch — exits 0 with the expected log line.
- [x] Local sim of the set-secret branch — payload round-trips through `python3 -m json.tool`, includes 7-char SHA, commit URL, actor, run URL.
- [ ] Forced failure on a throwaway branch after secret is wired (deferred — see acceptance criteria above).

## Related

- #123 (closed by this PR)
- #118 / #119 — the chronically-red `external_api` job whose two-month invisibility is the motivating evidence in #123.
- #124 — supply-chain hardening menu; the curl-only choice here keeps us off the SHA-pinning third-party-action treadmill.