### PR TITLE
ci: pin @railway/cli to 4.58.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Railway CLI
-        run: npm install -g @railway/cli
+        run: npm install -g @railway/cli@4.58.0
 
       - name: Deploy to Railway
         run: railway up --service request-o-matic
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Railway CLI
-        run: npm install -g @railway/cli
+        run: npm install -g @railway/cli@4.58.0
 
       - name: Deploy to Railway
         run: railway up --service request-o-matic


### PR DESCRIPTION
## Summary

- Pins `npm install -g @railway/cli` to exact version `4.58.0` in both `deploy-staging` and `deploy-production` jobs
- Trades floating npm `latest` for CI reproducibility — guards against silent CLI flag regressions breaking the deploy chain

Phase 5 of the WXYC org-wide GitHub Actions hardening project.

Closes #134.

## Test plan

- [ ] `deploy-staging` CI job succeeds on this PR (the install + `railway up --service request-o-matic` is the live test)
- [ ] Post-merge staging deploy succeeds