### PR TITLE
chore(ci): pin reusable workflows to gha/v1

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -24,6 +24,6 @@ jobs:
     uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1
     with:
       pinned-sha256: 41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66
-      package-version: "0.12.0"
+      package-version: "1.6.0"
     secrets:
       npm-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   drift:
-    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
+    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1
     with:
       pinned-sha256: 41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66
       package-version: "0.12.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
   marker-sync:
     # Verifies the pytest marker scheme stays in sync with this file. See
     # plans/test-patterns.md Section 3 ("Sync-check") for the invariant.
-    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@gha/v1
     with:
       repo-path: "."
       workflows-dir: ".github/workflows"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Two pins in `.github/workflows/ci.yml` exist for supply-chain reasons (issue #12
 
 Run `actionlint .github/workflows/*.yml` locally before pushing workflow changes; it validates `permissions:` syntax, action-version pins, and shell-script blocks, and catches the silent-mistake class of errors above before CI does.
 
-What is *not* pinned and why: the `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main` reference floats on `@main`. Item 2 in #124's free tier proposes pinning it to a versioned ref, but the iteration friction (release cut + N consumer bumps for every marker-sync change) currently outweighs the protection given how rarely marker-sync changes. Revisit if wxyc-etl push hygiene becomes a concern or if marker-sync stabilizes.
+Both reusable-workflow refs (`WXYC/wxyc-shared/.../check-charset-corpus-drift.yml` in `charset-corpus-drift.yml`, and `WXYC/wxyc-etl/.../check-ci-marker-sync.yml` in `ci.yml`) are pinned to `@gha/v1` — the publisher's moving major tag with a documented [Tag Stability Policy](https://github.com/WXYC/wxyc-shared/blob/main/CLAUDE.md#tag-stability-policy-read-before-editing-githubworkflows). Non-breaking changes move the tag forward; breaking changes cut `gha/v2` and require a consumer-side bump. Do not re-point either ref at `@main` — that re-introduces silent breakage from publisher changes.
 
 ## Common Issues and Fixes
 


### PR DESCRIPTION
## Summary

- Pin `WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml` from `@main` to `@gha/v1` in `charset-corpus-drift.yml`.
- Pin `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml` from `@main` to `@gha/v1` in `ci.yml` (`marker-sync` job).
- Update `CLAUDE.md` "CI pin maintenance" to remove the stale "marker-sync intentionally floats on @main" paragraph (the publisher now ships `gha/v1` with a documented non-breaking-move policy).

Closes #142.

Part of the org-wide hardening tracker [WXYC/wiki#68](https://github.com/WXYC/wiki/issues/68).

## Test plan

- [ ] CI green (both reusable workflows trigger and pass on `gha/v1`).
- [ ] `actionlint .github/workflows/*.yml` clean locally.