### PR TITLE
feat(admin): HTTP API for request-line fingerprint bans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ LML_API_KEY=
 # Error tracking (optional)
 SENTRY_DSN=
 
+# Admin API for request-line ban management (see docs/admin-bans.md).
+# When ADMIN_TOKEN is unset the endpoints fail-closed with 403; when the BS_
+# upstream vars are unset, /admin/bans returns 503.
+ADMIN_TOKEN=
+BS_INTERNAL_BANS_URL=https://api.wxyc.org/internal/banned-fingerprints
+BS_INTERNAL_KEY=
+
 # Discogs cache database (optional - reduces API calls)
 DATABASE_URL_DISCOGS=postgresql://user:pass@host:5432/discogs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ Request-O-Matic is a FastAPI service for WXYC radio that processes song requests
 CLAUDE.md is a router for the always-loaded reference card. Topic depth lives in `docs/`:
 
 - **[`docs/architecture.md`](docs/architecture.md)** — Request flow (parse → delegate → Slack), degraded modes (`parsing_unavailable`, `search_unavailable`), key files, optional Discogs PG cache, daily library.db ETL pipeline, pointer to LML for search-logic details
-- **[`docs/env-vars.md`](docs/env-vars.md)** — Full environment-variable reference (Groq, LML, Slack, Sentry, PostHog, telemetry/integration toggles)
+- **[`docs/env-vars.md`](docs/env-vars.md)** — Full environment-variable reference (Groq, LML, Slack, Sentry, PostHog, telemetry/integration toggles, admin-bans API)
+- **[`docs/admin-bans.md`](docs/admin-bans.md)** — Operator runbook for `/admin/bans` (request-line ban management): endpoints, curl examples, status codes, where to find a fingerprint. Both the HTTP admin router (#151) and the future Slack-native router (#152) share `services/ban_service.py`.
 - **[`docs/testing.md`](docs/testing.md)** — Unit / integration / performance test layout, pytest markers (`external_api`, `slow`, `contract`), TEST_ENV configuration, local server testing, bug-fix protocol
 - **[`docs/deployment.md`](docs/deployment.md)** — Railway hosting, branch → environment mapping, CI pin maintenance (Railway CLI version, workflow `permissions:`, `@gha/v1` reusable refs)
 - **[`docs/scripts.md`](docs/scripts.md)** — `scripts/lookup.py`, `scripts/repl.py`, `scripts/create_posthog_dashboard.py`

--- a/README.md
+++ b/README.md
@@ -155,11 +155,19 @@ docker-compose up
 
 ### Core Endpoints (v1)
 
-All endpoints except `/health` are prefixed with `/api/v1`:
+All endpoints except `/health` and `/admin/*` are prefixed with `/api/v1`:
 
 - `GET /health` - Health check with service status details (groq, lookup, slack)
 - `POST /api/v1/parse` - Parse a natural language song request into structured metadata
 - `POST /api/v1/request` - Full request workflow: parse -> delegate search to lookup service -> post to Slack
+
+### Admin Endpoints
+
+Request-line ban management (`Authorization: Bearer $ADMIN_TOKEN`). All writes are proxied to Backend-Service; request-o-matic owns no ban state. Full operator runbook in [`docs/admin-bans.md`](docs/admin-bans.md).
+
+- `POST /admin/bans` - Create or update a ban for a fingerprint (idempotent)
+- `DELETE /admin/bans/{fingerprint}` - Remove a ban (idempotent)
+- `GET /admin/bans` - List bans (keyset-paginated)
 
 ### Example Requests
 
@@ -295,6 +303,9 @@ If Slack integration fails:
 | `POSTHOG_API_KEY` | No | - | PostHog project API key for telemetry tracking |
 | `POSTHOG_HOST` | No | https://us.i.posthog.com | PostHog host URL |
 | `SENTRY_DSN` | No | - | Sentry DSN for error tracking |
+| `ADMIN_TOKEN` | No | - | Bearer token gating `/admin/bans`. Fail-closed when unset. |
+| `BS_INTERNAL_BANS_URL` | No | - | Base URL of Backend-Service's `/internal/banned-fingerprints` CRUD (BS#1261). |
+| `BS_INTERNAL_KEY` | No | - | Shared secret forwarded as `X-Internal-Key` on calls to BS internal endpoints. |
 
 ## Architecture
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -54,6 +54,34 @@ class Settings(BaseSettings):
         description="Bearer token sent to library-metadata-lookup. Required when LML has LML_REQUIRE_AUTH=true.",
     )
 
+    # Admin API (request-line ban management — request-o-matic#151)
+    # Co-located with the request-line surface so operators can curl/script
+    # bans against the same service they already know. Auth is a single shared
+    # bearer token; rom is a thin proxy and forwards writes to Backend-Service.
+    admin_token: str | None = Field(
+        None,
+        description=(
+            "Bearer token gating the /admin/bans endpoints. When unset, the "
+            "endpoints reject every request with 403 (fail-closed)."
+        ),
+    )
+    bs_internal_bans_url: str | None = Field(
+        None,
+        description=(
+            "Base URL of Backend-Service's /internal/banned-fingerprints CRUD "
+            "(BS#1261). Example: "
+            "'https://api.wxyc.org/internal/banned-fingerprints'."
+        ),
+    )
+    bs_internal_key: str | None = Field(
+        None,
+        description=(
+            "Shared secret forwarded as X-Internal-Key on calls to BS internal "
+            "endpoints (BS#1261 ROM_INTERNAL_KEY). Shared with the request-time "
+            "ban-check client (#150)."
+        ),
+    )
+
     # Application Metadata
     app_name: str = Field(default="Request-O-Matic", description="Application name")
     app_version: str = Field(default="1.0.0", description="Application version")

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import logging
 from typing import TYPE_CHECKING
 
@@ -207,8 +208,15 @@ def require_admin_token(
     if not authorization:
         raise HTTPException(status_code=401, detail="Missing authorization")
 
-    parts = authorization.split(" ", 1)
-    if len(parts) != 2 or parts[0].lower() != "bearer" or parts[1] != settings.admin_token:
+    parts = authorization.strip().split(None, 1)
+    # Encode to bytes so non-ASCII bearer values (which CPython's
+    # hmac.compare_digest rejects with TypeError on str) compare safely
+    # rather than escaping as an unhandled 500.
+    if (
+        len(parts) != 2
+        or parts[0].lower() != "bearer"
+        or not hmac.compare_digest(parts[1].encode("utf-8"), settings.admin_token.encode("utf-8"))
+    ):
         raise HTTPException(status_code=403, detail="Invalid token")
 
 

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -6,13 +6,14 @@ import logging
 from typing import TYPE_CHECKING
 
 import httpx
-from fastapi import Depends
+from fastapi import Depends, Header, HTTPException
 from groq import AsyncGroq
 from wxyc_fastapi.http import async_singleton
 from wxyc_fastapi.observability import get_posthog_client as _shared_posthog_client
 
 from config.settings import Settings, get_settings
 from core.exceptions import ServiceInitializationError
+from services.ban_admin_client import BanAdminClient
 from services.lookup_client import LookupServiceClient
 
 if TYPE_CHECKING:
@@ -180,3 +181,57 @@ async def get_slack_service(
     if webhook_url is None:
         return None
     return SlackService(webhook_url, http_client)
+
+
+def require_admin_token(
+    settings: Settings = Depends(get_settings),
+    authorization: str | None = Header(None),
+) -> None:
+    """Validate ``Authorization: Bearer <ADMIN_TOKEN>`` for admin endpoints.
+
+    Mirrors LML's ``routers/admin.py:_validate_auth`` so operators don't need
+    to learn two different bearer-token shapes between services. Status codes:
+
+    * ``ADMIN_TOKEN`` unset on the server -> 403 (fail-closed; the operator
+      should hear "disabled", not "you sent the wrong token").
+    * No ``Authorization`` header -> 401.
+    * Malformed scheme or wrong token -> 403.
+    * Correct bearer -> pass.
+    """
+    if not settings.admin_token:
+        raise HTTPException(
+            status_code=403,
+            detail="Admin endpoint disabled (no ADMIN_TOKEN set)",
+        )
+
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing authorization")
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer" or parts[1] != settings.admin_token:
+        raise HTTPException(status_code=403, detail="Invalid token")
+
+
+async def get_ban_admin_client(
+    settings: Settings = Depends(get_settings),
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+) -> BanAdminClient:
+    """Build a :class:`BanAdminClient` from settings, or 503 if misconfigured.
+
+    Both ``BS_INTERNAL_BANS_URL`` and ``BS_INTERNAL_KEY`` are required to talk
+    to Backend-Service. Surfacing the misconfiguration as 503 (not 500) tells
+    operators "the upstream isn't wired" rather than implying a bug in the
+    request they sent.
+    """
+    if not settings.bs_internal_bans_url or not settings.bs_internal_key:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Ban admin upstream not configured: set BS_INTERNAL_BANS_URL and BS_INTERNAL_KEY"
+            ),
+        )
+    return BanAdminClient(
+        settings.bs_internal_bans_url,
+        http_client,
+        internal_key=settings.bs_internal_key,
+    )

--- a/docs/admin-bans.md
+++ b/docs/admin-bans.md
@@ -1,0 +1,150 @@
+# Admin API — request-line fingerprint bans
+
+Three operator endpoints on request-o-matic for managing request-line bans. ROM is a thin proxy: ban state lives in Backend-Service (BS#1261 `banned_fingerprints` table). This API exists so operators can manage bans without writing SQL or learning Backend-Service's better-auth admin flow.
+
+## When to use this vs Slack-native ban (#152)
+
+The Slack-native action (filed at #152) is the primary operator UX once it lands — one click in the Slack post itself, no curl required. This HTTP API stays useful for: ad-hoc scripts, bulk operations, and as a backup if the Slack app has an outage.
+
+## Where to find a fingerprint
+
+When a listener's request post lands in Slack, the bot attaches the listener's fingerprint UUID to the message as metadata. Copy that value and pass it as the `fingerprint` field below. There is intentionally **no** "discover fingerprints" endpoint — operators identify a listener through the same Slack post they're already reacting to.
+
+## Authentication
+
+All three endpoints require:
+
+```
+Authorization: Bearer $ADMIN_TOKEN
+```
+
+The token is whatever's set as `ADMIN_TOKEN` on the Railway service. If unset on the server, every admin request is rejected with 403 (fail-closed). Rotate by updating the Railway variable; there is no per-user token.
+
+## Endpoints
+
+All paths are relative to the request-o-matic base URL — for production:
+```
+https://request-o-matic-production.up.railway.app
+```
+
+For staging:
+```
+https://request-o-matic-staging.up.railway.app
+```
+
+### POST /admin/bans — create or update a ban
+
+Idempotent. Re-banning an already-banned fingerprint succeeds with 200 and returns the updated record.
+
+Request body:
+
+```json
+{
+  "fingerprint": "11111111-2222-3333-4444-555555555555",
+  "reason": "spamming the request line",
+  "expires_in_seconds": 86400
+}
+```
+
+- `fingerprint` (string, required) — UUID copied from the Slack post metadata.
+- `reason` (string, required) — operator-visible reason. Capped at 1000 chars by Backend-Service.
+- `expires_in_seconds` (integer, optional) — auto-expiry. Omit for a permanent ban.
+
+Response (200):
+
+```json
+{
+  "fingerprint": "11111111-2222-3333-4444-555555555555",
+  "banned_at": "2026-05-31T18:00:00.000Z",
+  "ban_reason": "spamming the request line",
+  "ban_expires_at": "2026-06-01T18:00:00.000Z",
+  "banned_by_user_id": null
+}
+```
+
+`banned_by_user_id` is `null` for HTTP admin callers (they're identified only by `ADMIN_TOKEN`, not by an `auth_user.id`). The Slack-native router (#152) populates it.
+
+Curl:
+
+```bash
+curl -X POST "https://request-o-matic-production.up.railway.app/admin/bans" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fingerprint": "11111111-2222-3333-4444-555555555555",
+    "reason": "spamming the request line",
+    "expires_in_seconds": 86400
+  }'
+```
+
+### DELETE /admin/bans/{fingerprint} — remove a ban
+
+Idempotent. Unbanning a fingerprint that isn't banned still returns 204. Returns 204 with no body on success.
+
+Curl:
+
+```bash
+curl -X DELETE \
+  "https://request-o-matic-production.up.railway.app/admin/bans/11111111-2222-3333-4444-555555555555" \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+### GET /admin/bans — list bans (keyset-paginated)
+
+Query params:
+
+- `limit` (integer, optional, default 50, range 1–200) — max items per page.
+- `cursor` (string, optional) — opaque cursor from a prior response's `nextCursor`.
+
+Response (200):
+
+```json
+{
+  "items": [
+    {
+      "fingerprint": "11111111-2222-3333-4444-555555555555",
+      "banned_at": "2026-05-31T18:00:00.000Z",
+      "ban_reason": "spamming the request line",
+      "ban_expires_at": null,
+      "banned_by_user_id": null
+    }
+  ],
+  "nextCursor": "2026-05-31T18:00:00.000Z|11111111-2222-3333-4444-555555555555"
+}
+```
+
+`nextCursor` is `null` on the last page. To fetch the next page, pass it back verbatim.
+
+Curl:
+
+```bash
+curl -G "https://request-o-matic-production.up.railway.app/admin/bans" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  --data-urlencode "limit=25"
+```
+
+## Status codes
+
+| Code | When | What to do |
+|------|------|------------|
+| 200 / 204 | Success | — |
+| 400 | Malformed input (bad UUID, empty reason, expired-at out of range) | Fix the request body and retry |
+| 401 | Missing `Authorization` header | Add the bearer header |
+| 403 | Wrong token, or `ADMIN_TOKEN` not configured server-side | Check the token; if disabled, set `ADMIN_TOKEN` on the Railway service |
+| 422 | FastAPI rejected a query param (e.g. `limit=500`) | Use a valid value |
+| 502 | Backend-Service upstream returned 5xx | Check BS health; retry after |
+| 503 | `BS_INTERNAL_BANS_URL` or `BS_INTERNAL_KEY` not configured | Set the missing env var on the Railway service |
+
+## Environment variables
+
+See [`docs/env-vars.md`](env-vars.md) for the canonical reference. The three vars this API needs:
+
+- `ADMIN_TOKEN` — bearer for the operator side.
+- `BS_INTERNAL_BANS_URL` — base URL of BS's CRUD.
+- `BS_INTERNAL_KEY` — shared secret with BS's `ROM_INTERNAL_KEY`.
+
+## Related
+
+- Storage: [WXYC/Backend-Service#1261](https://github.com/WXYC/Backend-Service/issues/1261) — `banned_fingerprints` table + `/internal/banned-fingerprints` CRUD.
+- Request-time enforcement: [#150](https://github.com/WXYC/request-o-matic/issues/150).
+- Slack-native ban (planned): [#152](https://github.com/WXYC/request-o-matic/issues/152).

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -13,3 +13,8 @@ Optional:
 - `POSTHOG_HOST` - PostHog host URL (default: `https://us.i.posthog.com`)
 - `ENABLE_SLACK_INTEGRATION` - Enable/disable Slack notifications (default: `true`)
 - `ENABLE_TELEMETRY` - Enable/disable PostHog telemetry (default: `true`)
+
+Admin API for request-line bans (see [`docs/admin-bans.md`](admin-bans.md)):
+- `ADMIN_TOKEN` - Bearer token gating the `/admin/bans` endpoints. When unset, every admin request is rejected with 403 (fail-closed). Rotate by updating the Railway service variable.
+- `BS_INTERNAL_BANS_URL` - Base URL of Backend-Service's `/internal/banned-fingerprints` CRUD (BS#1261). Example: `https://api.wxyc.org/internal/banned-fingerprints`. When unset, `/admin/bans` returns 503.
+- `BS_INTERNAL_KEY` - Shared secret forwarded as `X-Internal-Key` on calls to BS internal endpoints. Must equal `ROM_INTERNAL_KEY` on the BS side. Shared with the request-time ban-check client.

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from config.settings import get_settings
 from core.dependencies import close_http_client
 from core.groq_tracing import install_groq_retry_breadcrumbs
 from core.logging import setup_logging
+from routers.admin import router as admin_router
 from routers.health import build_readiness_router
 from routers.parse import router as parse_router
 from routers.request import router as request_router
@@ -90,6 +91,11 @@ app.include_router(request_router, prefix="/api/v1", tags=["request"])
 # Backwards compatibility - mount at root as well
 app.include_router(parse_router, prefix="", tags=["parse-legacy"])
 app.include_router(request_router, prefix="", tags=["request-legacy"])
+
+# Admin API for request-line ban management (#151). Mounted at root so the
+# routes are reachable as ``/admin/bans`` — operators don't think about the
+# ``/api/v1`` prefix for admin tooling.
+app.include_router(admin_router)
 
 if __name__ == "__main__":
     import uvicorn

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -20,20 +20,34 @@ Operator runbook: see `docs/admin-bans.md`.
 from __future__ import annotations
 
 import logging
+from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Response
+from pydantic import BaseModel, ConfigDict, Field
 
 from core.dependencies import get_ban_admin_client, require_admin_token
 from services import ban_service
 from services.ban_admin_client import BanAdminClient, BanAdminClientError
+
+# BS-side 4xx statuses that reflect rom->BS hop configuration or pacing failures
+# rather than the operator's request itself. Forwarding these verbatim would
+# confuse the operator (BS 401 != rom 401; BS 429 != rom rate-limited the operator).
+# Map them all to 502 (the upstream is misbehaving from rom's perspective).
+_UPSTREAM_FAULT_4XX = frozenset({401, 403, 429})
+
+
+def _redact_fingerprint(fingerprint: str) -> str:
+    """First 8 chars for logs/traces. The full UUID is a stable per-device
+    identifier and shouldn't sit in plaintext in long-retention sinks."""
+    return f"{fingerprint[:8]}..."
+
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin/bans", tags=["admin"])
 
 
-class _BanCreateRequest(BaseModel):
+class BanCreateRequest(BaseModel):
     """Body for ``POST /admin/bans``.
 
     Mirrors BS's input shape but uses snake_case (rom-side convention) and
@@ -41,32 +55,49 @@ class _BanCreateRequest(BaseModel):
     boundary. ``actor`` is omitted because HTTP-admin callers are identified
     only by ``ADMIN_TOKEN``; if a future surface needs to forward an actor,
     add the field then.
+
+    ``extra='forbid'`` so operator typos like ``banned_by_user_id`` or
+    ``expiresInSeconds`` (camelCase from the BS docs) surface as 422 rather
+    than being silently dropped.
     """
 
-    fingerprint: str = Field(
+    model_config = ConfigDict(extra="forbid")
+
+    fingerprint: UUID = Field(
         ...,
-        description="iOS-Keychain UUID identifying the listener device to ban.",
+        description=(
+            "iOS-Keychain UUID identifying the listener device to ban. Any "
+            "UUID version is accepted (matches BS's permissive regex)."
+        ),
     )
     reason: str = Field(
         ...,
+        min_length=1,
+        max_length=1000,
         description="Operator-visible reason. Surfaced in Slack/admin UIs.",
     )
     expires_in_seconds: int | None = Field(
         None,
-        description="Optional auto-expiry. Omit for a permanent ban.",
+        gt=0,
+        description="Optional auto-expiry (seconds). Omit for a permanent ban.",
     )
 
 
 def _map_upstream_error(exc: BanAdminClientError) -> HTTPException:
     """Translate a BS-side rejection into an operator-friendly HTTPException.
 
-    * 4xx -> forward verbatim so operator typos surface as 400, etc.
+    * Transport failure (status 0) -> 502 ('upstream unreachable').
     * 5xx -> 502 (the upstream itself failed; this service is fine).
+    * BS 401/403/429 -> 502 (these reflect the rom->BS hop, not the operator
+      -> rom request; forwarding them verbatim conflates two auth/rate
+      layers and misleads the operator).
+    * Other 4xx (400, 404, 422, ...) -> forward verbatim so operator typos
+      surface cleanly.
     """
     detail = {"upstream_status": exc.status_code, "upstream_body": exc.body}
-    if 400 <= exc.status_code < 500:
-        return HTTPException(status_code=exc.status_code, detail=detail)
-    return HTTPException(status_code=502, detail=detail)
+    if exc.status_code == 0 or exc.status_code >= 500 or exc.status_code in _UPSTREAM_FAULT_4XX:
+        return HTTPException(status_code=502, detail=detail)
+    return HTTPException(status_code=exc.status_code, detail=detail)
 
 
 @router.post(
@@ -78,7 +109,10 @@ def _map_upstream_error(exc: BanAdminClientError) -> HTTPException:
     ),
     responses={
         200: {"description": "Ban created or updated"},
-        400: {"description": "Invalid fingerprint, reason, or expires_in_seconds"},
+        400: {"description": "BS-side validation failure (forwarded verbatim)"},
+        422: {
+            "description": "Local validation failure (bad UUID, empty reason, expires_in_seconds<=0, or unknown field)"
+        },
         401: {"description": "Missing authorization"},
         403: {"description": "Invalid or missing admin token"},
         502: {"description": "Backend-Service upstream error"},
@@ -86,15 +120,16 @@ def _map_upstream_error(exc: BanAdminClientError) -> HTTPException:
     },
 )
 async def create_ban(
-    body: _BanCreateRequest = Body(...),
+    body: BanCreateRequest = Body(...),
     _: None = Depends(require_admin_token),
     client: BanAdminClient = Depends(get_ban_admin_client),
 ) -> dict:
     """POST /admin/bans — create or update a ban via Backend-Service."""
+    fingerprint_str = str(body.fingerprint)
     try:
         row = await ban_service.ban(
             client,
-            fingerprint=body.fingerprint,
+            fingerprint=fingerprint_str,
             reason=body.reason,
             actor=None,  # HTTP-admin callers have no auth_user.id
             expires_in_seconds=body.expires_in_seconds,
@@ -102,7 +137,7 @@ async def create_ban(
     except BanAdminClientError as exc:
         logger.warning(
             "create_ban upstream error fingerprint=%s status=%d body=%r",
-            body.fingerprint,
+            _redact_fingerprint(fingerprint_str),
             exc.status_code,
             exc.body,
         )
@@ -120,7 +155,7 @@ async def create_ban(
     ),
     responses={
         204: {"description": "Ban removed (or never existed)"},
-        400: {"description": "Malformed fingerprint UUID"},
+        422: {"description": "Path fingerprint is not a valid UUID"},
         401: {"description": "Missing authorization"},
         403: {"description": "Invalid or missing admin token"},
         502: {"description": "Backend-Service upstream error"},
@@ -128,17 +163,18 @@ async def create_ban(
     },
 )
 async def delete_ban(
-    fingerprint: str,
+    fingerprint: UUID = Path(..., description="UUID of the fingerprint to unban."),
     _: None = Depends(require_admin_token),
     client: BanAdminClient = Depends(get_ban_admin_client),
 ) -> Response:
     """DELETE /admin/bans/{fingerprint} — remove a ban via Backend-Service."""
+    fingerprint_str = str(fingerprint)
     try:
-        await ban_service.unban(client, fingerprint=fingerprint, actor=None)
+        await ban_service.unban(client, fingerprint=fingerprint_str, actor=None)
     except BanAdminClientError as exc:
         logger.warning(
             "delete_ban upstream error fingerprint=%s status=%d body=%r",
-            fingerprint,
+            _redact_fingerprint(fingerprint_str),
             exc.status_code,
             exc.body,
         )
@@ -157,7 +193,7 @@ async def delete_ban(
     ),
     responses={
         200: {"description": "List of bans"},
-        400: {"description": "Invalid limit or cursor"},
+        422: {"description": "Local validation failure (limit outside 1-200)"},
         401: {"description": "Missing authorization"},
         403: {"description": "Invalid or missing admin token"},
         502: {"description": "Backend-Service upstream error"},

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1,0 +1,182 @@
+"""Admin HTTP API for request-line fingerprint bans (request-o-matic#151).
+
+Three endpoints under ``/admin/bans``, all gated by
+``Authorization: Bearer <ADMIN_TOKEN>``. ROM is a thin proxy — it owns no ban
+state. Every write goes to Backend-Service's ``/internal/banned-fingerprints``
+CRUD (BS#1261) via :mod:`services.ban_service` and :mod:`services.ban_admin_client`.
+
+Idempotency is preserved end-to-end:
+
+* POST a ban for an already-banned fingerprint -> 200 with the updated row.
+* DELETE a ban for a non-existent fingerprint -> 204.
+
+The future Slack-native ban router (#152) will reuse the same
+:mod:`services.ban_service` functions so the two operator UXes don't drift
+apart.
+
+Operator runbook: see `docs/admin-bans.md`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
+from pydantic import BaseModel, Field
+
+from core.dependencies import get_ban_admin_client, require_admin_token
+from services import ban_service
+from services.ban_admin_client import BanAdminClient, BanAdminClientError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/bans", tags=["admin"])
+
+
+class _BanCreateRequest(BaseModel):
+    """Body for ``POST /admin/bans``.
+
+    Mirrors BS's input shape but uses snake_case (rom-side convention) and
+    converts to BS's ``expiresInSeconds`` camelCase at the BanAdminClient
+    boundary. ``actor`` is omitted because HTTP-admin callers are identified
+    only by ``ADMIN_TOKEN``; if a future surface needs to forward an actor,
+    add the field then.
+    """
+
+    fingerprint: str = Field(
+        ...,
+        description="iOS-Keychain UUID identifying the listener device to ban.",
+    )
+    reason: str = Field(
+        ...,
+        description="Operator-visible reason. Surfaced in Slack/admin UIs.",
+    )
+    expires_in_seconds: int | None = Field(
+        None,
+        description="Optional auto-expiry. Omit for a permanent ban.",
+    )
+
+
+def _map_upstream_error(exc: BanAdminClientError) -> HTTPException:
+    """Translate a BS-side rejection into an operator-friendly HTTPException.
+
+    * 4xx -> forward verbatim so operator typos surface as 400, etc.
+    * 5xx -> 502 (the upstream itself failed; this service is fine).
+    """
+    detail = {"upstream_status": exc.status_code, "upstream_body": exc.body}
+    if 400 <= exc.status_code < 500:
+        return HTTPException(status_code=exc.status_code, detail=detail)
+    return HTTPException(status_code=502, detail=detail)
+
+
+@router.post(
+    "",
+    summary="Ban a fingerprint",
+    description=(
+        "Create or update a ban on the given fingerprint. Idempotent: re-banning "
+        "an already-banned fingerprint returns 200 with the updated record."
+    ),
+    responses={
+        200: {"description": "Ban created or updated"},
+        400: {"description": "Invalid fingerprint, reason, or expires_in_seconds"},
+        401: {"description": "Missing authorization"},
+        403: {"description": "Invalid or missing admin token"},
+        502: {"description": "Backend-Service upstream error"},
+        503: {"description": "Ban admin upstream not configured"},
+    },
+)
+async def create_ban(
+    body: _BanCreateRequest = Body(...),
+    _: None = Depends(require_admin_token),
+    client: BanAdminClient = Depends(get_ban_admin_client),
+) -> dict:
+    """POST /admin/bans — create or update a ban via Backend-Service."""
+    try:
+        row = await ban_service.ban(
+            client,
+            fingerprint=body.fingerprint,
+            reason=body.reason,
+            actor=None,  # HTTP-admin callers have no auth_user.id
+            expires_in_seconds=body.expires_in_seconds,
+        )
+    except BanAdminClientError as exc:
+        logger.warning(
+            "create_ban upstream error fingerprint=%s status=%d body=%r",
+            body.fingerprint,
+            exc.status_code,
+            exc.body,
+        )
+        raise _map_upstream_error(exc) from exc
+    return row
+
+
+@router.delete(
+    "/{fingerprint}",
+    status_code=204,
+    summary="Unban a fingerprint",
+    description=(
+        "Remove a ban on the given fingerprint. Idempotent: unbanning a "
+        "fingerprint that isn't banned still returns 204."
+    ),
+    responses={
+        204: {"description": "Ban removed (or never existed)"},
+        400: {"description": "Malformed fingerprint UUID"},
+        401: {"description": "Missing authorization"},
+        403: {"description": "Invalid or missing admin token"},
+        502: {"description": "Backend-Service upstream error"},
+        503: {"description": "Ban admin upstream not configured"},
+    },
+)
+async def delete_ban(
+    fingerprint: str,
+    _: None = Depends(require_admin_token),
+    client: BanAdminClient = Depends(get_ban_admin_client),
+) -> Response:
+    """DELETE /admin/bans/{fingerprint} — remove a ban via Backend-Service."""
+    try:
+        await ban_service.unban(client, fingerprint=fingerprint, actor=None)
+    except BanAdminClientError as exc:
+        logger.warning(
+            "delete_ban upstream error fingerprint=%s status=%d body=%r",
+            fingerprint,
+            exc.status_code,
+            exc.body,
+        )
+        raise _map_upstream_error(exc) from exc
+    return Response(status_code=204)
+
+
+@router.get(
+    "",
+    summary="List bans (keyset-paginated)",
+    description=(
+        "List currently banned fingerprints. Pagination shape matches "
+        "Backend-Service: ``{items, nextCursor}``. Pass ``cursor`` from a "
+        "previous response to fetch the next page; ``nextCursor`` is null on "
+        "the last page."
+    ),
+    responses={
+        200: {"description": "List of bans"},
+        400: {"description": "Invalid limit or cursor"},
+        401: {"description": "Missing authorization"},
+        403: {"description": "Invalid or missing admin token"},
+        502: {"description": "Backend-Service upstream error"},
+        503: {"description": "Ban admin upstream not configured"},
+    },
+)
+async def list_bans(
+    limit: int | None = Query(None, ge=1, le=200, description="Max items per page (1-200)."),
+    cursor: str | None = Query(None, description="Opaque pagination cursor from a prior response."),
+    _: None = Depends(require_admin_token),
+    client: BanAdminClient = Depends(get_ban_admin_client),
+) -> dict:
+    """GET /admin/bans — list bans via Backend-Service."""
+    try:
+        return await ban_service.list_bans(client, limit=limit, cursor=cursor)
+    except BanAdminClientError as exc:
+        logger.warning(
+            "list_bans upstream error status=%d body=%r",
+            exc.status_code,
+            exc.body,
+        )
+        raise _map_upstream_error(exc) from exc

--- a/services/ban_admin_client.py
+++ b/services/ban_admin_client.py
@@ -1,0 +1,152 @@
+"""HTTP client for Backend-Service's internal banned-fingerprints CRUD (BS#1261).
+
+This is the *only* place in rom that talks to BS's `/internal/banned-fingerprints`
+endpoints. Both the HTTP admin router (#151) and the future Slack-native ban
+router (#152) go through `services/ban_service.py`, which in turn uses this
+client. Keeping all BS-shaped concerns here means a contract change on the BS
+side (added field, renamed query param, etc.) touches one file.
+
+Response shapes mirror BS exactly — see
+`apps/backend/routes/internal-bans.route.ts` for the source of truth:
+
+* POST `/` returns 200 with the upserted row (`fingerprint`, `banned_at`,
+  `ban_reason`, `ban_expires_at`, `banned_by_user_id`). Idempotent: a re-ban
+  with the same fingerprint succeeds and returns the updated state.
+* DELETE `/{fingerprint}` returns 204 with no body. Idempotent: deleting a
+  non-existent fingerprint also returns 204.
+* GET `/?limit=&cursor=` returns 200 with `{items, nextCursor}` (keyset
+  pagination on `(banned_at DESC, fingerprint DESC)`).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class BanAdminClientError(Exception):
+    """Raised when BS rejects an admin call with a 4xx/5xx response.
+
+    Carries the upstream status code and (best-effort decoded) body so the
+    router can surface a faithful status code to the operator instead of
+    masking everything as 500.
+    """
+
+    def __init__(self, status_code: int, body: Any):
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"Backend-Service returned {status_code}: {body!r}")
+
+
+class BanAdminClient:
+    """Thin async client for Backend-Service's banned-fingerprints CRUD.
+
+    Args:
+        base_url: BS endpoint base URL (no trailing slash required). Example:
+            ``https://api.wxyc.org/internal/banned-fingerprints``.
+        http_client: Shared :class:`httpx.AsyncClient` (same singleton used by
+            the lookup client).
+        internal_key: Value of ``ROM_INTERNAL_KEY`` on the BS side. Sent as
+            the ``X-Internal-Key`` header on every request.
+        timeout: Per-call timeout in seconds. BS admin endpoints are simple
+            single-row CRUD against a small table; 10s is generous.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        http_client: httpx.AsyncClient,
+        *,
+        internal_key: str,
+        timeout: float = 10.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.http_client = http_client
+        self.internal_key = internal_key
+        self.timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-Internal-Key": self.internal_key}
+
+    @staticmethod
+    def _decode_body(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
+
+    async def ban(
+        self,
+        *,
+        fingerprint: str,
+        reason: str,
+        expires_in_seconds: int | None = None,
+        banned_by_user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create or update a ban (BS idempotent upsert).
+
+        Returns the upserted row as a dict. The BS endpoint validates the
+        fingerprint UUID shape, the non-empty reason, and the positive
+        ``expiresInSeconds`` — invalid input surfaces as a 400 wrapped in
+        :class:`BanAdminClientError` rather than silently succeeding.
+        """
+        payload: dict[str, Any] = {"fingerprint": fingerprint, "reason": reason}
+        if expires_in_seconds is not None:
+            payload["expiresInSeconds"] = expires_in_seconds
+        if banned_by_user_id is not None:
+            payload["bannedByUserId"] = banned_by_user_id
+
+        response = await self.http_client.post(
+            self.base_url,
+            json=payload,
+            headers=self._headers(),
+            timeout=self.timeout,
+        )
+        if response.status_code != 200:
+            raise BanAdminClientError(response.status_code, self._decode_body(response))
+        return response.json()  # type: ignore[no-any-return]
+
+    async def unban(self, *, fingerprint: str) -> None:
+        """Delete a ban. Idempotent — succeeds whether or not the row existed.
+
+        Returns None. Raises :class:`BanAdminClientError` for any non-204
+        response (including 400 for a malformed fingerprint).
+        """
+        response = await self.http_client.delete(
+            f"{self.base_url}/{fingerprint}",
+            headers=self._headers(),
+            timeout=self.timeout,
+        )
+        if response.status_code != 204:
+            raise BanAdminClientError(response.status_code, self._decode_body(response))
+
+    async def list_bans(
+        self,
+        *,
+        limit: int | None = None,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """List bans (keyset-paginated). Returns ``{items, nextCursor}``.
+
+        Both query params are optional and forwarded verbatim — BS defaults
+        ``limit=50`` and rejects values outside ``[1, 200]``.
+        """
+        params: dict[str, str] = {}
+        if limit is not None:
+            params["limit"] = str(limit)
+        if cursor is not None:
+            params["cursor"] = cursor
+
+        response = await self.http_client.get(
+            self.base_url,
+            params=params,
+            headers=self._headers(),
+            timeout=self.timeout,
+        )
+        if response.status_code != 200:
+            raise BanAdminClientError(response.status_code, self._decode_body(response))
+        return response.json()  # type: ignore[no-any-return]

--- a/services/ban_admin_client.py
+++ b/services/ban_admin_client.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -29,7 +30,13 @@ logger = logging.getLogger(__name__)
 
 
 class BanAdminClientError(Exception):
-    """Raised when BS rejects an admin call with a 4xx/5xx response.
+    """Raised when BS rejects an admin call with a 4xx/5xx response, OR when
+    the rom->BS hop fails at the transport layer (DNS, TLS, connect-refused,
+    socket timeout).
+
+    Transport-layer failures are reported with ``status_code=0`` so the router
+    can render them as 502 (upstream unreachable) rather than letting the raw
+    httpx exception escape as 500.
 
     Carries the upstream status code and (best-effort decoded) body so the
     router can surface a faithful status code to the operator instead of
@@ -79,6 +86,23 @@ class BanAdminClient:
         except ValueError:
             return response.text
 
+    @staticmethod
+    def _safe_json(response: httpx.Response) -> Any:
+        """Decode a 2xx body, raising BanAdminClientError if it isn't JSON.
+
+        BS contract is JSON-on-success, but a reverse proxy or content-type
+        drift could return a 200 with HTML/text. Without this guard the bare
+        ``response.json()`` would raise ``json.JSONDecodeError`` and escape
+        the router's ``except BanAdminClientError`` as an unhandled 500.
+        """
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise BanAdminClientError(
+                response.status_code,
+                {"error": "non_json_upstream_body", "text": response.text[:200]},
+            ) from exc
+
     async def ban(
         self,
         *,
@@ -100,27 +124,42 @@ class BanAdminClient:
         if banned_by_user_id is not None:
             payload["bannedByUserId"] = banned_by_user_id
 
-        response = await self.http_client.post(
-            self.base_url,
-            json=payload,
-            headers=self._headers(),
-            timeout=self.timeout,
-        )
-        if response.status_code != 200:
+        try:
+            response = await self.http_client.post(
+                self.base_url,
+                json=payload,
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+        except httpx.HTTPError as exc:
+            raise BanAdminClientError(
+                0, {"error": "upstream_unreachable", "detail": str(exc)}
+            ) from exc
+        if not 200 <= response.status_code < 300:
             raise BanAdminClientError(response.status_code, self._decode_body(response))
-        return response.json()  # type: ignore[no-any-return]
+        return self._safe_json(response)  # type: ignore[no-any-return]
 
     async def unban(self, *, fingerprint: str) -> None:
         """Delete a ban. Idempotent — succeeds whether or not the row existed.
 
         Returns None. Raises :class:`BanAdminClientError` for any non-204
         response (including 400 for a malformed fingerprint).
+
+        ``fingerprint`` is URL-quoted so a caller that bypasses the FastAPI
+        path-param validator (e.g. the future Slack-native router #152
+        consuming an interaction payload) cannot inject ``?``/``#``/``/`` into
+        the BS request path.
         """
-        response = await self.http_client.delete(
-            f"{self.base_url}/{fingerprint}",
-            headers=self._headers(),
-            timeout=self.timeout,
-        )
+        try:
+            response = await self.http_client.delete(
+                f"{self.base_url}/{quote(fingerprint, safe='')}",
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+        except httpx.HTTPError as exc:
+            raise BanAdminClientError(
+                0, {"error": "upstream_unreachable", "detail": str(exc)}
+            ) from exc
         if response.status_code != 204:
             raise BanAdminClientError(response.status_code, self._decode_body(response))
 
@@ -141,12 +180,17 @@ class BanAdminClient:
         if cursor is not None:
             params["cursor"] = cursor
 
-        response = await self.http_client.get(
-            self.base_url,
-            params=params,
-            headers=self._headers(),
-            timeout=self.timeout,
-        )
-        if response.status_code != 200:
+        try:
+            response = await self.http_client.get(
+                self.base_url,
+                params=params,
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+        except httpx.HTTPError as exc:
+            raise BanAdminClientError(
+                0, {"error": "upstream_unreachable", "detail": str(exc)}
+            ) from exc
+        if not 200 <= response.status_code < 300:
             raise BanAdminClientError(response.status_code, self._decode_body(response))
-        return response.json()  # type: ignore[no-any-return]
+        return self._safe_json(response)  # type: ignore[no-any-return]

--- a/services/ban_service.py
+++ b/services/ban_service.py
@@ -55,9 +55,12 @@ async def ban(
         The upserted row as a dict: ``fingerprint``, ``banned_at``,
         ``ban_reason``, ``ban_expires_at``, ``banned_by_user_id``.
     """
+    # Fingerprint is a stable per-device identifier (iOS-Keychain UUID).
+    # Log only the first 8 chars so Railway/Sentry log retention doesn't act as
+    # a deanon vector for anyone with log access.
     logger.info(
-        "ban_service.ban fingerprint=%s reason_len=%d actor=%s expires_in=%s",
-        fingerprint,
+        "ban_service.ban fingerprint=%s... reason_len=%d actor=%s expires_in=%s",
+        fingerprint[:8],
         len(reason),
         actor or "<none>",
         expires_in_seconds,
@@ -83,9 +86,10 @@ async def unban(
     trail it goes in the BS-side route as a separate column; rom should not
     invent local audit state.)
     """
+    # See ban() above for the rationale on truncating the fingerprint.
     logger.info(
-        "ban_service.unban fingerprint=%s actor=%s",
-        fingerprint,
+        "ban_service.unban fingerprint=%s... actor=%s",
+        fingerprint[:8],
         actor or "<none>",
     )
     await client.unban(fingerprint=fingerprint)

--- a/services/ban_service.py
+++ b/services/ban_service.py
@@ -1,0 +1,101 @@
+"""Shared ban-mutation surface for request-o-matic.
+
+Both the HTTP admin router (`routers/admin.py`, #151) and the future
+Slack-native ban router (`routers/slack_interactivity.py`, #152) call into the
+functions defined here. The motivation for the explicit indirection is that
+#152 needs to apply identical validation, idempotency, and audit-actor handling
+as #151 — two parallel codepaths would diverge.
+
+There is no local state. Every call delegates to
+:class:`services.ban_admin_client.BanAdminClient` which talks to BS's
+`/internal/banned-fingerprints` CRUD (BS#1261). Backend-Service owns the
+storage; rom owns the operator UX.
+
+The ``actor`` argument is forwarded to BS as ``banned_by_user_id`` for the
+audit trail. The HTTP admin caller passes ``None`` because they're only
+identified by ``ADMIN_TOKEN`` — leaving it ``None`` is preferable to inventing
+a synthetic user_id (which couldn't satisfy BS's foreign-key constraint to
+``auth_user.id``). The Slack caller will pass the Slack user's mapped
+``auth_user.id``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from services.ban_admin_client import BanAdminClient
+
+logger = logging.getLogger(__name__)
+
+
+async def ban(
+    client: BanAdminClient,
+    *,
+    fingerprint: str,
+    reason: str,
+    actor: str | None = None,
+    expires_in_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Ban a fingerprint. Idempotent — re-banning returns the updated row.
+
+    Args:
+        client: BS admin client (constructed by the FastAPI dependency).
+        fingerprint: The iOS-Keychain UUID identifying the listener device.
+            BS validates the UUID shape and rejects malformed values with 400.
+        reason: Free-text reason surfaced in operator UIs. BS caps at 1000
+            characters and rejects empty/whitespace.
+        actor: ``auth_user.id`` of the operator initiating the ban, or
+            ``None`` for HTTP-admin callers identified only by
+            ``ADMIN_TOKEN``. Forwarded as ``banned_by_user_id``.
+        expires_in_seconds: Optional auto-expiry. ``None`` means permanent
+            until manually unbanned.
+
+    Returns:
+        The upserted row as a dict: ``fingerprint``, ``banned_at``,
+        ``ban_reason``, ``ban_expires_at``, ``banned_by_user_id``.
+    """
+    logger.info(
+        "ban_service.ban fingerprint=%s reason_len=%d actor=%s expires_in=%s",
+        fingerprint,
+        len(reason),
+        actor or "<none>",
+        expires_in_seconds,
+    )
+    return await client.ban(
+        fingerprint=fingerprint,
+        reason=reason,
+        expires_in_seconds=expires_in_seconds,
+        banned_by_user_id=actor,
+    )
+
+
+async def unban(
+    client: BanAdminClient,
+    *,
+    fingerprint: str,
+    actor: str | None = None,
+) -> None:
+    """Remove a ban. Idempotent — succeeds whether or not the row existed.
+
+    The ``actor`` argument is currently used only for logging; BS's DELETE
+    endpoint does not record who removed a ban. (If we ever want that audit
+    trail it goes in the BS-side route as a separate column; rom should not
+    invent local audit state.)
+    """
+    logger.info(
+        "ban_service.unban fingerprint=%s actor=%s",
+        fingerprint,
+        actor or "<none>",
+    )
+    await client.unban(fingerprint=fingerprint)
+
+
+async def list_bans(
+    client: BanAdminClient,
+    *,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """List bans. Pure pass-through to BS; no actor field (read-only)."""
+    return await client.list_bans(limit=limit, cursor=cursor)

--- a/tests/unit/test_admin_router.py
+++ b/tests/unit/test_admin_router.py
@@ -312,15 +312,30 @@ class TestDeleteBan:
         assert resp.status_code == 204
 
     @pytest.mark.asyncio
-    async def test_upstream_400_forwarded(self):
+    async def test_non_uuid_path_returns_422_before_hitting_bs(self):
+        """The path-param UUID validator short-circuits malformed input."""
         client = _mock_client()
-        client.unban = AsyncMock(
-            side_effect=BanAdminClientError(400, {"error": "fingerprint must be a valid UUID"})
-        )
         app = _build_app(client=client)
 
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
             resp = await c.delete("/admin/bans/not-a-uuid", headers=AUTH_HEADERS)
+
+        assert resp.status_code == 422
+        client.unban.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_upstream_400_forwarded(self):
+        """A BS 400 (the only non-UUID path that survives 422 short-circuit
+        is a valid UUID that BS rejects for some other reason, e.g. a
+        constraint violation) forwards as 400."""
+        client = _mock_client()
+        client.unban = AsyncMock(
+            side_effect=BanAdminClientError(400, {"error": "some bs validation failure"})
+        )
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.delete(f"/admin/bans/{SAMPLE_FP}", headers=AUTH_HEADERS)
 
         assert resp.status_code == 400
 
@@ -414,3 +429,134 @@ class TestUpstreamMisconfig:
             resp = await c.get("/admin/bans", headers=AUTH_HEADERS)
 
         assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Local validation — Pydantic body model rejects bad shapes before BS round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestBodyValidation:
+    """Verifies that BanCreateRequest rejects bad shapes locally rather than
+    forwarding the operator typo to BS and surfacing a nested 400.
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_uuid_fingerprint_returns_422(self):
+        client = _mock_client()
+        app = _build_app(client=client)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": "not-a-uuid", "reason": "spam"},
+            )
+        assert resp.status_code == 422
+        client.ban.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_reason_returns_422(self):
+        client = _mock_client()
+        app = _build_app(client=client)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": ""},
+            )
+        assert resp.status_code == 422
+        client.ban.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reason_over_1000_chars_returns_422(self):
+        client = _mock_client()
+        app = _build_app(client=client)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "x" * 1001},
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", [0, -1, -3600])
+    async def test_expires_in_seconds_must_be_positive(self, bad):
+        client = _mock_client()
+        app = _build_app(client=client)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "spam", "expires_in_seconds": bad},
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_extra_field_rejected_as_422(self):
+        """Operator typo like ``banned_by_user_id`` (which the HTTP route
+        deliberately doesn't honor — see router docstring) surfaces as 422
+        instead of silently dropping the field."""
+        client = _mock_client()
+        app = _build_app(client=client)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={
+                    "fingerprint": SAMPLE_FP,
+                    "reason": "spam",
+                    "banned_by_user_id": "jake",
+                },
+            )
+        assert resp.status_code == 422
+        client.ban.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Upstream-fault status remapping — BS 401/403/429 are rom->BS hop concerns
+# that mustn't conflate with the operator->rom request's auth/rate state.
+# ---------------------------------------------------------------------------
+
+
+class TestUpstreamFaultRemap:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bs_status", [401, 403, 429])
+    async def test_bs_upstream_fault_4xx_remaps_to_502(self, bs_status):
+        """BS 401 (X-Internal-Key drift), 403 (BS perm), 429 (rom->BS rate-
+        limit at BS) all become 502 — they describe an upstream problem, not
+        an operator request problem. Forwarding them verbatim would mislead
+        the operator (e.g. 401 reads as 'your ADMIN_TOKEN is wrong')."""
+        client = _mock_client()
+        client.ban = AsyncMock(
+            side_effect=BanAdminClientError(bs_status, {"error": "upstream said no"})
+        )
+        app = _build_app(client=client)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+        assert resp.status_code == 502
+        assert resp.json()["detail"]["upstream_status"] == bs_status
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_remaps_to_502(self):
+        """BanAdminClient wraps httpx.HTTPError as BanAdminClientError(0, ...);
+        the router renders that as 502 (upstream unreachable)."""
+        client = _mock_client()
+        client.ban = AsyncMock(
+            side_effect=BanAdminClientError(
+                0, {"error": "upstream_unreachable", "detail": "conn refused"}
+            )
+        )
+        app = _build_app(client=client)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+        assert resp.status_code == 502
+        assert resp.json()["detail"]["upstream_body"]["error"] == "upstream_unreachable"

--- a/tests/unit/test_admin_router.py
+++ b/tests/unit/test_admin_router.py
@@ -1,0 +1,416 @@
+"""Unit tests for routers/admin.py — the /admin/bans HTTP API (#151).
+
+These tests cover:
+
+* Bearer-token auth (mirror of LML's ``_validate_auth`` pattern)
+* The three endpoints' happy paths
+* Upstream-error translation (4xx forwarded, 5xx -> 502)
+* The 503 fail-closed path when BS upstream config is missing
+
+Mocking strategy: the FastAPI dependency for :class:`BanAdminClient` is
+overridden with an :class:`unittest.mock.AsyncMock`, so we exercise the actual
+ban_service + router code paths but never make a real HTTP call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import Settings, get_settings
+from core.dependencies import get_ban_admin_client
+from routers.admin import router
+from services.ban_admin_client import BanAdminClientError
+
+ADMIN_TOKEN = "test-admin-secret"
+SAMPLE_FP = "11111111-2222-3333-4444-555555555555"
+AUTH_HEADERS = {"Authorization": f"Bearer {ADMIN_TOKEN}"}
+
+
+def _build_app(
+    *, admin_token: str | None = ADMIN_TOKEN, client: AsyncMock | None = None
+) -> FastAPI:
+    """Construct a fresh FastAPI app with the admin router and overridable deps."""
+    app = FastAPI()
+    app.include_router(router)
+
+    test_settings = Settings(
+        groq_api_key="test_groq_key",
+        admin_token=admin_token,
+        bs_internal_bans_url="https://bs.example.com/internal/banned-fingerprints",
+        bs_internal_key="test-internal-key",
+    )
+    app.dependency_overrides[get_settings] = lambda: test_settings
+
+    if client is not None:
+        app.dependency_overrides[get_ban_admin_client] = lambda: client
+
+    return app
+
+
+def _ban_row(**overrides: object) -> dict:
+    row: dict = {
+        "fingerprint": SAMPLE_FP,
+        "banned_at": "2026-01-01T00:00:00Z",
+        "ban_reason": "spam",
+        "ban_expires_at": None,
+        "banned_by_user_id": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _mock_client() -> AsyncMock:
+    client = AsyncMock()
+    client.ban = AsyncMock(return_value=_ban_row())
+    client.unban = AsyncMock(return_value=None)
+    client.list_bans = AsyncMock(return_value={"items": [_ban_row()], "nextCursor": None})
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Auth tests — mirror LML admin pattern. Apply uniformly to all three routes.
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "url", "json_body"),
+        [
+            ("POST", "/admin/bans", {"fingerprint": SAMPLE_FP, "reason": "spam"}),
+            ("DELETE", f"/admin/bans/{SAMPLE_FP}", None),
+            ("GET", "/admin/bans", None),
+        ],
+    )
+    async def test_missing_authorization_header_401(self, method, url, json_body):
+        app = _build_app(client=_mock_client())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.request(method, url, json=json_body)
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Missing authorization"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "url", "json_body"),
+        [
+            ("POST", "/admin/bans", {"fingerprint": SAMPLE_FP, "reason": "spam"}),
+            ("DELETE", f"/admin/bans/{SAMPLE_FP}", None),
+            ("GET", "/admin/bans", None),
+        ],
+    )
+    async def test_wrong_bearer_token_403(self, method, url, json_body):
+        app = _build_app(client=_mock_client())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.request(
+                method, url, headers={"Authorization": "Bearer wrong-token"}, json=json_body
+            )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Invalid token"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method", "url", "json_body"),
+        [
+            ("POST", "/admin/bans", {"fingerprint": SAMPLE_FP, "reason": "spam"}),
+            ("DELETE", f"/admin/bans/{SAMPLE_FP}", None),
+            ("GET", "/admin/bans", None),
+        ],
+    )
+    async def test_malformed_scheme_403(self, method, url, json_body):
+        """``Authorization: <token>`` without the ``Bearer`` scheme -> 403."""
+        app = _build_app(client=_mock_client())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.request(
+                method, url, headers={"Authorization": ADMIN_TOKEN}, json=json_body
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_token_unset_returns_403_fail_closed(self):
+        """No ``ADMIN_TOKEN`` configured -> reject everything with 403 (fail-closed)."""
+        app = _build_app(admin_token=None, client=_mock_client())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers={"Authorization": "Bearer anything"},
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+        assert resp.status_code == 403
+        assert "ADMIN_TOKEN" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_bearer_scheme(self):
+        """RFC 7235 allows case-insensitive scheme — accept ``bearer`` and ``BEARER``."""
+        app = _build_app(client=_mock_client())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers={"Authorization": f"bearer {ADMIN_TOKEN}"},
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/bans
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBan:
+    @pytest.mark.asyncio
+    async def test_minimal_ban_returns_200_with_row(self):
+        client = _mock_client()
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == _ban_row()
+        client.ban.assert_awaited_once_with(
+            fingerprint=SAMPLE_FP,
+            reason="spam",
+            expires_in_seconds=None,
+            banned_by_user_id=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_passes_expires_in_seconds_through(self):
+        client = _mock_client()
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={
+                    "fingerprint": SAMPLE_FP,
+                    "reason": "spam",
+                    "expires_in_seconds": 3600,
+                },
+            )
+
+        assert resp.status_code == 200
+        _, kwargs = client.ban.call_args
+        assert kwargs["expires_in_seconds"] == 3600
+
+    @pytest.mark.asyncio
+    async def test_http_admin_caller_has_no_actor(self):
+        """HTTP-admin callers identified only by ADMIN_TOKEN forward NULL banned_by_user_id."""
+        client = _mock_client()
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+
+        _, kwargs = client.ban.call_args
+        assert kwargs["banned_by_user_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_re_ban_returns_200_with_updated_row_idempotent(self):
+        """Re-banning an already-banned fingerprint returns 200 (idempotent)."""
+        client = _mock_client()
+        # BS upserts and returns the new banned_at / new reason
+        client.ban = AsyncMock(
+            return_value=_ban_row(banned_at="2026-02-01T00:00:00Z", ban_reason="still spam")
+        )
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "still spam"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["ban_reason"] == "still spam"
+        assert resp.json()["banned_at"] == "2026-02-01T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_upstream_400_forwarded_as_400(self):
+        """A BS 400 (malformed fingerprint) surfaces as 400 to the operator."""
+        client = _mock_client()
+        client.ban = AsyncMock(
+            side_effect=BanAdminClientError(400, {"error": "fingerprint must be a valid UUID"})
+        )
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["upstream_status"] == 400
+        assert resp.json()["detail"]["upstream_body"] == {
+            "error": "fingerprint must be a valid UUID"
+        }
+
+    @pytest.mark.asyncio
+    async def test_upstream_500_becomes_502(self):
+        """An upstream 5xx surfaces as 502 (upstream broke, this service is fine)."""
+        client = _mock_client()
+        client.ban = AsyncMock(
+            side_effect=BanAdminClientError(500, {"error": "Internal server error"})
+        )
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+
+        assert resp.status_code == 502
+        assert resp.json()["detail"]["upstream_status"] == 500
+
+
+# ---------------------------------------------------------------------------
+# DELETE /admin/bans/{fingerprint}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteBan:
+    @pytest.mark.asyncio
+    async def test_returns_204_on_success(self):
+        client = _mock_client()
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.delete(f"/admin/bans/{SAMPLE_FP}", headers=AUTH_HEADERS)
+
+        assert resp.status_code == 204
+        assert resp.content == b""
+        client.unban.assert_awaited_once_with(fingerprint=SAMPLE_FP)
+
+    @pytest.mark.asyncio
+    async def test_returns_204_idempotent_when_row_missing(self):
+        """BS returns 204 whether or not the row existed; rom does the same."""
+        client = _mock_client()
+        client.unban = AsyncMock(return_value=None)  # BS 204 path
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.delete(f"/admin/bans/{SAMPLE_FP}", headers=AUTH_HEADERS)
+
+        assert resp.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_upstream_400_forwarded(self):
+        client = _mock_client()
+        client.unban = AsyncMock(
+            side_effect=BanAdminClientError(400, {"error": "fingerprint must be a valid UUID"})
+        )
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.delete("/admin/bans/not-a-uuid", headers=AUTH_HEADERS)
+
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/bans
+# ---------------------------------------------------------------------------
+
+
+class TestListBans:
+    @pytest.mark.asyncio
+    async def test_returns_paginated_envelope(self):
+        client = _mock_client()
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/admin/bans", headers=AUTH_HEADERS)
+
+        assert resp.status_code == 200
+        assert resp.json() == {"items": [_ban_row()], "nextCursor": None}
+        client.list_bans.assert_awaited_once_with(limit=None, cursor=None)
+
+    @pytest.mark.asyncio
+    async def test_forwards_limit_and_cursor(self):
+        client = _mock_client()
+        app = _build_app(client=client)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                params={"limit": "25", "cursor": "abc"},
+            )
+
+        assert resp.status_code == 200
+        client.list_bans.assert_awaited_once_with(limit=25, cursor="abc")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_limit", ["0", "-1", "201", "abc"])
+    async def test_rejects_out_of_range_limit_with_422(self, bad_limit):
+        """FastAPI's Query(ge=1, le=200) returns 422 before hitting BS."""
+        app = _build_app(client=_mock_client())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/admin/bans", headers=AUTH_HEADERS, params={"limit": bad_limit})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Misconfiguration — BS upstream not wired
+# ---------------------------------------------------------------------------
+
+
+class TestUpstreamMisconfig:
+    @pytest.mark.asyncio
+    async def test_missing_bs_internal_bans_url_returns_503(self):
+        """No ``BS_INTERNAL_BANS_URL`` -> 503 with operator-friendly message."""
+        app = FastAPI()
+        app.include_router(router)
+        test_settings = Settings(
+            groq_api_key="test_groq_key",
+            admin_token=ADMIN_TOKEN,
+            bs_internal_bans_url=None,
+            bs_internal_key="test-internal-key",
+        )
+        app.dependency_overrides[get_settings] = lambda: test_settings
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/admin/bans",
+                headers=AUTH_HEADERS,
+                json={"fingerprint": SAMPLE_FP, "reason": "spam"},
+            )
+
+        assert resp.status_code == 503
+        assert "BS_INTERNAL_BANS_URL" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_missing_bs_internal_key_returns_503(self):
+        """No ``BS_INTERNAL_KEY`` -> 503 as well (both halves required)."""
+        app = FastAPI()
+        app.include_router(router)
+        test_settings = Settings(
+            groq_api_key="test_groq_key",
+            admin_token=ADMIN_TOKEN,
+            bs_internal_bans_url="https://bs.example.com/internal/banned-fingerprints",
+            bs_internal_key=None,
+        )
+        app.dependency_overrides[get_settings] = lambda: test_settings
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/admin/bans", headers=AUTH_HEADERS)
+
+        assert resp.status_code == 503

--- a/tests/unit/test_ban_admin_client.py
+++ b/tests/unit/test_ban_admin_client.py
@@ -300,3 +300,105 @@ class TestRealHttpxResponse:
             result = await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
 
         assert result == body
+
+
+class TestTransportFailure:
+    """Network/transport errors wrap as BanAdminClientError(status_code=0).
+
+    Without this guard, httpx.HTTPError would escape the router's
+    ``except BanAdminClientError`` and surface as an unhandled 500 — even
+    though the docstring on _map_upstream_error and the route's responses=
+    table both promise 502 for upstream failures.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectError("conn refused"),
+            httpx.ReadTimeout("read timeout"),
+            httpx.ConnectTimeout("connect timeout"),
+            httpx.RemoteProtocolError("bad upstream"),
+        ],
+    )
+    async def test_ban_transport_error_wraps_as_status_zero(self, exc):
+        http = AsyncMock()
+        http.post = AsyncMock(side_effect=exc)
+        with pytest.raises(BanAdminClientError) as excinfo:
+            await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
+        assert excinfo.value.status_code == 0
+        assert excinfo.value.body["error"] == "upstream_unreachable"
+
+    @pytest.mark.asyncio
+    async def test_unban_transport_error_wraps_as_status_zero(self):
+        http = AsyncMock()
+        http.delete = AsyncMock(side_effect=httpx.ConnectError("conn refused"))
+        with pytest.raises(BanAdminClientError) as excinfo:
+            await _client(http).unban(fingerprint=SAMPLE_FP)
+        assert excinfo.value.status_code == 0
+
+    @pytest.mark.asyncio
+    async def test_list_bans_transport_error_wraps_as_status_zero(self):
+        http = AsyncMock()
+        http.get = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+        with pytest.raises(BanAdminClientError) as excinfo:
+            await _client(http).list_bans()
+        assert excinfo.value.status_code == 0
+
+
+class TestNonJsonSuccess:
+    """A 200 with non-JSON body (HTML from a reverse proxy, content-type drift,
+    truncation) should NOT escape as an uncaught json.JSONDecodeError. Wrap
+    it as BanAdminClientError so the router renders 502 via the existing
+    upstream-error path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ban_non_json_2xx_raises_ban_admin_client_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"<html>not json</html>")
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as http:
+            with pytest.raises(BanAdminClientError) as excinfo:
+                await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
+        assert excinfo.value.status_code == 200
+        assert excinfo.value.body["error"] == "non_json_upstream_body"
+
+    @pytest.mark.asyncio
+    async def test_list_bans_non_json_2xx_raises_ban_admin_client_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"<html>not json</html>")
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as http:
+            with pytest.raises(BanAdminClientError) as excinfo:
+                await _client(http).list_bans()
+        assert excinfo.value.status_code == 200
+
+
+class TestUnbanUrlQuoting:
+    """unban() must URL-quote the fingerprint so a non-FastAPI caller (e.g.
+    the future Slack-native router #152) can't inject path/query/fragment
+    characters into the BS request URL.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unban_quotes_special_chars_in_path(self):
+        seen_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_urls.append(str(request.url))
+            return httpx.Response(204)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as http:
+            # Caller-supplied value that would otherwise create a query string
+            # rather than a path component.
+            await _client(http).unban(fingerprint="aa?bb#cc")
+        assert len(seen_urls) == 1
+        # The '?' and '#' must be percent-encoded into the path; no query or
+        # fragment may appear on the resulting URL.
+        assert "?" not in seen_urls[0]
+        assert "#" not in seen_urls[0]
+        assert "aa%3Fbb%23cc" in seen_urls[0]

--- a/tests/unit/test_ban_admin_client.py
+++ b/tests/unit/test_ban_admin_client.py
@@ -1,0 +1,302 @@
+"""Unit tests for services/ban_admin_client.py."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import httpx
+import pytest
+
+from services.ban_admin_client import BanAdminClient, BanAdminClientError
+
+BS_BASE = "https://bs.example.com/internal/banned-fingerprints"
+SAMPLE_FP = "11111111-2222-3333-4444-555555555555"
+INTERNAL_KEY = "test-internal-key"
+
+
+def _client(http_client: object) -> BanAdminClient:
+    """Helper: build a BanAdminClient against the supplied (Async)Mock."""
+    return BanAdminClient(BS_BASE, http_client, internal_key=INTERNAL_KEY)  # type: ignore[arg-type]
+
+
+def _ok_response(status_code: int, body: object | None = None) -> Mock:
+    resp = Mock()
+    resp.status_code = status_code
+    if body is None:
+        resp.json = Mock(side_effect=ValueError("no json"))
+        resp.text = ""
+    else:
+        resp.json = Mock(return_value=body)
+        resp.text = str(body)
+    return resp
+
+
+class TestBan:
+    """Tests for BanAdminClient.ban (POST upsert)."""
+
+    @pytest.mark.asyncio
+    async def test_sends_x_internal_key_header(self):
+        """Every POST carries X-Internal-Key sourced from settings."""
+        http = AsyncMock()
+        http.post = AsyncMock(
+            return_value=_ok_response(
+                200,
+                {
+                    "fingerprint": SAMPLE_FP,
+                    "banned_at": "2026-01-01T00:00:00Z",
+                    "ban_reason": "spam",
+                    "ban_expires_at": None,
+                    "banned_by_user_id": None,
+                },
+            )
+        )
+
+        await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
+
+        called_url, called_kwargs = http.post.call_args
+        assert called_url[0] == BS_BASE
+        assert called_kwargs["headers"] == {"X-Internal-Key": INTERNAL_KEY}
+
+    @pytest.mark.asyncio
+    async def test_serializes_camelcase_fields(self):
+        """expires_in_seconds and banned_by_user_id translate to camelCase BS fields."""
+        http = AsyncMock()
+        http.post = AsyncMock(
+            return_value=_ok_response(
+                200,
+                {
+                    "fingerprint": SAMPLE_FP,
+                    "banned_at": "2026-01-01T00:00:00Z",
+                    "ban_reason": "spam",
+                    "ban_expires_at": "2026-01-08T00:00:00Z",
+                    "banned_by_user_id": "user-abc",
+                },
+            )
+        )
+
+        await _client(http).ban(
+            fingerprint=SAMPLE_FP,
+            reason="spam",
+            expires_in_seconds=604800,
+            banned_by_user_id="user-abc",
+        )
+
+        _, called_kwargs = http.post.call_args
+        assert called_kwargs["json"] == {
+            "fingerprint": SAMPLE_FP,
+            "reason": "spam",
+            "expiresInSeconds": 604800,
+            "bannedByUserId": "user-abc",
+        }
+
+    @pytest.mark.asyncio
+    async def test_omits_optional_fields_when_none(self):
+        """None-valued optional fields are omitted from the payload entirely."""
+        http = AsyncMock()
+        http.post = AsyncMock(
+            return_value=_ok_response(
+                200,
+                {
+                    "fingerprint": SAMPLE_FP,
+                    "banned_at": "2026-01-01T00:00:00Z",
+                    "ban_reason": "spam",
+                    "ban_expires_at": None,
+                    "banned_by_user_id": None,
+                },
+            )
+        )
+
+        await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
+
+        _, called_kwargs = http.post.call_args
+        assert called_kwargs["json"] == {"fingerprint": SAMPLE_FP, "reason": "spam"}
+
+    @pytest.mark.asyncio
+    async def test_returns_upserted_row(self):
+        """Successful 200 returns the parsed JSON body verbatim."""
+        body = {
+            "fingerprint": SAMPLE_FP,
+            "banned_at": "2026-01-01T00:00:00Z",
+            "ban_reason": "spam",
+            "ban_expires_at": None,
+            "banned_by_user_id": None,
+        }
+        http = AsyncMock()
+        http.post = AsyncMock(return_value=_ok_response(200, body))
+
+        row = await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
+
+        assert row == body
+
+    @pytest.mark.asyncio
+    async def test_raises_on_400(self):
+        """A 400 response (e.g. malformed fingerprint) becomes BanAdminClientError."""
+        http = AsyncMock()
+        http.post = AsyncMock(
+            return_value=_ok_response(400, {"error": "fingerprint must be a valid UUID"})
+        )
+
+        with pytest.raises(BanAdminClientError) as excinfo:
+            await _client(http).ban(fingerprint="not-a-uuid", reason="spam")
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.body == {"error": "fingerprint must be a valid UUID"}
+
+    @pytest.mark.asyncio
+    async def test_raises_on_500(self):
+        """5xx upstream errors are also wrapped (router decides 502 mapping)."""
+        http = AsyncMock()
+        http.post = AsyncMock(return_value=_ok_response(500, {"error": "Internal server error"}))
+
+        with pytest.raises(BanAdminClientError) as excinfo:
+            await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
+
+        assert excinfo.value.status_code == 500
+
+
+class TestUnban:
+    """Tests for BanAdminClient.unban (DELETE)."""
+
+    @pytest.mark.asyncio
+    async def test_targets_per_fingerprint_url(self):
+        """DELETE goes to {base_url}/{fingerprint}, not the collection URL."""
+        http = AsyncMock()
+        http.delete = AsyncMock(return_value=_ok_response(204))
+
+        await _client(http).unban(fingerprint=SAMPLE_FP)
+
+        called_args, called_kwargs = http.delete.call_args
+        assert called_args[0] == f"{BS_BASE}/{SAMPLE_FP}"
+        assert called_kwargs["headers"] == {"X-Internal-Key": INTERNAL_KEY}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_204(self):
+        """204 (whether row existed or not) returns cleanly with no body."""
+        http = AsyncMock()
+        http.delete = AsyncMock(return_value=_ok_response(204))
+
+        # unban() returns None on success; the assertion is "no exception raised".
+        await _client(http).unban(fingerprint=SAMPLE_FP)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_400(self):
+        """Malformed fingerprint surfaces as BanAdminClientError(400)."""
+        http = AsyncMock()
+        http.delete = AsyncMock(
+            return_value=_ok_response(400, {"error": "fingerprint must be a valid UUID"})
+        )
+
+        with pytest.raises(BanAdminClientError) as excinfo:
+            await _client(http).unban(fingerprint="not-a-uuid")
+
+        assert excinfo.value.status_code == 400
+
+
+class TestListBans:
+    """Tests for BanAdminClient.list_bans (GET)."""
+
+    @pytest.mark.asyncio
+    async def test_omits_query_params_when_unset(self):
+        """No limit / cursor -> empty params dict (BS applies its own defaults)."""
+        http = AsyncMock()
+        http.get = AsyncMock(return_value=_ok_response(200, {"items": [], "nextCursor": None}))
+
+        await _client(http).list_bans()
+
+        _, called_kwargs = http.get.call_args
+        assert called_kwargs["params"] == {}
+
+    @pytest.mark.asyncio
+    async def test_forwards_limit_and_cursor(self):
+        """limit/cursor pass through as string query params."""
+        http = AsyncMock()
+        http.get = AsyncMock(return_value=_ok_response(200, {"items": [], "nextCursor": None}))
+
+        await _client(http).list_bans(limit=25, cursor="2026-01-01T00:00:00.000Z|" + SAMPLE_FP)
+
+        _, called_kwargs = http.get.call_args
+        assert called_kwargs["params"] == {
+            "limit": "25",
+            "cursor": "2026-01-01T00:00:00.000Z|" + SAMPLE_FP,
+        }
+
+    @pytest.mark.asyncio
+    async def test_returns_paginated_envelope(self):
+        """Returns the {items, nextCursor} envelope verbatim."""
+        body = {
+            "items": [
+                {
+                    "fingerprint": SAMPLE_FP,
+                    "banned_at": "2026-01-01T00:00:00Z",
+                    "ban_reason": "spam",
+                    "ban_expires_at": None,
+                    "banned_by_user_id": None,
+                }
+            ],
+            "nextCursor": None,
+        }
+        http = AsyncMock()
+        http.get = AsyncMock(return_value=_ok_response(200, body))
+
+        result = await _client(http).list_bans()
+
+        assert result == body
+
+    @pytest.mark.asyncio
+    async def test_raises_on_non_200(self):
+        """Any non-200 (e.g. bad limit) becomes BanAdminClientError."""
+        http = AsyncMock()
+        http.get = AsyncMock(return_value=_ok_response(400, {"error": "limit out of range"}))
+
+        with pytest.raises(BanAdminClientError) as excinfo:
+            await _client(http).list_bans(limit=999)
+
+        assert excinfo.value.status_code == 400
+
+
+class TestErrorBodyDecoding:
+    """Tests for the JSON-or-text fallback in BanAdminClientError.body."""
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_text_when_body_not_json(self):
+        """A non-JSON error body (e.g. an HTML 502 page) falls back to the raw text."""
+        resp = Mock()
+        resp.status_code = 502
+        resp.json = Mock(side_effect=ValueError("not json"))
+        resp.text = "<html>bad gateway</html>"
+        http = AsyncMock()
+        http.post = AsyncMock(return_value=resp)
+
+        with pytest.raises(BanAdminClientError) as excinfo:
+            await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
+
+        assert excinfo.value.status_code == 502
+        assert excinfo.value.body == "<html>bad gateway</html>"
+
+
+class TestRealHttpxResponse:
+    """Sanity: BanAdminClient works against an actual httpx.Response (not a Mock).
+
+    Catches accidental over-reliance on mock semantics — e.g. forgetting that
+    httpx.Response.json() raises a JSONDecodeError subclass of ValueError.
+    """
+
+    @pytest.mark.asyncio
+    async def test_post_with_real_response_envelope(self):
+        body = {
+            "fingerprint": SAMPLE_FP,
+            "banned_at": "2026-01-01T00:00:00Z",
+            "ban_reason": "spam",
+            "ban_expires_at": None,
+            "banned_by_user_id": None,
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.headers["x-internal-key"] == INTERNAL_KEY
+            return httpx.Response(200, json=body)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as http:
+            result = await _client(http).ban(fingerprint=SAMPLE_FP, reason="spam")
+
+        assert result == body

--- a/tests/unit/test_ban_service.py
+++ b/tests/unit/test_ban_service.py
@@ -1,0 +1,127 @@
+"""Unit tests for services/ban_service.py — the shared mutation surface.
+
+These tests pin the contract that both the HTTP admin router (#151) and the
+future Slack-native ban router (#152) rely on:
+
+* ``ban(client, ...)`` forwards the call to BanAdminClient with the same shape
+* ``unban(client, ...)`` forwards similarly
+* ``actor`` translates to ``banned_by_user_id``
+* ``list_bans(client, ...)`` is a pure pass-through
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services import ban_service
+
+SAMPLE_FP = "11111111-2222-3333-4444-555555555555"
+
+
+def _client_mock() -> AsyncMock:
+    """Build an AsyncMock that quacks like BanAdminClient."""
+    client = AsyncMock()
+    client.ban = AsyncMock(
+        return_value={
+            "fingerprint": SAMPLE_FP,
+            "banned_at": "2026-01-01T00:00:00Z",
+            "ban_reason": "spam",
+            "ban_expires_at": None,
+            "banned_by_user_id": None,
+        }
+    )
+    client.unban = AsyncMock(return_value=None)
+    client.list_bans = AsyncMock(return_value={"items": [], "nextCursor": None})
+    return client
+
+
+class TestBan:
+    @pytest.mark.asyncio
+    async def test_forwards_minimal_args(self):
+        client = _client_mock()
+        await ban_service.ban(client, fingerprint=SAMPLE_FP, reason="spam")
+        client.ban.assert_awaited_once_with(
+            fingerprint=SAMPLE_FP,
+            reason="spam",
+            expires_in_seconds=None,
+            banned_by_user_id=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_actor_translates_to_banned_by_user_id(self):
+        """actor (rom vocab) -> banned_by_user_id (BS vocab) at the client boundary."""
+        client = _client_mock()
+        await ban_service.ban(
+            client,
+            fingerprint=SAMPLE_FP,
+            reason="spam",
+            actor="user-abc",
+        )
+        _, kwargs = client.ban.call_args
+        assert kwargs["banned_by_user_id"] == "user-abc"
+
+    @pytest.mark.asyncio
+    async def test_forwards_expires_in_seconds(self):
+        client = _client_mock()
+        await ban_service.ban(
+            client,
+            fingerprint=SAMPLE_FP,
+            reason="spam",
+            expires_in_seconds=3600,
+        )
+        _, kwargs = client.ban.call_args
+        assert kwargs["expires_in_seconds"] == 3600
+
+    @pytest.mark.asyncio
+    async def test_returns_client_row_verbatim(self):
+        """ban_service is a passthrough — no transformation of the BS response."""
+        client = _client_mock()
+        result = await ban_service.ban(client, fingerprint=SAMPLE_FP, reason="spam")
+        assert result == {
+            "fingerprint": SAMPLE_FP,
+            "banned_at": "2026-01-01T00:00:00Z",
+            "ban_reason": "spam",
+            "ban_expires_at": None,
+            "banned_by_user_id": None,
+        }
+
+
+class TestUnban:
+    @pytest.mark.asyncio
+    async def test_forwards_fingerprint(self):
+        client = _client_mock()
+        await ban_service.unban(client, fingerprint=SAMPLE_FP)
+        client.unban.assert_awaited_once_with(fingerprint=SAMPLE_FP)
+
+    @pytest.mark.asyncio
+    async def test_actor_is_ignored_by_client_but_accepted_by_service(self):
+        """``actor`` is logged but never forwarded to the client (BS DELETE has no audit field)."""
+        client = _client_mock()
+        await ban_service.unban(client, fingerprint=SAMPLE_FP, actor="user-abc")
+        _, kwargs = client.unban.call_args
+        assert "actor" not in kwargs
+        assert "banned_by_user_id" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_returns_none(self):
+        """unban returns None on success; the assertion is "no exception raised"."""
+        client = _client_mock()
+        await ban_service.unban(client, fingerprint=SAMPLE_FP)
+
+
+class TestListBans:
+    @pytest.mark.asyncio
+    async def test_passthrough(self):
+        """list_bans is a pure pass-through; no transformation of args or response."""
+        client = _client_mock()
+        result = await ban_service.list_bans(client, limit=10, cursor="abc")
+        client.list_bans.assert_awaited_once_with(limit=10, cursor="abc")
+        assert result == {"items": [], "nextCursor": None}
+
+    @pytest.mark.asyncio
+    async def test_omits_unset_args(self):
+        client = _client_mock()
+        await ban_service.list_bans(client)
+        client.list_bans.assert_awaited_once_with(limit=None, cursor=None)

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -387,6 +387,41 @@ class TestRequireAdminToken:
             require_admin_token(settings=settings, authorization="Bearer anything")
         assert excinfo.value.status_code == 403
 
+    def test_admin_token_empty_string_raises_403(self):
+        """Pins the empty-string fail-closed path. Operator who accidentally
+        clears the Railway variable (ADMIN_TOKEN=) gets 'disabled', not 'wrong
+        token' — and the empty bearer never authenticates."""
+        settings = Settings(groq_api_key="x", admin_token="")
+        with pytest.raises(HTTPException) as excinfo:
+            require_admin_token(settings=settings, authorization="Bearer ")
+        assert excinfo.value.status_code == 403
+
+    def test_tolerates_extra_whitespace_in_header(self):
+        """RFC 7235 allows 1*SP between scheme and token; copy-paste from a
+        wiki or notes app often introduces double spaces or tabs. Strict
+        single-space split would 403 the operator with a misleading 'Invalid
+        token' message."""
+        settings = Settings(groq_api_key="x", admin_token="secret")
+        # Multiple spaces between scheme and token
+        require_admin_token(settings=settings, authorization="Bearer  secret")
+        # Tab between scheme and token
+        require_admin_token(settings=settings, authorization="Bearer\tsecret")
+        # Surrounding whitespace
+        require_admin_token(settings=settings, authorization="  Bearer secret  ")
+
+    def test_uses_constant_time_comparison(self):
+        """Smoke check that hmac.compare_digest is being used (the comparison
+        path returns False for wrong tokens of the same length AND of
+        different lengths — both raise 403 rather than leaking via length-
+        dependent control flow)."""
+        settings = Settings(groq_api_key="x", admin_token="secret-token-123")
+        # Same-length wrong token
+        with pytest.raises(HTTPException):
+            require_admin_token(settings=settings, authorization="Bearer XXXXXX-token-123")
+        # Different-length wrong token (compare_digest doesn't short-circuit)
+        with pytest.raises(HTTPException):
+            require_admin_token(settings=settings, authorization="Bearer short")
+
 
 class TestGetBanAdminClient:
     """Tests for the ``get_ban_admin_client`` FastAPI dependency."""

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -5,18 +5,22 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
+from fastapi import HTTPException
 
 from config.settings import Settings
 from core.dependencies import (
     SlackService,
     close_http_client,
+    get_ban_admin_client,
     get_groq_client,
     get_http_client,
     get_posthog_client,
     get_slack_service,
     get_slack_webhook_url,
+    require_admin_token,
 )
 from core.exceptions import ServiceInitializationError
+from services.ban_admin_client import BanAdminClient
 
 
 @pytest.fixture
@@ -344,3 +348,89 @@ class TestGetSlackService:
         assert isinstance(service, SlackService)
         assert service.webhook_url == "https://hooks.slack.com/test"
         assert service.http_client is mock_client
+
+
+# ---------------------------------------------------------------------------
+# Admin auth + ban admin client (#151)
+# ---------------------------------------------------------------------------
+
+
+class TestRequireAdminToken:
+    """Tests for the ``require_admin_token`` FastAPI dependency."""
+
+    def test_passes_with_correct_bearer(self):
+        settings = Settings(groq_api_key="x", admin_token="secret")
+        # Should not raise
+        require_admin_token(settings=settings, authorization="Bearer secret")
+
+    def test_case_insensitive_scheme(self):
+        settings = Settings(groq_api_key="x", admin_token="secret")
+        require_admin_token(settings=settings, authorization="bearer secret")
+        require_admin_token(settings=settings, authorization="BEARER secret")
+
+    def test_missing_header_raises_401(self):
+        settings = Settings(groq_api_key="x", admin_token="secret")
+        with pytest.raises(HTTPException) as excinfo:
+            require_admin_token(settings=settings, authorization=None)
+        assert excinfo.value.status_code == 401
+
+    def test_wrong_token_raises_403(self):
+        settings = Settings(groq_api_key="x", admin_token="secret")
+        with pytest.raises(HTTPException) as excinfo:
+            require_admin_token(settings=settings, authorization="Bearer wrong")
+        assert excinfo.value.status_code == 403
+
+    def test_admin_token_unset_raises_403(self):
+        """Fail-closed: server with no ADMIN_TOKEN rejects every request."""
+        settings = Settings(groq_api_key="x", admin_token=None)
+        with pytest.raises(HTTPException) as excinfo:
+            require_admin_token(settings=settings, authorization="Bearer anything")
+        assert excinfo.value.status_code == 403
+
+
+class TestGetBanAdminClient:
+    """Tests for the ``get_ban_admin_client`` FastAPI dependency."""
+
+    @pytest.mark.asyncio
+    async def test_builds_client_with_settings(self):
+        settings = Settings(
+            groq_api_key="x",
+            bs_internal_bans_url="https://bs.example.com/internal/banned-fingerprints",
+            bs_internal_key="key-123",
+        )
+        http = httpx.AsyncClient()
+        try:
+            client = await get_ban_admin_client(settings=settings, http_client=http)
+        finally:
+            await http.aclose()
+
+        assert isinstance(client, BanAdminClient)
+        assert client.base_url == "https://bs.example.com/internal/banned-fingerprints"
+        assert client.internal_key == "key-123"
+        assert client.http_client is http
+
+    @pytest.mark.asyncio
+    async def test_missing_url_raises_503(self):
+        settings = Settings(groq_api_key="x", bs_internal_bans_url=None, bs_internal_key="key")
+        http = httpx.AsyncClient()
+        try:
+            with pytest.raises(HTTPException) as excinfo:
+                await get_ban_admin_client(settings=settings, http_client=http)
+        finally:
+            await http.aclose()
+        assert excinfo.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_missing_key_raises_503(self):
+        settings = Settings(
+            groq_api_key="x",
+            bs_internal_bans_url="https://bs.example.com/internal/banned-fingerprints",
+            bs_internal_key=None,
+        )
+        http = httpx.AsyncClient()
+        try:
+            with pytest.raises(HTTPException) as excinfo:
+                await get_ban_admin_client(settings=settings, http_client=http)
+        finally:
+            await http.aclose()
+        assert excinfo.value.status_code == 503

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -51,6 +51,27 @@ class TestAppConfiguration:
             assert any("/request" in route and "/api/v1" not in route for route in routes)
             assert any("/parse" in route and "/api/v1" not in route for route in routes)
 
+    def test_app_has_admin_bans_routes(self):
+        """Pin that ``/admin/bans`` (#151) is mounted at the root, not under /api/v1.
+
+        Operators curl ``/admin/bans`` directly — burying it under ``/api/v1``
+        would diverge from LML's admin pattern and from the operator runbook
+        in ``docs/admin-bans.md``.
+        """
+        with patch.dict("os.environ", {"GROQ_API_KEY": "test_key"}):
+            from config.settings import get_settings
+
+            get_settings.cache_clear()
+
+            from main import app
+
+            routes = [route.path for route in app.routes if hasattr(route, "path")]
+
+            assert "/admin/bans" in routes
+            assert "/admin/bans/{fingerprint}" in routes
+            # Must NOT have been accidentally namespaced under /api/v1
+            assert not any("/api/v1/admin" in r for r in routes)
+
     def test_app_has_description(self):
         """Test that app has a description."""
         with patch.dict("os.environ", {"GROQ_API_KEY": "test_key"}):


### PR DESCRIPTION
## Summary

Three operator endpoints under `/admin/bans`, gated by `ADMIN_TOKEN` bearer auth (mirror of LML's `/admin/upload-library-db` pattern). request-o-matic is a thin proxy: every write forwards to Backend-Service's `/internal/banned-fingerprints` CRUD (BS#1261). No local ban state, no JWT verification — rom's value-add is being co-located with the request-line surface operators already think about.

The shared mutation surface lives in `services/ban_service.py` so the future Slack-native router (#152) plugs into the same `ban` / `unban` / `list_bans` functions without spawning a second codepath.

End-to-end idempotency is preserved:
- Re-banning a fingerprint returns 200 with the updated row.
- Unbanning a non-existent fingerprint returns 204.
- 4xx upstream errors forward verbatim (operator typos surface as 400, not 500).
- 5xx upstream becomes 502 so a BS outage doesn't look like a rom bug.

## Endpoints

| Method | Path | Behavior |
|---|---|---|
| `POST` | `/admin/bans` | Create or update a ban (idempotent) |
| `DELETE` | `/admin/bans/{fingerprint}` | Remove a ban (idempotent — 204 whether or not row existed) |
| `GET` | `/admin/bans?limit=&cursor=` | List bans (keyset-paginated, mirrors BS shape) |

## Files

- `routers/admin.py` (new) — FastAPI router.
- `services/ban_service.py` (new) — shared mutation surface for #151 + #152.
- `services/ban_admin_client.py` (new) — httpx client for BS admin endpoints.
- `core/dependencies.py` — `require_admin_token` + `get_ban_admin_client`.
- `config/settings.py` — `admin_token`, `bs_internal_bans_url`, `bs_internal_key`.
- `main.py` — wire admin router at root (operators expect `/admin/bans`, not `/api/v1/admin/bans`).
- `docs/admin-bans.md` (new) — operator runbook with curl examples.
- `docs/env-vars.md`, `README.md`, `.env.example`, `CLAUDE.md` — env-var reference and topic-router updates.

## Test plan

- [x] Unit tests for `ban_admin_client` (httpx-mock-based: header forwarding, camelCase serialization, success + 4xx + 5xx + non-JSON body)
- [x] Unit tests for `ban_service` (passthrough, `actor` → `banned_by_user_id` translation)
- [x] Unit tests for router (auth matrix across all three endpoints, idempotency, upstream-error mapping, fail-closed when `BS_INTERNAL_*` unset)
- [x] Unit tests for `require_admin_token` + `get_ban_admin_client` dependencies
- [x] `test_main.py` pin that `/admin/bans` mounts at root, not under `/api/v1`
- [x] `pytest tests/unit/` — 413 passing locally
- [x] `ruff check .`, `ruff format --check .`, `mypy . --ignore-missing-imports` — all clean
- [ ] Staging smoke: after merge, set `ADMIN_TOKEN` + `BS_INTERNAL_BANS_URL` + `BS_INTERNAL_KEY` on the Railway service, then curl the runbook examples in `docs/admin-bans.md`

## Related

- Storage + upstream contract: WXYC/Backend-Service#1261
- Sibling — request-time enforcement: #150 (shares `BS_INTERNAL_KEY`)
- Sibling — Slack-native ban (planned): #152 (reuses `services/ban_service.py`)
- Tracker: #148
- Supersedes: #147

Closes #151