### PR TITLE
Document CI pin maintenance (closes rom scope of #124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,9 @@ venv/bin/python scripts/repl.py --local
 Two pins in `.github/workflows/ci.yml` exist for supply-chain reasons (issue #124, free tier). They will bit-rot and need occasional bumps:
 
 - **`@railway/cli@<version>`** in the `Install Railway CLI` step of both `deploy-staging` and `deploy-production`. Failure mode is loud (deploy step fails with a CLI error). Bump by checking `npm view @railway/cli version` and updating both lines. Railway ships fast (~40 versions in 60 days as of 2026-05); pin "current" rather than chasing every release. Last bump: 57b2d8a (2026-05-12, pinned to 4.58.0).
-- **Workflow-level `permissions: contents: read`** on every workflow. Failure mode is silent (a job that needs e.g. `pull-requests: write` fails its API call but the workflow stays green). When adding a step that needs to comment on PRs, push tags, mint releases, etc., explicitly grant the scope at the job level — do not widen the workflow-level floor.
+- **Workflow-level `permissions:`** scoped to the minimum each workflow needs — `contents: read` for `ci.yml` and `external-api.yml`; `contents: read` plus `packages: read` for `charset-corpus-drift.yml` (which pulls `@wxyc/shared` from `npm.pkg.github.com`). Failure mode is silent (a job that needs e.g. `pull-requests: write` fails its API call but the workflow stays green). When adding a step that needs to comment on PRs, push tags, mint releases, etc., explicitly grant the scope at the job level — do not widen the workflow-level floor.
+
+Run `actionlint .github/workflows/*.yml` locally before pushing workflow changes; it validates `permissions:` syntax, action-version pins, and shell-script blocks, and catches the silent-mistake class of errors above before CI does.
 
 What is *not* pinned and why: the `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main` reference floats on `@main`. Item 2 in #124's free tier proposes pinning it to a versioned ref, but the iteration friction (release cut + N consumer bumps for every marker-sync change) currently outweighs the protection given how rarely marker-sync changes. Revisit if wxyc-etl push hygiene becomes a concern or if marker-sync stabilizes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,15 @@ venv/bin/python scripts/repl.py --local
 - `prod` branch auto-deploys to **production**
 - Use `railway` CLI for status/logs (requires TTY for some commands)
 
+### CI pin maintenance
+
+Two pins in `.github/workflows/ci.yml` exist for supply-chain reasons (issue #124, free tier). They will bit-rot and need occasional bumps:
+
+- **`@railway/cli@<version>`** in the `Install Railway CLI` step of both `deploy-staging` and `deploy-production`. Failure mode is loud (deploy step fails with a CLI error). Bump by checking `npm view @railway/cli version` and updating both lines. Railway ships fast (~40 versions in 60 days as of 2026-05); pin "current" rather than chasing every release. Last bump: 57b2d8a (2026-05-12, pinned to 4.58.0).
+- **Workflow-level `permissions: contents: read`** on every workflow. Failure mode is silent (a job that needs e.g. `pull-requests: write` fails its API call but the workflow stays green). When adding a step that needs to comment on PRs, push tags, mint releases, etc., explicitly grant the scope at the job level — do not widen the workflow-level floor.
+
+What is *not* pinned and why: the `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main` reference floats on `@main`. Item 2 in #124's free tier proposes pinning it to a versioned ref, but the iteration friction (release cut + N consumer bumps for every marker-sync change) currently outweighs the protection given how rarely marker-sync changes. Revisit if wxyc-etl push hygiene becomes a concern or if marker-sync stabilizes.
+
 ## Common Issues and Fixes
 
 Search logic (artist matching, ambiguous format handling, compilation search) lives in the [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) service. See that repo's documentation for details on false positive filtering, ambiguous format handling, and compilation search.


### PR DESCRIPTION
## Summary

Adds a short \"CI pin maintenance\" subsection to `CLAUDE.md` under Deployment. Closes the last open bullet of #124's acceptance criteria as scoped to this repo.

## State of #124 in rom (today)

| Item | Status | Where |
|---|---|---|
| 1. Workflow-level `permissions: contents: read` | ✓ done | `f654066` (all 3 workflows) |
| 2. Pin `wxyc-etl/check-ci-marker-sync.yml@main` | **deferred** | per the analysis we walked through; see runbook |
| 4. Pin `@railway/cli` to a specific version | ✓ done | `57b2d8a` (4.58.0 in both deploy jobs) |
| Runbook entry in `CLAUDE.md` | ✓ this PR | new subsection under Deployment |

## Why item 2 is deferred (captured in the runbook)

Pinning `wxyc-etl/check-ci-marker-sync.yml` from `@main` to a tag changes the iteration model on shared CI infra: every marker-sync change becomes a 4-step migration (edit wxyc-etl → cut release → open bump PRs in N consumers → merge each), instead of a one-line push that propagates immediately. Given how rarely marker-sync changes today, the friction outweighs the protection. The runbook flags the decision and the trigger conditions for revisiting (wxyc-etl push hygiene concern, or marker-sync stabilizing enough that the iteration friction stops mattering).

## Out of scope for this PR

- **Org-wide replication of items 1 + 4** to `library-metadata-lookup`, `Backend-Service`, `dj-site`, `semantic-index`. #124's Scope section explicitly says the same patterns should ship to every WXYC repo with a deploy gate on `main`. That's a separate cross-repo workstream — closing #124 from rom is appropriate for the rom-scoped work, but the broader org-wide effort needs its own tracking (existing #124 or a new org-level epic).

## Test plan

- [x] Markdown renders cleanly (no broken tables, no malformed lists).
- [x] No newline-wrapping inside paragraphs (per global formatting rule).
- [x] Cross-references to commit SHAs (`57b2d8a`) and the not-pinned reusable workflow path are accurate.