### PR TITLE
Trace Groq parse calls and surface SDK retries in Sentry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ If Slack itself fails the endpoint returns `502` — there is no further fallbac
 - `services/lookup_client.py` - HTTP client for library-metadata-lookup delegation
 - `services/slack.py` - Slack message formatting and posting
 - `core/dependencies.py` - FastAPI dependency injection (HTTP client, Groq, Slack, PostHog). Sentry, telemetry, cache stats, and PostHog client construction live in [`wxyc-fastapi`](https://github.com/WXYC/wxyc-fastapi); `core/dependencies.get_posthog_client` only wraps the shared singleton with the rom-side `enable_telemetry` flag.
+- `core/groq_tracing.py` - Sentry instrumentation for Groq parse calls: a `groq_parse_span` context manager wrapping `services.parser.parse_request` (op `ai.parse`, tagged with model, input length, token counts, and parse-result fields), and an `install_groq_retry_breadcrumbs()` filter on the `groq._base_client` logger that converts the SDK's silent 429-retry log lines into structured `groq.retry` breadcrumbs. Installed once from `main.py` after `init_sentry`.
 - `config/settings.py` - Pydantic Settings configuration
 
 ### Discogs Cache (Optional)

--- a/core/groq_tracing.py
+++ b/core/groq_tracing.py
@@ -1,0 +1,95 @@
+"""Sentry tracing helpers for Groq AI parse calls.
+
+Two pieces of instrumentation live here:
+
+1. ``groq_parse_span`` — context manager that opens an ``ai.parse`` span around
+   a single Groq chat-completions call. Tagged with model name, input length,
+   and (on success) token counts + parse-result fields. ``HttpxIntegration``
+   already emits one child span per HTTP attempt, so the ``ai.parse`` span
+   shows the 429-retry cadence as a series of child spans with sleep gaps
+   between them, under a single named parent that consumers can filter on
+   in Sentry's trace explorer.
+
+2. ``install_groq_retry_breadcrumbs`` — installs a logging.Filter on the
+   ``groq._base_client`` logger that converts ``Retrying request to <path>
+   in <n> seconds`` log lines into structured Sentry breadcrumbs (category
+   ``groq.retry``). This surfaces retry cadence on captured events even
+   when the surrounding trace is unsampled.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+from collections.abc import Iterator
+
+import sentry_sdk
+
+logger = logging.getLogger(__name__)
+
+GROQ_RETRY_LOGGER = "groq._base_client"
+
+# Matches the Groq SDK retry log: "Retrying request to /openai/v1/chat/completions in 8.000000 seconds"
+# Source: https://github.com/groq/groq-python/blob/main/src/groq/_base_client.py
+_RETRY_LOG_RE = re.compile(r"Retrying request to (\S+) in ([\d.]+) seconds")
+
+
+@contextlib.contextmanager
+def groq_parse_span(*, model: str, message: str) -> Iterator[sentry_sdk.tracing.Span]:
+    """Open an ``ai.parse`` span around a Groq chat-completions call.
+
+    The yielded span is pre-tagged with ``ai.model`` and the input message
+    length. Callers should additionally call ``span.set_data(...)`` for
+    output-side fields (parsed result, token counts) after a successful
+    Groq response.
+
+    When Sentry isn't initialized, ``sentry_sdk.start_span`` returns a no-op
+    span that swallows ``set_data`` silently, so this is safe to call
+    unconditionally.
+    """
+    with sentry_sdk.start_span(op="ai.parse", name="groq.parse") as span:
+        span.set_data("ai.model", model)
+        span.set_data("ai.input.message_length", len(message))
+        yield span
+
+
+class _GroqRetryBreadcrumbFilter(logging.Filter):
+    """logging.Filter that emits a Sentry breadcrumb for each retry log.
+
+    The filter never suppresses records (``filter()`` always returns ``True``);
+    it's a side-effecting hook, not a gate.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003 - logging API
+        message = record.getMessage()
+        match = _RETRY_LOG_RE.search(message)
+        if match is None:
+            return True
+
+        try:
+            sentry_sdk.add_breadcrumb(
+                category="groq.retry",
+                message=message,
+                level="warning",
+                data={
+                    "path": match.group(1),
+                    "retry_in_seconds": float(match.group(2)),
+                },
+            )
+        except Exception:
+            # Breadcrumb emission must never break logging itself.
+            pass
+        return True
+
+
+def install_groq_retry_breadcrumbs() -> None:
+    """Install the retry-breadcrumb filter on ``groq._base_client``.
+
+    Idempotent: a second call is a no-op.
+    """
+    target = logging.getLogger(GROQ_RETRY_LOGGER)
+    for existing in target.filters:
+        if isinstance(existing, _GroqRetryBreadcrumbFilter):
+            return
+    target.addFilter(_GroqRetryBreadcrumbFilter())

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from wxyc_fastapi.observability import flush_posthog, init_sentry, shutdown_post
 
 from config.settings import get_settings
 from core.dependencies import close_http_client
+from core.groq_tracing import install_groq_retry_breadcrumbs
 from core.logging import setup_logging
 from routers.health import build_readiness_router
 from routers.parse import router as parse_router
@@ -26,6 +27,8 @@ init_sentry(
     environment=settings.deployment_environment,
     release=settings.app_version,
 )
+
+install_groq_retry_breadcrumbs()
 
 # Configure logging
 # In production, log to /app/logs which is writable by appuser

--- a/services/parser.py
+++ b/services/parser.py
@@ -5,7 +5,11 @@ from enum import StrEnum
 from groq import AsyncGroq
 from pydantic import BaseModel
 
+from core.groq_tracing import groq_parse_span
+
 logger = logging.getLogger(__name__)
+
+GROQ_MODEL = "llama-3.1-8b-instant"
 
 
 class MessageType(StrEnum):
@@ -67,36 +71,48 @@ async def parse_request(message: str, client: AsyncGroq) -> ParsedRequest:
     """Parse a listener message and extract song request metadata."""
     logger.info(f"Parsing message: {message[:100]}...")
 
-    try:
-        response = await client.chat.completions.create(
-            model="llama-3.1-8b-instant",
-            messages=[
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": USER_PROMPT_TEMPLATE.format(message=message)},
-            ],
-            response_format={"type": "json_object"},
-            temperature=0.1,
-        )
+    with groq_parse_span(model=GROQ_MODEL, message=message) as span:
+        try:
+            response = await client.chat.completions.create(
+                model=GROQ_MODEL,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": USER_PROMPT_TEMPLATE.format(message=message)},
+                ],
+                response_format={"type": "json_object"},
+                temperature=0.1,
+            )
 
-        content = response.choices[0].message.content
-        if content is None:
-            raise ValueError("Empty response from Groq")
+            content = response.choices[0].message.content
+            if content is None:
+                raise ValueError("Empty response from Groq")
 
-        parsed = json.loads(content)
-        logger.debug(f"Raw parsed response: {parsed}")
+            parsed = json.loads(content)
+            logger.debug(f"Raw parsed response: {parsed}")
 
-        return ParsedRequest(
-            song=parsed.get("song"),
-            album=parsed.get("album"),
-            artist=parsed.get("artist"),
-            is_request=parsed.get("is_request", False),
-            message_type=parsed.get("message_type", MessageType.OTHER),
-            raw_message=message,
-        )
+            parsed_request = ParsedRequest(
+                song=parsed.get("song"),
+                album=parsed.get("album"),
+                artist=parsed.get("artist"),
+                is_request=parsed.get("is_request", False),
+                message_type=parsed.get("message_type", MessageType.OTHER),
+                raw_message=message,
+            )
 
-    except json.JSONDecodeError as e:
-        logger.error(f"Failed to parse JSON response: {e}")
-        raise ValueError(f"Invalid JSON response from Groq: {e}") from e
-    except Exception as e:
-        logger.error(f"Error parsing request: {e}")
-        raise
+            span.set_data("ai.output.is_request", parsed_request.is_request)
+            span.set_data("ai.output.message_type", parsed_request.message_type.value)
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                if getattr(usage, "prompt_tokens", None) is not None:
+                    span.set_data("ai.tokens.prompt", usage.prompt_tokens)
+                if getattr(usage, "completion_tokens", None) is not None:
+                    span.set_data("ai.tokens.completion", usage.completion_tokens)
+
+            return parsed_request
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse JSON response: {e}")
+            raise ValueError(f"Invalid JSON response from Groq: {e}") from e
+        except Exception as e:
+            logger.error(f"Error parsing request: {e}")
+            raise

--- a/tests/unit/test_groq_tracing.py
+++ b/tests/unit/test_groq_tracing.py
@@ -1,0 +1,257 @@
+"""Tests for Groq tracing instrumentation.
+
+Two pieces are exercised here:
+
+1. The ``ai.parse`` span opened around ``services.parser.parse_request``
+   (input/output tags + token counts).
+2. The ``groq._base_client`` logging filter that converts the Groq SDK's
+   "Retrying request to ... in N seconds" log line into a structured
+   Sentry breadcrumb.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from services.parser import parse_request
+
+
+def _groq_response(
+    content: dict | None = None,
+    prompt_tokens: int = 100,
+    completion_tokens: int = 10,
+) -> Mock:
+    """Build a Mock that looks like a Groq chat.completions response."""
+    if content is None:
+        content = {"is_request": True, "message_type": "request"}
+    response = Mock()
+    response.choices = [Mock()]
+    response.choices[0].message = Mock()
+    response.choices[0].message.content = json.dumps(content)
+    response.usage = Mock()
+    response.usage.prompt_tokens = prompt_tokens
+    response.usage.completion_tokens = completion_tokens
+    return response
+
+
+class TestAiParseSpan:
+    """The parser opens an `ai.parse` span around the Groq call, tags it with
+    model + input metadata, and (on success) annotates it with token counts
+    and the parsed result. Httpx child spans cover the actual HTTP attempts;
+    this parent span is the semantic container."""
+
+    @pytest.mark.asyncio
+    async def test_opens_ai_parse_span(self):
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=_groq_response())
+
+        with patch("core.groq_tracing.sentry_sdk.start_span") as mock_start_span:
+            mock_span = MagicMock()
+            mock_start_span.return_value.__enter__.return_value = mock_span
+
+            await parse_request("any message", client)
+
+            mock_start_span.assert_called_once()
+            kwargs = mock_start_span.call_args.kwargs
+            assert kwargs["op"] == "ai.parse"
+            assert kwargs["name"] == "groq.parse"
+
+    @pytest.mark.asyncio
+    async def test_span_tagged_with_input(self):
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=_groq_response())
+
+        with patch("core.groq_tracing.sentry_sdk.start_span") as mock_start_span:
+            mock_span = MagicMock()
+            mock_start_span.return_value.__enter__.return_value = mock_span
+
+            await parse_request("hello world", client)
+
+            mock_span.set_data.assert_any_call("ai.model", "llama-3.1-8b-instant")
+            mock_span.set_data.assert_any_call("ai.input.message_length", len("hello world"))
+
+    @pytest.mark.asyncio
+    async def test_span_tagged_with_output_fields(self):
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(
+            return_value=_groq_response(
+                content={
+                    "song": "la paradoja",
+                    "artist": "Juana Molina",
+                    "is_request": True,
+                    "message_type": "request",
+                },
+                prompt_tokens=150,
+                completion_tokens=20,
+            )
+        )
+
+        with patch("core.groq_tracing.sentry_sdk.start_span") as mock_start_span:
+            mock_span = MagicMock()
+            mock_start_span.return_value.__enter__.return_value = mock_span
+
+            await parse_request("play la paradoja by Juana Molina", client)
+
+            mock_span.set_data.assert_any_call("ai.output.is_request", True)
+            mock_span.set_data.assert_any_call("ai.output.message_type", "request")
+            mock_span.set_data.assert_any_call("ai.tokens.prompt", 150)
+            mock_span.set_data.assert_any_call("ai.tokens.completion", 20)
+
+    @pytest.mark.asyncio
+    async def test_span_still_opened_when_groq_raises(self):
+        """Span must wrap the call even on failure so the exception is captured
+        with the span context. We re-raise so the router's existing error
+        handling (degraded mode, etc.) keeps working."""
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch("core.groq_tracing.sentry_sdk.start_span") as mock_start_span:
+            mock_span = MagicMock()
+            mock_start_span.return_value.__enter__.return_value = mock_span
+
+            with pytest.raises(RuntimeError):
+                await parse_request("any", client)
+
+            mock_start_span.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_output_tags_when_groq_raises(self):
+        """Output tags are only set after a successful parse — never on the
+        error path. Otherwise a partial set of tags could mislead a reader
+        into thinking the parse succeeded."""
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch("core.groq_tracing.sentry_sdk.start_span") as mock_start_span:
+            mock_span = MagicMock()
+            mock_start_span.return_value.__enter__.return_value = mock_span
+
+            with pytest.raises(RuntimeError):
+                await parse_request("any", client)
+
+            output_calls = [
+                c
+                for c in mock_span.set_data.call_args_list
+                if c.args and c.args[0].startswith("ai.output")
+            ]
+            assert output_calls == []
+
+
+class TestGroqRetryBreadcrumbs:
+    """The Groq SDK silently retries 429/5xx via `time.sleep` inside
+    `_base_client`. Each retry emits a log line ``Retrying request to
+    <path> in <n> seconds``. We install a logging.Filter on that logger to
+    turn those lines into structured Sentry breadcrumbs so the retry cadence
+    shows up on captured events even if the surrounding trace is dropped."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_filters(self):
+        """Strip any previously-installed retry filters between tests, and
+        ensure the logger emits INFO so filters actually run (the Groq SDK
+        logs retries at INFO level; production sets the root level to INFO
+        via ``setup_logging``)."""
+        from core.groq_tracing import _GroqRetryBreadcrumbFilter
+
+        groq_logger = logging.getLogger("groq._base_client")
+        prior_level = groq_logger.level
+        groq_logger.setLevel(logging.INFO)
+        groq_logger.filters = [
+            f for f in groq_logger.filters if not isinstance(f, _GroqRetryBreadcrumbFilter)
+        ]
+        yield
+        groq_logger.filters = [
+            f for f in groq_logger.filters if not isinstance(f, _GroqRetryBreadcrumbFilter)
+        ]
+        groq_logger.setLevel(prior_level)
+
+    def test_install_adds_filter_to_groq_base_client_logger(self):
+        from core.groq_tracing import (
+            _GroqRetryBreadcrumbFilter,
+            install_groq_retry_breadcrumbs,
+        )
+
+        install_groq_retry_breadcrumbs()
+        groq_logger = logging.getLogger("groq._base_client")
+        assert any(isinstance(f, _GroqRetryBreadcrumbFilter) for f in groq_logger.filters)
+
+    def test_install_is_idempotent(self):
+        from core.groq_tracing import (
+            _GroqRetryBreadcrumbFilter,
+            install_groq_retry_breadcrumbs,
+        )
+
+        install_groq_retry_breadcrumbs()
+        install_groq_retry_breadcrumbs()
+
+        groq_logger = logging.getLogger("groq._base_client")
+        count = sum(1 for f in groq_logger.filters if isinstance(f, _GroqRetryBreadcrumbFilter))
+        assert count == 1
+
+    def test_retry_log_emits_breadcrumb_with_structured_data(self):
+        from core.groq_tracing import install_groq_retry_breadcrumbs
+
+        install_groq_retry_breadcrumbs()
+        groq_logger = logging.getLogger("groq._base_client")
+
+        with patch("core.groq_tracing.sentry_sdk.add_breadcrumb") as mock_add:
+            groq_logger.info("Retrying request to /openai/v1/chat/completions in 8.000000 seconds")
+
+        mock_add.assert_called_once()
+        kwargs = mock_add.call_args.kwargs
+        assert kwargs["category"] == "groq.retry"
+        assert kwargs["data"]["path"] == "/openai/v1/chat/completions"
+        assert kwargs["data"]["retry_in_seconds"] == 8.0
+
+    def test_non_retry_log_does_not_emit_breadcrumb(self):
+        from core.groq_tracing import install_groq_retry_breadcrumbs
+
+        install_groq_retry_breadcrumbs()
+        groq_logger = logging.getLogger("groq._base_client")
+
+        with patch("core.groq_tracing.sentry_sdk.add_breadcrumb") as mock_add:
+            groq_logger.info("Request to /openai/v1/chat/completions succeeded")
+            groq_logger.debug("Some other diagnostic message")
+
+        mock_add.assert_not_called()
+
+    def test_filter_returns_true_so_log_still_propagates(self):
+        """The filter must never suppress the underlying log record — it's a
+        breadcrumb emitter, not a log gate."""
+        from core.groq_tracing import _GroqRetryBreadcrumbFilter
+
+        f = _GroqRetryBreadcrumbFilter()
+        record = logging.LogRecord(
+            name="groq._base_client",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="Retrying request to /x in 1 seconds",
+            args=(),
+            exc_info=None,
+        )
+        assert f.filter(record) is True
+
+    def test_breadcrumb_emission_failure_does_not_break_logging(self):
+        """If Sentry isn't initialized or `add_breadcrumb` raises for any
+        reason, the log record must still propagate normally."""
+        from core.groq_tracing import _GroqRetryBreadcrumbFilter
+
+        f = _GroqRetryBreadcrumbFilter()
+        record = logging.LogRecord(
+            name="groq._base_client",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="Retrying request to /x in 1 seconds",
+            args=(),
+            exc_info=None,
+        )
+        with patch(
+            "core.groq_tracing.sentry_sdk.add_breadcrumb",
+            side_effect=RuntimeError("sentry not ready"),
+        ):
+            assert f.filter(record) is True


### PR DESCRIPTION
Closes #136.

## Summary

- New `core/groq_tracing.py` with two pieces of Sentry instrumentation:
  - `groq_parse_span(model, message)` — context manager that opens an `op=\"ai.parse\"`, `name=\"groq.parse\"` span around a Groq chat-completions call. Pre-tagged with `ai.model` + `ai.input.message_length`; on success the caller annotates `ai.output.is_request`, `ai.output.message_type`, `ai.tokens.prompt`, `ai.tokens.completion`. Output tags are skipped on the error path.
  - `install_groq_retry_breadcrumbs()` — idempotent installer that attaches a `logging.Filter` to `groq._base_client`. The filter regex-matches the SDK's `Retrying request to <path> in <n> seconds` log line and emits a structured `groq.retry` Sentry breadcrumb with `path` + `retry_in_seconds`. Filter always returns `True`; breadcrumb-emission errors are swallowed so logging can never break.
- `services/parser.py` wraps the `client.chat.completions.create(...)` call in `groq_parse_span(...)`; `GROQ_MODEL` lifted to a module constant so the span tag and the API call stay in sync.
- `main.py` calls `install_groq_retry_breadcrumbs()` once at startup right after `init_sentry`.
- `CLAUDE.md` adds a Key Files entry for the new module.

## Trace shape this produces

A slow parse (the original incident was ~22s — 21s of which was Groq SDK retry backoff after a TPM 429) shows as one `ai.parse` parent span containing three `http.client POST api.groq.com` child spans (429, 429, 200) with `time.sleep` gaps between them. Each retry also drops a `groq.retry` breadcrumb on the event with structured data, so the cadence is visible on captured errors even when the surrounding trace is unsampled.

## Test plan

- [x] `pytest tests/unit/` — 322 passing, including 11 new tests in `tests/unit/test_groq_tracing.py`:
  - Span op/name, input tags, output tags
  - Span still opened when Groq raises; no output tags written on the error path
  - Filter installation, idempotency, retry-log regex match, non-retry log no-op, breadcrumb-emission failure tolerated
- [x] `ruff format --check .` — clean
- [x] `ruff check .` — clean
- [x] `mypy . --ignore-missing-imports` — clean
- [ ] CI green on the deploy-staging job
- [ ] Manual: trigger a parse in staging, confirm an `ai.parse` span appears in Sentry with the expected tags and that Groq's HTTP attempts hang under it as children