### PR TITLE
feat(request): enforce request-line bans via BS /auth/check-request-ban

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,16 @@ SENTRY_DSN=
 # upstream vars are unset, /admin/bans returns 503.
 ADMIN_TOKEN=
 BS_INTERNAL_BANS_URL=https://api.wxyc.org/internal/banned-fingerprints
+
+# Request-line ban enforcement (WXYC/request-o-matic#150 + WXYC/Backend-Service#1261)
+# Default OFF; flip to true after iOS 3.2 reaches App Store rollout.
+ENFORCE_REQUEST_BANS=false
+# Full URL of BS apps/auth POST /auth/check-request-ban (port 8082)
+BS_CHECK_REQUEST_BAN_URL=
+
+# Shared secret for BS internal endpoints. Used by /admin/bans (forwarded as
+# X-Internal-Key to BS /internal/banned-fingerprints) and held in shared
+# scope for both #150 (request-time check) and #151 (admin CRUD).
 BS_INTERNAL_KEY=
 
 # Discogs cache database (optional - reduces API calls)

--- a/config/settings.py
+++ b/config/settings.py
@@ -77,8 +77,29 @@ class Settings(BaseSettings):
         None,
         description=(
             "Shared secret forwarded as X-Internal-Key on calls to BS internal "
-            "endpoints (BS#1261 ROM_INTERNAL_KEY). Shared with the request-time "
-            "ban-check client (#150)."
+            "endpoints (BS#1261 ROM_INTERNAL_KEY). Used by /admin/bans (#151); "
+            "the public /auth/check-request-ban handler does NOT consume this."
+        ),
+    )
+
+    # Request-line ban enforcement (WXYC/request-o-matic#150 + WXYC/Backend-Service#1261).
+    # When enforce_request_bans is True and the caller supplies Authorization
+    # and/or X-Device-Fingerprint, ROM consults BS's /auth/check-request-ban
+    # endpoint and blocks 403 if BS says banned. See docs/architecture.md for
+    # the full flow.
+    bs_check_request_ban_url: str | None = Field(
+        None,
+        description=(
+            "Full URL of Backend-Service's POST /auth/check-request-ban endpoint "
+            "(apps/auth service, port 8082). When unset, the ban check is disabled "
+            "regardless of enforce_request_bans."
+        ),
+    )
+    enforce_request_bans: bool = Field(
+        default=False,
+        description=(
+            "Feature flag for request-line ban enforcement. Default False so the "
+            "code can deploy before iOS 3.2 reaches App Store rollout."
         ),
     )
 

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -15,6 +15,7 @@ from wxyc_fastapi.observability import get_posthog_client as _shared_posthog_cli
 from config.settings import Settings, get_settings
 from core.exceptions import ServiceInitializationError
 from services.ban_admin_client import BanAdminClient
+from services.ban_check_client import BanCheckClient
 from services.lookup_client import LookupServiceClient
 
 if TYPE_CHECKING:
@@ -51,6 +52,21 @@ def get_groq_client(settings: Settings = Depends(get_settings)) -> AsyncGroq:
     if not settings.groq_api_key:
         raise ServiceInitializationError("GROQ_API_KEY not configured")
     return AsyncGroq(api_key=settings.groq_api_key, max_retries=4)
+
+
+async def get_ban_check_client(
+    settings: Settings = Depends(get_settings),
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+) -> BanCheckClient | None:
+    """Get the BS ban-check client if request-line ban enforcement is enabled.
+
+    Returns None when either the feature flag (``ENFORCE_REQUEST_BANS``) is off
+    or the BS URL (``BS_CHECK_REQUEST_BAN_URL``) is unset, so the router can
+    skip the check entirely without a second branch on every request.
+    """
+    if not settings.enforce_request_bans or not settings.bs_check_request_ban_url:
+        return None
+    return BanCheckClient(settings.bs_check_request_ban_url, http_client)
 
 
 async def get_lookup_client(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,16 +1,18 @@
 # Architecture
 
 ## Request Flow
-1. **Parse**: Groq AI (`llama-3.1-8b-instant`) extracts artist/song/album from message
-2. **Early return**: Non-request messages (feedback, DJ messages) are posted to Slack without search
-3. **Delegate**: Search is delegated to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) via HTTP (`LOOKUP_SERVICE_URL`).
-4. **Slack**: Post enriched results with artwork to Slack
+1. **Ban check (optional)**: When `ENFORCE_REQUEST_BANS=true` and the caller supplies `Authorization` and/or `X-Device-Fingerprint`, ROM consults Backend-Service's `POST /auth/check-request-ban` ([BS#1261](https://github.com/WXYC/Backend-Service/issues/1261)) before parsing. Banned callers get 403 with no Slack, no Groq, no LML; everyone else proceeds. See `services/ban_check_client.py` and [`docs/env-vars.md`](env-vars.md) for the full flow + flag.
+2. **Parse**: Groq AI (`llama-3.1-8b-instant`) extracts artist/song/album from message
+3. **Early return**: Non-request messages (feedback, DJ messages) are posted to Slack without search
+4. **Delegate**: Search is delegated to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) via HTTP (`LOOKUP_SERVICE_URL`).
+5. **Slack**: Post enriched results with artwork to Slack
 
 ## Degraded Modes
 Slack is the only hard dependency. When Groq or LML are unavailable the listener's message still reaches Slack, with a context line explaining what's missing. The response is `200` with a `degraded_mode` field:
 
 - **`parsing_unavailable`** — Groq failed (rate limit, timeout, parse error, etc.). The raw listener message is posted to Slack with a `_Parsing unavailable_` context line. No classification, no search.
 - **`search_unavailable`** — LML is down or `LOOKUP_SERVICE_URL` is unset. The parsed message is posted to Slack with a `_Search unavailable_` context line containing any artist/song/album fields Groq extracted. Empty `library_results`.
+- **`ban_check_unavailable`** — BS `/auth/check-request-ban` was unreachable. The request still proceeds (fail-open is the correct posture for an authz feature; a BS outage must not break listener requests). Emitted only when no more severe degraded mode is active; the independent `ban_check_degraded` PostHog property is always set so operators see both signals together.
 
 If Slack itself fails the endpoint returns `502` — there is no further fallback. PostHog events for degraded requests carry `degraded_mode` and `degraded_reason` (the exception class name) so outages are visible in telemetry.
 
@@ -22,6 +24,7 @@ If Slack itself fails the endpoint returns `502` — there is no further fallbac
 - `routers/health.py` - Health check endpoints: `GET /health` (shallow liveness probe, no external calls) and `GET /health/ready` (deep readiness check: groq, lookup, slack services). Railway's `healthcheckPath` uses `/health` so the container becomes routable immediately on boot.
 - `services/parser.py` - Groq AI message parsing
 - `services/lookup_client.py` - HTTP client for library-metadata-lookup delegation
+- `services/ban_check_client.py` - HTTP client for Backend-Service `POST /auth/check-request-ban` (BS#1261). Fails open (raises `BanCheckUnavailableError`) on network errors, timeouts, or 5xx; treats BS 401/404 as proceed-as-unauth so the caller is never 401'd on `POST /request`.
 - `services/slack.py` - Slack message formatting and posting
 - `core/dependencies.py` - FastAPI dependency injection (HTTP client, Groq, Slack, PostHog). Sentry, telemetry, cache stats, and PostHog client construction live in [`wxyc-fastapi`](https://github.com/WXYC/wxyc-fastapi); `core/dependencies.get_posthog_client` only wraps the shared singleton with the rom-side `enable_telemetry` flag.
 - `core/groq_tracing.py` - Sentry instrumentation for Groq parse calls: a `groq_parse_span` context manager wrapping `services.parser.parse_request` (op `ai.parse`, tagged with model, input length, token counts, and parse-result fields), and an `install_groq_retry_breadcrumbs()` filter on the `groq._base_client` logger that converts the SDK's silent 429-retry log lines into structured `groq.retry` breadcrumbs. Installed once from `main.py` after `init_sentry`.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -17,4 +17,10 @@ Optional:
 Admin API for request-line bans (see [`docs/admin-bans.md`](admin-bans.md)):
 - `ADMIN_TOKEN` - Bearer token gating the `/admin/bans` endpoints. When unset, every admin request is rejected with 403 (fail-closed). Rotate by updating the Railway service variable.
 - `BS_INTERNAL_BANS_URL` - Base URL of Backend-Service's `/internal/banned-fingerprints` CRUD (BS#1261). Example: `https://api.wxyc.org/internal/banned-fingerprints`. When unset, `/admin/bans` returns 503.
-- `BS_INTERNAL_KEY` - Shared secret forwarded as `X-Internal-Key` on calls to BS internal endpoints. Must equal `ROM_INTERNAL_KEY` on the BS side. Shared with the request-time ban-check client.
+- `BS_INTERNAL_KEY` - Shared secret forwarded as `X-Internal-Key` on calls to BS internal endpoints. Must equal `ROM_INTERNAL_KEY` on the BS side. Used by `/admin/bans` (#151); the public `/auth/check-request-ban` handler does NOT consume this.
+
+Request-line ban enforcement ([WXYC/request-o-matic#150](https://github.com/WXYC/request-o-matic/issues/150) + [WXYC/Backend-Service#1261](https://github.com/WXYC/Backend-Service/issues/1261)):
+- `ENFORCE_REQUEST_BANS` - Feature flag for request-line ban enforcement. Default `false` so the code can deploy before iOS 3.2 reaches App Store rollout. When `true` AND `BS_CHECK_REQUEST_BAN_URL` is set, every `POST /request` consults BS before parsing.
+- `BS_CHECK_REQUEST_BAN_URL` - Full URL of Backend-Service's `POST /auth/check-request-ban` endpoint (apps/auth service, port 8082), e.g. `https://wxyc-auth-staging.up.railway.app/auth/check-request-ban`. When unset, the ban check is disabled regardless of `ENFORCE_REQUEST_BANS`.
+
+Flow when enforcement is on and the caller supplies `Authorization: Bearer <jwt>` and/or `X-Device-Fingerprint: <uuid>`: ROM POSTs both headers to `BS_CHECK_REQUEST_BAN_URL` before parse. `banned: true` short-circuits to 403 (no Slack, no Groq, no LML) and emits a `request_blocked` PostHog event with `user_id`, `fingerprint`, `ban_reason`, `ban_source`. `banned: false` proceeds. BS 401 (invalid JWT) and 404 (user not found) proceed-as-unauth — the caller MUST NOT see a 401 on `POST /request`, since v3.1 iOS clients send no Authorization header. When BS is unreachable, ROM fails open: log a Sentry breadcrumb, emit `degraded_mode=ban_check_unavailable` telemetry, proceed.

--- a/routers/request.py
+++ b/routers/request.py
@@ -260,17 +260,24 @@ async def handle_request(
             if ban_result.banned:
                 # Shadow-ban semantics: no Slack, no Groq, no LML. iOS v3.2
                 # silently swallows 403 so the listener sees nothing.
+                # PostHog capture is wrapped because a Posthog ingest outage
+                # raising here would otherwise prevent the 403 and 500 the
+                # caller instead — breaking shadow-ban (the banned listener
+                # would see that the backend is doing extra work).
                 if posthog_client is not None:
-                    posthog_client.capture(
-                        distinct_id="request-o-matic-service",
-                        event="request_blocked",
-                        properties={
-                            "user_id": ban_result.user_id,
-                            "fingerprint": ban_result.fingerprint,
-                            "ban_reason": ban_result.ban_reason,
-                            "ban_source": ban_result.ban_source,
-                        },
-                    )
+                    try:
+                        posthog_client.capture(
+                            distinct_id="request-o-matic-service",
+                            event="request_blocked",
+                            properties={
+                                "user_id": ban_result.user_id,
+                                "fingerprint": ban_result.fingerprint,
+                                "ban_reason": ban_result.ban_reason,
+                                "ban_source": ban_result.ban_source,
+                            },
+                        )
+                    except Exception:
+                        logger.exception("PostHog request_blocked capture failed")
                 logger.info(
                     "Blocked request from banned caller (source=%s, user_id=%s)",
                     ban_result.ban_source,

--- a/routers/request.py
+++ b/routers/request.py
@@ -1,16 +1,20 @@
 """Request handling router that delegates search to library-metadata-lookup service.
 
 Flow:
-1. Parse the message using Groq AI to extract artist/song/album
-2. Early return for non-requests (feedback, DJ messages, etc.)
-3. Delegate search to library-metadata-lookup service via HTTP
-4. Post enriched results to Slack
+1. (Optional) Consult BS /auth/check-request-ban to enforce request-line bans.
+2. Parse the message using Groq AI to extract artist/song/album
+3. Early return for non-requests (feedback, DJ messages, etc.)
+4. Delegate search to library-metadata-lookup service via HTTP
+5. Post enriched results to Slack
 
 Degraded modes:
 - "parsing_unavailable": Groq parsing failed. Slack receives the raw listener
   message with a "_Parsing unavailable_" note. No classification, no search.
 - "search_unavailable": LML is down or unconfigured. Slack receives the parsed
   metadata with a "_Search unavailable_" note. No library results.
+- "ban_check_unavailable": BS /auth/check-request-ban was unreachable. The
+  request still proceeds (fail-open) but the telemetry property is set so
+  operators can see the outage in PostHog.
 
 Slack remains the only hard dependency: if it fails, the endpoint returns 502.
 """
@@ -21,13 +25,15 @@ import logging
 from typing import TYPE_CHECKING
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+import sentry_sdk
+from fastapi import APIRouter, Depends, Header, HTTPException
 from groq import AsyncGroq
 from pydantic import BaseModel
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
 
 from core.dependencies import (
     SlackService,
+    get_ban_check_client,
     get_groq_client,
     get_lookup_client,
     get_posthog_client,
@@ -37,6 +43,7 @@ from core.dependencies import (
 if TYPE_CHECKING:
     from posthog import Posthog
 from models import LibraryItem, ReleaseMetadata
+from services.ban_check_client import BanCheckClient, BanCheckUnavailableError
 from services.lookup_client import LookupRequest, LookupServiceClient
 from services.parser import MessageType, ParsedRequest, parse_request
 from services.slack import build_simple_slack_blocks, build_slack_blocks
@@ -54,6 +61,7 @@ MESSAGE_TYPE_LABELS = {
 
 DEGRADED_PARSING = "parsing_unavailable"
 DEGRADED_SEARCH = "search_unavailable"
+DEGRADED_BAN_CHECK = "ban_check_unavailable"
 
 _LML_TRANSIENT_ERRORS = (
     httpx.HTTPStatusError,
@@ -193,6 +201,7 @@ async def _post_degraded_to_slack(
     responses={
         200: {"description": "Request processed (possibly via a degraded fallback)"},
         400: {"description": "Invalid request (empty message)"},
+        403: {"description": "Caller is banned from the request line"},
         502: {"description": "Slack unavailable"},
     },
 )
@@ -202,6 +211,9 @@ async def handle_request(
     slack_service: SlackService | None = Depends(get_slack_service),
     posthog_client: Posthog | None = Depends(get_posthog_client),
     lookup_client: LookupServiceClient | None = Depends(get_lookup_client),
+    ban_check_client: BanCheckClient | None = Depends(get_ban_check_client),
+    authorization: str | None = Header(default=None),
+    x_device_fingerprint: str | None = Header(default=None),
 ):
     """Parse a request, search the library, and post to Slack.
 
@@ -217,6 +229,54 @@ async def handle_request(
         distinct_id="request-o-matic-service",
         event_prefix="request",
     )
+
+    # Request-line ban enforcement (WXYC/request-o-matic#150 + BS#1261).
+    # Runs BEFORE parse so an abusive listener does not consume Groq TPM or
+    # LML cache budget. The check is fully skipped when:
+    #   - the feature flag is off (ban_check_client is None), OR
+    #   - the caller supplies neither Authorization nor X-Device-Fingerprint
+    #     (matches v3.1 iOS clients in production — BS would 400 no_signal).
+    # The BS endpoint is public; we do NOT forward X-Internal-Key here.
+    ban_check_degraded = False
+    if ban_check_client is not None and (authorization or x_device_fingerprint):
+        try:
+            ban_result = await ban_check_client.check(
+                authorization=authorization,
+                fingerprint=x_device_fingerprint,
+            )
+        except BanCheckUnavailableError as exc:
+            # Fail open: log a Sentry breadcrumb so the outage is visible in
+            # the distributed trace, and let the request proceed. The
+            # degraded_mode flag rides on the final telemetry event.
+            logger.warning("Ban check unavailable (%s); proceeding with request", exc)
+            sentry_sdk.add_breadcrumb(
+                category="ban_check",
+                level="warning",
+                message="BS /auth/check-request-ban unavailable; failing open",
+                data={"error": str(exc)},
+            )
+            ban_check_degraded = True
+        else:
+            if ban_result.banned:
+                # Shadow-ban semantics: no Slack, no Groq, no LML. iOS v3.2
+                # silently swallows 403 so the listener sees nothing.
+                if posthog_client is not None:
+                    posthog_client.capture(
+                        distinct_id="request-o-matic-service",
+                        event="request_blocked",
+                        properties={
+                            "user_id": ban_result.user_id,
+                            "fingerprint": ban_result.fingerprint,
+                            "ban_reason": ban_result.ban_reason,
+                            "ban_source": ban_result.ban_source,
+                        },
+                    )
+                logger.info(
+                    "Blocked request from banned caller (source=%s, user_id=%s)",
+                    ban_result.ban_source,
+                    ban_result.user_id,
+                )
+                raise HTTPException(status_code=403, detail="Request blocked")
 
     try:
         with telemetry.track_step("parse"):
@@ -242,19 +302,22 @@ async def handle_request(
                 note="Parsing unavailable",
             )
         if posthog_client:
+            parse_props: dict = {
+                "results_count": 0,
+                "search_type": "none",
+                "had_artist": False,
+                "had_album": False,
+                "had_song": False,
+                "is_request": None,
+                "message_type": None,
+                "degraded_mode": DEGRADED_PARSING,
+                "degraded_reason": type(e).__name__,
+            }
+            if ban_check_degraded:
+                parse_props["ban_check_degraded"] = True
             telemetry.send_to_posthog(
                 posthog_client,
-                {
-                    "results_count": 0,
-                    "search_type": "none",
-                    "had_artist": False,
-                    "had_album": False,
-                    "had_song": False,
-                    "is_request": None,
-                    "message_type": None,
-                    "degraded_mode": DEGRADED_PARSING,
-                    "degraded_reason": type(e).__name__,
-                },
+                parse_props,
             )
         return UnifiedResponse(
             parsed=None,
@@ -345,8 +408,13 @@ async def handle_request(
         next((art for _, art in items_with_artwork if art), None) if items_with_artwork else None
     )
 
-    # Send telemetry
+    # Send telemetry. degraded_mode priority: search > ban_check. Search is
+    # more user-visible (no library results) so it wins on the single field;
+    # ban_check_degraded rides on its own dedicated property so operators can
+    # see both signals in PostHog.
     degraded_mode = DEGRADED_SEARCH if lookup_failure is not None else None
+    if degraded_mode is None and ban_check_degraded:
+        degraded_mode = DEGRADED_BAN_CHECK
     if posthog_client:
         properties: dict = {
             "results_count": len(library_results),
@@ -359,7 +427,12 @@ async def handle_request(
         }
         if degraded_mode:
             properties["degraded_mode"] = degraded_mode
-            properties["degraded_reason"] = type(lookup_failure).__name__
+            if lookup_failure is not None:
+                properties["degraded_reason"] = type(lookup_failure).__name__
+        if ban_check_degraded:
+            # Always emit the ban_check signal independently so it surfaces
+            # even when a more severe degraded_mode (search) is also set.
+            properties["ban_check_degraded"] = True
         telemetry.send_to_posthog(posthog_client, properties)
 
     return UnifiedResponse(

--- a/services/ban_check_client.py
+++ b/services/ban_check_client.py
@@ -1,0 +1,189 @@
+"""HTTP client for Backend-Service ``POST /auth/check-request-ban``.
+
+BS#1261 exposes a public endpoint on the apps/auth service (port 8082) that
+ROM calls on every ``POST /request`` to decide whether to allow or block a
+listener. See WXYC/Backend-Service#1261 for the architecture record and
+``apps/auth/check-request-ban-handler.ts`` in that repo for the BS-side
+implementation.
+
+Contract (relevant subset):
+
+* Inputs travel in two request headers — ``Authorization: Bearer <jwt>`` and
+  ``X-Device-Fingerprint: <uuid>``. The body is empty. At least one of the
+  two must be present; BS returns 400 ``no_signal`` otherwise. We treat 400
+  as a contract bug and surface it as ``BanCheckUnavailableError`` so the router
+  fails open rather than silently banning every caller.
+* 200 with ``banned: true`` → caller is banned. Response carries ``userId``,
+  ``fingerprint``, ``banReason``, ``banSource`` (``"user"`` | ``"fingerprint"``).
+* 200 with ``banned: false`` → caller is allowed.
+* 401 (invalid/expired JWT) and 404 (user not found) → treat as "proceed as
+  unauthenticated". The caller MUST NOT receive a 401 on ``POST /request``;
+  v3.1 iOS clients in production send no Authorization header, and an invalid
+  JWT (e.g. from a stale install) must not break them.
+* Network errors, timeouts, and 5xx → ``BanCheckUnavailableError``. The router
+  fails open: log a Sentry breadcrumb, emit ``degraded_mode=ban_check_unavailable``,
+  and proceed with the request.
+
+No ``X-Internal-Key`` header is forwarded: the BS endpoint is intentionally
+public (per ``apps/auth/app.ts`` comment, "intentionally public (no
+X-Internal-Key gate)"). Authentication is per-request via the JWT and/or
+fingerprint, and BS bounds the cost with per-IP rate limiting.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+__all__ = [
+    "BanCheckClient",
+    "BanCheckResult",
+    "BanCheckUnavailableError",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class BanCheckUnavailableError(Exception):
+    """Raised when the BS ban-check endpoint is unreachable or returns 5xx/400.
+
+    The router catches this and fails open: the listener's request proceeds
+    through the existing pipeline, a Sentry breadcrumb is recorded, and a
+    ``degraded_mode=ban_check_unavailable`` telemetry property is emitted so
+    operators can see the outage in PostHog.
+    """
+
+
+@dataclass(frozen=True)
+class BanCheckResult:
+    """Parsed result of a ban check.
+
+    Attributes:
+        banned: True when BS says block the caller.
+        user_id: ``user.id`` claim from the verified JWT (None when the call
+            was fingerprint-only, when the JWT was invalid, or when the user
+            was not found).
+        fingerprint: The echoed device fingerprint (None when absent).
+        ban_reason: Free-form ban reason from BS (only set when ``banned``).
+        ban_source: ``"user"`` (better-auth user ban) or ``"fingerprint"``
+            (banned_fingerprints row). Only set when ``banned``.
+    """
+
+    banned: bool
+    user_id: str | None = None
+    fingerprint: str | None = None
+    ban_reason: str | None = None
+    ban_source: str | None = None
+
+
+class BanCheckClient:
+    """Thin async client for BS ``POST /auth/check-request-ban``.
+
+    Args:
+        url: Full URL of the BS endpoint, e.g.
+            ``http://localhost:8082/auth/check-request-ban``.
+        http_client: Shared ``httpx.AsyncClient`` (Sentry's httpx integration
+            adds distributed tracing so the BS call appears as a child span
+            of ``handle_request``).
+        timeout: Per-request timeout in seconds. BS's handler does a JWT
+            signature verify + 1-2 DB lookups; ~5s is plenty.
+        retry_delay: Currently unused — kept as a no-op kwarg so the
+            constructor signature stays stable if we add a single retry later.
+    """
+
+    _NETWORK_ERRORS = (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError)
+
+    def __init__(
+        self,
+        url: str,
+        http_client: httpx.AsyncClient,
+        *,
+        timeout: float = 5.0,
+        retry_delay: float = 0.0,
+    ):
+        self.url = url
+        self.http_client = http_client
+        self.timeout = timeout
+        self.retry_delay = retry_delay
+
+    async def check(
+        self,
+        *,
+        authorization: str | None,
+        fingerprint: str | None,
+    ) -> BanCheckResult:
+        """Call BS and return the parsed result.
+
+        Args:
+            authorization: Raw value of the caller's ``Authorization`` header
+                (e.g. ``"Bearer <jwt>"``), or None.
+            fingerprint: Raw value of the caller's ``X-Device-Fingerprint``
+                header, or None.
+
+        Returns:
+            A ``BanCheckResult``. ``banned=False`` is also returned for the
+            "proceed as unauth" cases (BS 401/404).
+
+        Raises:
+            ValueError: If neither ``authorization`` nor ``fingerprint`` is
+                supplied — the caller must gate that case to avoid the
+                pointless BS round-trip.
+            BanCheckUnavailableError: On network errors, timeouts, 5xx, or
+                contract-bug 4xx (e.g. 400 ``no_signal``).
+        """
+        if not authorization and not fingerprint:
+            raise ValueError(
+                "BanCheckClient.check requires at least one of authorization or fingerprint"
+            )
+
+        headers: dict[str, str] = {}
+        if authorization:
+            headers["Authorization"] = authorization
+        if fingerprint:
+            headers["X-Device-Fingerprint"] = fingerprint
+
+        try:
+            response = await self.http_client.post(
+                self.url,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except self._NETWORK_ERRORS as exc:
+            logger.warning("BS ban-check unreachable (%s: %s)", type(exc).__name__, exc)
+            raise BanCheckUnavailableError(str(exc)) from exc
+
+        status = response.status_code
+        if status in (401, 404):
+            # Invalid JWT or unknown user — proceed as unauthenticated.
+            # iOS v3.1 clients (the current App Store binary) send no
+            # Authorization header, and a stale JWT from a re-install must
+            # not break them.
+            logger.debug("BS ban-check returned %d; treating as proceed-as-unauth", status)
+            return BanCheckResult(banned=False)
+
+        if 500 <= status < 600:
+            logger.warning("BS ban-check returned %d", status)
+            raise BanCheckUnavailableError(f"BS returned {status}")
+
+        if status != 200:
+            # 400 no_signal / 400 invalid_fingerprint / unexpected 4xx.
+            # Surface as unavailable so the router fails open rather than
+            # turning a contract bug into a silent block-everyone failure.
+            logger.warning("BS ban-check unexpected status %d: %s", status, response.text[:200])
+            raise BanCheckUnavailableError(f"BS returned {status}")
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            logger.warning("BS ban-check returned 200 with non-JSON body")
+            raise BanCheckUnavailableError("BS returned non-JSON body") from exc
+
+        return BanCheckResult(
+            banned=bool(body.get("banned", False)),
+            user_id=body.get("userId"),
+            fingerprint=body.get("fingerprint"),
+            ban_reason=body.get("banReason"),
+            ban_source=body.get("banSource"),
+        )

--- a/services/ban_check_client.py
+++ b/services/ban_check_client.py
@@ -33,9 +33,21 @@ fingerprint, and BS bounds the cost with per-IP rate limiting.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 
 import httpx
+
+# Permissive UUID regex matching BS's UUID_REGEX in
+# apps/auth/check-request-ban-handler.ts — accepts any UUID version. ROM uses
+# this to drop malformed fingerprint headers BEFORE the BS round-trip, since
+# a malformed fingerprint would make BS reply 400 (the entire ban check would
+# fail open and let a banned listener bypass enforcement just by appending
+# garbage to their X-Device-Fingerprint header).
+_FINGERPRINT_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 __all__ = [
     "BanCheckClient",
@@ -93,7 +105,12 @@ class BanCheckClient:
             constructor signature stays stable if we add a single retry later.
     """
 
-    _NETWORK_ERRORS = (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError)
+    # Use httpx.HTTPError (the base class for every httpx exception) so that
+    # transport-class errors NOT in TransportError's subtree — InvalidURL,
+    # UnsupportedProtocol, ProxyError — also fail open. Otherwise a
+    # misconfigured BS_CHECK_REQUEST_BAN_URL would 500 every /request instead
+    # of letting traffic through.
+    _NETWORK_ERRORS = (httpx.HTTPError,)
 
     def __init__(
         self,
@@ -133,6 +150,17 @@ class BanCheckClient:
             BanCheckUnavailableError: On network errors, timeouts, 5xx, or
                 contract-bug 4xx (e.g. 400 ``no_signal``).
         """
+        # Drop malformed fingerprint values before they reach BS. Without
+        # this, a banned listener could bypass enforcement by sending
+        # `X-Device-Fingerprint: not-a-uuid` — BS would reply 400, ROM would
+        # treat that as BanCheckUnavailableError, and the router would fail
+        # open. Treat malformed fingerprint as if no fingerprint was sent;
+        # BS will then check only the JWT (or, if neither survives, the
+        # caller is no-signal and we short-circuit to fail open below).
+        if fingerprint is not None and not _FINGERPRINT_RE.match(fingerprint):
+            logger.info("X-Device-Fingerprint header is not a valid UUID; ignoring")
+            fingerprint = None
+
         if not authorization and not fingerprint:
             raise ValueError(
                 "BanCheckClient.check requires at least one of authorization or fingerprint"
@@ -180,8 +208,17 @@ class BanCheckClient:
             logger.warning("BS ban-check returned 200 with non-JSON body")
             raise BanCheckUnavailableError("BS returned non-JSON body") from exc
 
+        # The `banned` key is REQUIRED on every successful response. Coercing a
+        # missing key to False would silently disable enforcement if a future
+        # BS regression returned a partial body — visible only as a drop in
+        # PostHog `request_blocked` events, which is exactly the metric an
+        # operator wouldn't notice was missing.
+        if "banned" not in body:
+            logger.warning("BS ban-check returned 200 without 'banned' key: %r", body)
+            raise BanCheckUnavailableError("BS response missing 'banned' key")
+
         return BanCheckResult(
-            banned=bool(body.get("banned", False)),
+            banned=bool(body["banned"]),
             user_id=body.get("userId"),
             fingerprint=body.get("fingerprint"),
             ban_reason=body.get("banReason"),

--- a/tests/integration/test_ban_enforcement_e2e.py
+++ b/tests/integration/test_ban_enforcement_e2e.py
@@ -1,0 +1,88 @@
+"""End-to-end ban-enforcement smoke tests against a deployed BS environment.
+
+These exercise the actual BS ``POST /auth/check-request-ban`` endpoint
+(WXYC/Backend-Service#1261). They are deliberately small — full coverage lives
+in the unit suite. The point here is to catch contract drift between ROM's
+``BanCheckClient`` and the live BS endpoint.
+
+Run only against staging, since they POST to the deployed ROM ``/request``
+endpoint (which posts to Slack from the deployed container — production runs
+would spam the live WXYC channel; we always pass ``skip_slack=True`` for
+safety, but staging is the conventional target).
+
+Activation:
+
+* Marker: ``external_api``
+* Required env: ``BS_CHECK_REQUEST_BAN_URL`` (full staging URL), and ROM
+  staging must have ``ENFORCE_REQUEST_BANS=true`` set for the in-router
+  enforcement to actually fire. Without one of those, the suite is skipped.
+
+Run with:
+
+    BS_CHECK_REQUEST_BAN_URL=https://wxyc-auth-staging.up.railway.app/auth/check-request-ban \\
+        TEST_ENV=staging pytest tests/integration/test_ban_enforcement_e2e.py -v -m external_api
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.external_api
+
+BS_URL: str | None = os.getenv("BS_CHECK_REQUEST_BAN_URL")
+
+skip_if_no_bs_url = pytest.mark.skipif(
+    not BS_URL,
+    reason="BS_CHECK_REQUEST_BAN_URL not set — skipping live BS contract tests",
+)
+
+
+@skip_if_no_bs_url
+@pytest.mark.asyncio
+async def test_bs_check_request_ban_no_signal_returns_400():
+    """Smoke test: BS endpoint exists and returns 400 no_signal when called bare.
+
+    This is the cheapest possible contract check — it doesn't require any
+    pre-seeded user or fingerprint to exist on the BS side, and it pins the
+    request shape (POST, no body) and BS's error response contract.
+    """
+    assert BS_URL is not None  # narrows for mypy; the skipif guarantees this
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(BS_URL)
+
+    assert response.status_code == 400, (
+        f"Expected 400 no_signal from BS without headers, got {response.status_code}: "
+        f"{response.text[:300]}"
+    )
+    body = response.json()
+    assert body.get("error") == "no_signal", f"Unexpected error body: {body}"
+
+
+@skip_if_no_bs_url
+@pytest.mark.asyncio
+async def test_bs_check_request_ban_unknown_fingerprint_returns_unbanned():
+    """A random UUID fingerprint should be 200 banned=false.
+
+    BS#1261's banned_fingerprints table is keyed on UUID. A fresh random UUID
+    is overwhelmingly unlikely to collide with a real ban, so the response
+    should be 200 ``banned=false`` with no userId.
+    """
+    import uuid
+
+    assert BS_URL is not None  # narrows for mypy
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(
+            BS_URL,
+            headers={"X-Device-Fingerprint": str(uuid.uuid4())},
+        )
+
+    assert response.status_code == 200, (
+        f"Expected 200 from BS with random fingerprint, got {response.status_code}: "
+        f"{response.text[:300]}"
+    )
+    body = response.json()
+    assert body.get("banned") is False
+    assert body.get("userId") is None

--- a/tests/unit/test_ban_check_client.py
+++ b/tests/unit/test_ban_check_client.py
@@ -246,3 +246,108 @@ class TestBanCheckClientRequestShape:
         client = _make_client(handler)
         with pytest.raises(ValueError):
             await client.check(authorization=None, fingerprint=None)
+
+
+class TestFingerprintValidation:
+    """Malformed `X-Device-Fingerprint` headers are dropped client-side rather
+    than forwarded to BS. Without this guard a banned listener could bypass
+    enforcement by appending garbage to the header — BS would 400, ROM would
+    treat as `BanCheckUnavailableError`, and the router would fail open.
+    """
+
+    @pytest.mark.asyncio
+    async def test_malformed_fingerprint_dropped_jwt_only_call_proceeds(self):
+        """With a JWT plus a non-UUID fingerprint, ROM forwards only the JWT."""
+        captured: dict = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = dict(request.headers)
+            return httpx.Response(200, json={"banned": False})
+
+        client = _make_client(handler)
+        result = await client.check(authorization="Bearer x", fingerprint="not-a-uuid")
+
+        assert result.banned is False
+        assert captured["headers"].get("authorization") == "Bearer x"
+        # The malformed fingerprint must NOT have been forwarded — BS would
+        # have rejected the call with 400, which we already test as
+        # fail-open. The whole point of this guard is to never reach that
+        # state in the first place.
+        assert "x-device-fingerprint" not in captured["headers"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_fingerprint_no_jwt_raises_value_error(self):
+        """Only signal is a bad fingerprint — after dropping it, we have
+        nothing to send, so check() raises ValueError (the standard
+        no-signal contract). The router gates on the same condition so this
+        is reachable only via a misbehaving direct caller."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail("BS must not be called when no signal survives validation")
+
+        client = _make_client(handler)
+        with pytest.raises(ValueError):
+            await client.check(authorization=None, fingerprint="abc?inject=evil")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "valid_uuid",
+        [
+            "11111111-2222-3333-4444-555555555555",  # any version
+            "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",  # uppercase
+            "11111111-1111-4111-8111-111111111111",  # v4-shaped
+        ],
+    )
+    async def test_valid_uuid_forwarded_verbatim(self, valid_uuid):
+        captured: dict = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = dict(request.headers)
+            return httpx.Response(200, json={"banned": False})
+
+        client = _make_client(handler)
+        await client.check(authorization=None, fingerprint=valid_uuid)
+        assert captured["headers"]["x-device-fingerprint"] == valid_uuid
+
+
+class TestMissingBannedKey:
+    """A 200 response missing the required `banned` key must NOT coerce to
+    `banned=False` — that would silently disable enforcement on a BS
+    regression. Surface as unavailable so the router fails open AND the
+    operator sees the breadcrumb."""
+
+    @pytest.mark.asyncio
+    async def test_missing_banned_key_raises_unavailable(self):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            # BS regression: returns 200 with an empty object.
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler)
+        with pytest.raises(BanCheckUnavailableError):
+            await client.check(authorization="Bearer x", fingerprint=None)
+
+    @pytest.mark.asyncio
+    async def test_present_banned_key_with_false_value_proceeds(self):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"banned": False})
+
+        client = _make_client(handler)
+        result = await client.check(authorization="Bearer x", fingerprint=None)
+        assert result.banned is False
+
+
+class TestInvalidUrlFailsOpen:
+    """A misconfigured BS URL (typo, missing scheme) must fail open as
+    `BanCheckUnavailableError` — NOT escape as an httpx.InvalidURL crashing
+    every /request. _NETWORK_ERRORS broadened to httpx.HTTPError covers this."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_raises_unavailable(self):
+        # Construct a client whose URL httpx will reject at send time.
+        client = BanCheckClient(
+            "not-a-url",
+            httpx.AsyncClient(),
+            timeout=1.0,
+        )
+        with pytest.raises(BanCheckUnavailableError):
+            await client.check(authorization="Bearer x", fingerprint=None)

--- a/tests/unit/test_ban_check_client.py
+++ b/tests/unit/test_ban_check_client.py
@@ -241,7 +241,7 @@ class TestBanCheckClientRequestShape:
         """Calling check() with neither header is a programmer error; raise."""
 
         async def handler(request: httpx.Request) -> httpx.Response:
-            pytest.fail("BS must not be called when no signal is present")
+            raise AssertionError("BS must not be called when no signal is present")
 
         client = _make_client(handler)
         with pytest.raises(ValueError):
@@ -283,7 +283,7 @@ class TestFingerprintValidation:
         is reachable only via a misbehaving direct caller."""
 
         async def handler(request: httpx.Request) -> httpx.Response:
-            pytest.fail("BS must not be called when no signal survives validation")
+            raise AssertionError("BS must not be called when no signal survives validation")
 
         client = _make_client(handler)
         with pytest.raises(ValueError):

--- a/tests/unit/test_ban_check_client.py
+++ b/tests/unit/test_ban_check_client.py
@@ -1,0 +1,248 @@
+"""Unit tests for services/ban_check_client.py.
+
+The ban-check client wraps BS `POST /auth/check-request-ban` (WXYC/Backend-Service#1261).
+Responsibilities:
+
+- Build the request from the two caller-supplied headers (``Authorization`` and/or
+  ``X-Device-Fingerprint``) and POST to BS auth.
+- Parse 200 responses into a typed ``BanCheckResult``.
+- Treat 401 (invalid/expired JWT) and 404 (user not found) as
+  ``banned=False`` — i.e. proceed-as-unauth. The caller must NOT be 401'd.
+- Raise ``BanCheckUnavailableError`` for network errors, timeouts, and 5xx responses.
+  The router fails open on this exception.
+- Skip the call entirely when neither header is present (caller's responsibility
+  to gate, but we still validate here so the client is safe to call directly).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from services.ban_check_client import (
+    BanCheckClient,
+    BanCheckResult,
+    BanCheckUnavailableError,
+)
+
+
+def _make_client(handler, *, retry_delay: float = 0.0) -> BanCheckClient:
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(transport=transport)
+    return BanCheckClient(
+        "http://bs-auth:8082/auth/check-request-ban",
+        http_client,
+        retry_delay=retry_delay,
+    )
+
+
+class TestBanCheckClientHappyPath:
+    """Successful BS responses parse into BanCheckResult."""
+
+    @pytest.mark.asyncio
+    async def test_unbanned_user_with_jwt(self):
+        captured: dict = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = dict(request.headers)
+            captured["url"] = str(request.url)
+            captured["method"] = request.method
+            return httpx.Response(
+                200,
+                json={"userId": "user-abc", "fingerprint": None, "banned": False},
+            )
+
+        client = _make_client(handler)
+        result = await client.check(authorization="Bearer eyJhbGc...", fingerprint=None)
+
+        assert isinstance(result, BanCheckResult)
+        assert result.banned is False
+        assert result.user_id == "user-abc"
+        assert result.fingerprint is None
+        assert result.ban_reason is None
+        assert result.ban_source is None
+
+        assert captured["method"] == "POST"
+        assert captured["url"] == "http://bs-auth:8082/auth/check-request-ban"
+        assert captured["headers"]["authorization"] == "Bearer eyJhbGc..."
+        assert "x-device-fingerprint" not in captured["headers"]
+
+    @pytest.mark.asyncio
+    async def test_banned_user(self):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "userId": "user-banned",
+                    "fingerprint": "11111111-1111-4111-8111-111111111111",
+                    "banned": True,
+                    "banReason": "Repeated abuse",
+                    "banSource": "user",
+                },
+            )
+
+        client = _make_client(handler)
+        result = await client.check(
+            authorization="Bearer eyJ...",
+            fingerprint="11111111-1111-4111-8111-111111111111",
+        )
+
+        assert result.banned is True
+        assert result.user_id == "user-banned"
+        assert result.fingerprint == "11111111-1111-4111-8111-111111111111"
+        assert result.ban_reason == "Repeated abuse"
+        assert result.ban_source == "user"
+
+    @pytest.mark.asyncio
+    async def test_banned_fingerprint_only(self):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "userId": None,
+                    "fingerprint": "22222222-2222-4222-8222-222222222222",
+                    "banned": True,
+                    "banReason": "Spam",
+                    "banSource": "fingerprint",
+                },
+            )
+
+        client = _make_client(handler)
+        result = await client.check(
+            authorization=None,
+            fingerprint="22222222-2222-4222-8222-222222222222",
+        )
+
+        assert result.banned is True
+        assert result.user_id is None
+        assert result.fingerprint == "22222222-2222-4222-8222-222222222222"
+        assert result.ban_source == "fingerprint"
+
+    @pytest.mark.asyncio
+    async def test_forwards_both_headers(self):
+        captured: dict = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["headers"] = dict(request.headers)
+            return httpx.Response(200, json={"userId": "u", "fingerprint": "f", "banned": False})
+
+        client = _make_client(handler)
+        await client.check(
+            authorization="Bearer abc",
+            fingerprint="33333333-3333-4333-8333-333333333333",
+        )
+
+        assert captured["headers"]["authorization"] == "Bearer abc"
+        assert captured["headers"]["x-device-fingerprint"] == "33333333-3333-4333-8333-333333333333"
+
+
+class TestBanCheckClientProceedAsUnauth:
+    """401 / 404 from BS → proceed-as-unauth (banned=False), NOT an error."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_returns_unbanned(self):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"error": "invalid_token"})
+
+        client = _make_client(handler)
+        result = await client.check(authorization="Bearer garbage", fingerprint=None)
+
+        assert result.banned is False
+        assert result.user_id is None
+        assert result.fingerprint is None
+
+    @pytest.mark.asyncio
+    async def test_user_not_found_returns_unbanned(self):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"error": "user_not_found"})
+
+        client = _make_client(handler)
+        result = await client.check(authorization="Bearer ghost", fingerprint=None)
+
+        assert result.banned is False
+        assert result.user_id is None
+
+
+class TestBanCheckClientFailOpen:
+    """Network/timeout/5xx → BanCheckUnavailableError so the router can fail open."""
+
+    @pytest.mark.parametrize(
+        "exc_factory",
+        [
+            lambda: httpx.ConnectError("Connection refused"),
+            lambda: httpx.TimeoutException("Read timed out"),
+        ],
+        ids=["connect_error", "timeout"],
+    )
+    @pytest.mark.asyncio
+    async def test_network_errors_raise_unavailable(self, exc_factory):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            raise exc_factory()
+
+        client = _make_client(handler)
+        with pytest.raises(BanCheckUnavailableError):
+            await client.check(authorization="Bearer x", fingerprint=None)
+
+    @pytest.mark.asyncio
+    async def test_500_raises_unavailable(self):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"error": "internal_server_error"})
+
+        client = _make_client(handler)
+        with pytest.raises(BanCheckUnavailableError):
+            await client.check(authorization="Bearer x", fingerprint=None)
+
+    @pytest.mark.asyncio
+    async def test_400_no_signal_raises_unavailable(self):
+        """A 400 from BS indicates a contract bug on our end, not a banned user.
+
+        Bubble it as unavailable so the router fails open and the operator sees
+        the Sentry breadcrumb rather than silently banning every caller.
+        """
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, json={"error": "no_signal"})
+
+        client = _make_client(handler)
+        with pytest.raises(BanCheckUnavailableError):
+            await client.check(authorization="Bearer x", fingerprint=None)
+
+
+class TestBanCheckClientRequestShape:
+    """Request body and method invariants."""
+
+    @pytest.mark.asyncio
+    async def test_post_with_empty_body(self):
+        """All signal travels in headers; the body is empty.
+
+        BS#1261's handler reads ``Authorization`` and ``X-Device-Fingerprint``
+        directly from the request headers — we don't send a JSON body.
+        """
+        captured: dict = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = request.content
+            captured["method"] = request.method
+            return httpx.Response(200, json={"userId": "u", "fingerprint": None, "banned": False})
+
+        client = _make_client(handler)
+        await client.check(authorization="Bearer x", fingerprint=None)
+
+        assert captured["method"] == "POST"
+        # Either empty or an empty JSON object — both are acceptable; nothing
+        # load-bearing should travel in the body.
+        if captured["body"]:
+            assert json.loads(captured["body"]) == {}
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_signal_supplied(self):
+        """Calling check() with neither header is a programmer error; raise."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail("BS must not be called when no signal is present")
+
+        client = _make_client(handler)
+        with pytest.raises(ValueError):
+            await client.check(authorization=None, fingerprint=None)

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -226,6 +226,57 @@ class TestGetPosthogClient:
         mock_shared.assert_called_once_with(event_prefix="request")
 
 
+class TestGetBanCheckClient:
+    """Tests for get_ban_check_client function.
+
+    The provider is the only line of defense that prevents BS calls when the
+    feature flag is off or the URL is unset, so it has to be pinned both ways.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_flag_off(self):
+        """Default config has ENFORCE_REQUEST_BANS=False; provider returns None."""
+        from core.dependencies import get_ban_check_client
+
+        settings = Settings(
+            groq_api_key="test_key",
+            bs_check_request_ban_url="http://bs/auth/check-request-ban",
+            enforce_request_bans=False,
+        )
+        client = await get_ban_check_client(settings, AsyncMock())
+        assert client is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_url_unset(self):
+        """Flag on but URL missing → still None (no half-configured calls)."""
+        from core.dependencies import get_ban_check_client
+
+        settings = Settings(
+            groq_api_key="test_key",
+            bs_check_request_ban_url=None,
+            enforce_request_bans=True,
+        )
+        client = await get_ban_check_client(settings, AsyncMock())
+        assert client is None
+
+    @pytest.mark.asyncio
+    async def test_returns_client_when_enabled(self):
+        """Flag on AND URL set → return a wired BanCheckClient."""
+        from core.dependencies import get_ban_check_client
+        from services.ban_check_client import BanCheckClient
+
+        settings = Settings(
+            groq_api_key="test_key",
+            bs_check_request_ban_url="http://bs/auth/check-request-ban",
+            enforce_request_bans=True,
+        )
+        http_client = AsyncMock()
+        client = await get_ban_check_client(settings, http_client)
+        assert isinstance(client, BanCheckClient)
+        assert client.url == "http://bs/auth/check-request-ban"
+        assert client.http_client is http_client
+
+
 class TestGetSlackWebhookUrl:
     """Tests for get_slack_webhook_url function."""
 

--- a/tests/unit/test_request_ban_enforcement.py
+++ b/tests/unit/test_request_ban_enforcement.py
@@ -1,0 +1,585 @@
+"""Unit tests for request-line ban enforcement on POST /request.
+
+WXYC/request-o-matic#150 / WXYC/Backend-Service#1261. The ban check runs after
+the empty-message guard and BEFORE parse, so a banned listener never consumes
+Groq TPM or LML cache budget.
+
+Behavior matrix:
+- valid + unbanned  → proceed (LML + Slack as usual)
+- valid + banned    → 403, no Slack, no Groq, no LML, request_blocked telemetry
+- BS 401 / 404      → proceed-as-unauth (don't 401 the caller)
+- no headers        → proceed AND don't call BS (saves the v3.1 round-trip)
+- fingerprint-only + banned → 403
+- BS unreachable    → fail-open: proceed, log warning, emit
+                      degraded_mode=ban_check_unavailable telemetry
+- feature flag off  → never call BS, never 403
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from core.dependencies import (
+    get_ban_check_client,
+    get_groq_client,
+    get_lookup_client,
+    get_posthog_client,
+    get_slack_service,
+)
+from generated.api_models import SearchType
+from routers.request import router
+from services.ban_check_client import (
+    BanCheckClient,
+    BanCheckResult,
+    BanCheckUnavailableError,
+)
+from services.lookup_client import LookupResponse, LookupServiceClient
+from tests.conftest import make_parsed_request
+
+SAMPLE_PARSED = make_parsed_request(
+    song="la paradoja",
+    artist="Juana Molina",
+    raw_message="play la paradoja by juana molina",
+)
+
+EMPTY_LOOKUP = LookupResponse(
+    results=[],
+    search_type=SearchType.none,
+    song_not_found=False,
+    found_on_compilation=False,
+    context_message=None,
+    corrected_artist=None,
+    cache_stats={"hits": 0, "misses": 0},
+)
+
+
+def _make_app(
+    *,
+    ban_check_client: BanCheckClient | None,
+    lookup_client: LookupServiceClient | None = None,
+    slack_service: AsyncMock | None = None,
+    posthog_client: Mock | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[get_groq_client] = lambda: Mock()
+    app.dependency_overrides[get_slack_service] = lambda: slack_service
+    app.dependency_overrides[get_posthog_client] = lambda: posthog_client
+    app.dependency_overrides[get_lookup_client] = lambda: lookup_client
+    app.dependency_overrides[get_ban_check_client] = lambda: ban_check_client
+    return app
+
+
+@pytest.fixture
+def mock_ban_check_client():
+    return AsyncMock(spec=BanCheckClient)
+
+
+@pytest.fixture
+def mock_lookup_client():
+    client = AsyncMock(spec=LookupServiceClient)
+    client.lookup.return_value = EMPTY_LOOKUP
+    return client
+
+
+@pytest.fixture
+def mock_slack_service():
+    svc = AsyncMock()
+    svc.post_blocks = AsyncMock()
+    svc.webhook_url = "https://hooks.slack.com/test"
+    return svc
+
+
+@pytest.fixture
+def mock_posthog():
+    posthog = Mock()
+    posthog.capture = Mock()
+    return posthog
+
+
+# ---------------------------------------------------------------------------
+# Banned-caller path
+# ---------------------------------------------------------------------------
+
+
+class TestBannedCallerBlocked:
+    """When BS says banned, return 403 and skip the whole pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_user_ban_returns_403_no_slack_no_groq(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        mock_ban_check_client.check.return_value = BanCheckResult(
+            banned=True,
+            user_id="user-banned",
+            fingerprint="11111111-1111-4111-8111-111111111111",
+            ban_reason="Repeated abuse",
+            ban_source="user",
+        )
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ) as mock_parse:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={
+                        "Authorization": "Bearer eyJ...",
+                        "X-Device-Fingerprint": "11111111-1111-4111-8111-111111111111",
+                    },
+                )
+
+        assert response.status_code == 403
+        mock_ban_check_client.check.assert_awaited_once()
+        # Verify the headers were forwarded
+        call_kwargs = mock_ban_check_client.check.call_args.kwargs
+        assert call_kwargs["authorization"] == "Bearer eyJ..."
+        assert call_kwargs["fingerprint"] == "11111111-1111-4111-8111-111111111111"
+        # Shadow-ban: no Groq, no LML, no Slack
+        mock_parse.assert_not_awaited()
+        mock_lookup_client.lookup.assert_not_awaited()
+        mock_slack_service.post_blocks.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fingerprint_only_ban_returns_403(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        mock_ban_check_client.check.return_value = BanCheckResult(
+            banned=True,
+            user_id=None,
+            fingerprint="22222222-2222-4222-8222-222222222222",
+            ban_reason="Spam",
+            ban_source="fingerprint",
+        )
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ) as mock_parse:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={
+                        "X-Device-Fingerprint": "22222222-2222-4222-8222-222222222222",
+                    },
+                )
+
+        assert response.status_code == 403
+        # Header was forwarded as fingerprint, authorization is None
+        call_kwargs = mock_ban_check_client.check.call_args.kwargs
+        assert call_kwargs["authorization"] is None
+        assert call_kwargs["fingerprint"] == "22222222-2222-4222-8222-222222222222"
+        mock_parse.assert_not_awaited()
+        mock_lookup_client.lookup.assert_not_awaited()
+        mock_slack_service.post_blocks.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ban_emits_request_blocked_posthog_event(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        mock_ban_check_client.check.return_value = BanCheckResult(
+            banned=True,
+            user_id="user-xyz",
+            fingerprint="33333333-3333-4333-8333-333333333333",
+            ban_reason="Hate speech",
+            ban_source="user",
+        )
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await client.post(
+                "/api/v1/request",
+                json={"message": "anything"},
+                headers={
+                    "Authorization": "Bearer eyJ...",
+                    "X-Device-Fingerprint": "33333333-3333-4333-8333-333333333333",
+                },
+            )
+
+        # Find the request_blocked event among capture calls.
+        blocked_calls = [
+            c
+            for c in mock_posthog.capture.call_args_list
+            if c.kwargs.get("event") == "request_blocked"
+        ]
+        assert len(blocked_calls) == 1, "Expected exactly one request_blocked event"
+        props = blocked_calls[0].kwargs["properties"]
+        assert props["user_id"] == "user-xyz"
+        assert props["fingerprint"] == "33333333-3333-4333-8333-333333333333"
+        assert props["ban_reason"] == "Hate speech"
+        assert props["ban_source"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Allowed-caller path
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedCallerProceeds:
+    """When BS says not banned, the request proceeds normally."""
+
+    @pytest.mark.asyncio
+    async def test_unbanned_user_proceeds(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        mock_ban_check_client.check.return_value = BanCheckResult(
+            banned=False, user_id="user-good", fingerprint=None
+        )
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ) as mock_parse:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"Authorization": "Bearer eyJ..."},
+                )
+
+        assert response.status_code == 200
+        mock_ban_check_client.check.assert_awaited_once()
+        mock_parse.assert_awaited_once()
+        mock_lookup_client.lookup.assert_awaited_once()
+        mock_slack_service.post_blocks.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_headers_skips_bs_call(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        """v3.1 iOS clients send no Authorization header — must not call BS."""
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                )
+
+        assert response.status_code == 200
+        mock_ban_check_client.check.assert_not_awaited()
+        mock_lookup_client.lookup.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_proceed_as_unauth_on_invalid_token(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        """BS 401 (invalid JWT) → BanCheckResult(banned=False); proceed.
+
+        The caller MUST NOT see 401 on POST /request.
+        """
+        mock_ban_check_client.check.return_value = BanCheckResult(banned=False)
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"Authorization": "Bearer garbage"},
+                )
+
+        assert response.status_code == 200
+        mock_ban_check_client.check.assert_awaited_once()
+        mock_lookup_client.lookup.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Fail-open path
+# ---------------------------------------------------------------------------
+
+
+class TestBanCheckUnreachableFailsOpen:
+    """When BS is unreachable, proceed with the request (don't 502 the caller)."""
+
+    @pytest.mark.asyncio
+    async def test_bs_unreachable_proceeds(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        mock_ban_check_client.check.side_effect = BanCheckUnavailableError("BS down")
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"Authorization": "Bearer eyJ..."},
+                )
+
+        # Fail open: caller sees a normal 200, the pipeline runs.
+        assert response.status_code == 200
+        mock_lookup_client.lookup.assert_awaited_once()
+        mock_slack_service.post_blocks.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_bs_unreachable_emits_ban_check_degraded_telemetry(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        mock_ban_check_client.check.side_effect = BanCheckUnavailableError("BS down")
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"Authorization": "Bearer eyJ..."},
+                )
+
+        # The summary completed event should carry both degraded_mode and the
+        # ban_check_degraded property (since LML succeeded, degraded_mode falls
+        # back to ban_check_unavailable).
+        completed_calls = [
+            c
+            for c in mock_posthog.capture.call_args_list
+            if c.kwargs.get("event") == "request_completed"
+        ]
+        assert len(completed_calls) == 1
+        props = completed_calls[0].kwargs["properties"]
+        assert props.get("ban_check_degraded") is True
+        assert props.get("degraded_mode") == "ban_check_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_lml_outage_takes_precedence_in_degraded_mode_field(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        """If both BS and LML are down, degraded_mode=search_unavailable wins.
+
+        ban_check_degraded is still emitted as its own property so operators
+        can see both signals.
+        """
+        mock_ban_check_client.check.side_effect = BanCheckUnavailableError("BS down")
+        mock_lookup_client.lookup.side_effect = httpx.ConnectError("LML down")
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"Authorization": "Bearer eyJ..."},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "search_unavailable"
+        completed_calls = [
+            c
+            for c in mock_posthog.capture.call_args_list
+            if c.kwargs.get("event") == "request_completed"
+        ]
+        props = completed_calls[0].kwargs["properties"]
+        assert props.get("degraded_mode") == "search_unavailable"
+        assert props.get("ban_check_degraded") is True
+
+
+# ---------------------------------------------------------------------------
+# Feature flag off
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFlagOff:
+    """When the feature flag is off, the dependency returns None and BS is never called."""
+
+    @pytest.mark.asyncio
+    async def test_no_ban_check_client_skips_check(
+        self, mock_lookup_client, mock_slack_service, mock_posthog
+    ):
+        app = _make_app(
+            ban_check_client=None,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={
+                        "Authorization": "Bearer eyJ...",
+                        "X-Device-Fingerprint": "44444444-4444-4444-8444-444444444444",
+                    },
+                )
+
+        assert response.status_code == 200
+        mock_lookup_client.lookup.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Skip-call optimization
+# ---------------------------------------------------------------------------
+
+
+class TestSkipBSWhenNoSignal:
+    """When the caller supplies neither header, skip BS even if the client is wired."""
+
+    @pytest.mark.asyncio
+    async def test_no_headers_does_not_call_bs(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        app = _make_app(
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                )
+
+        assert response.status_code == 200
+        mock_ban_check_client.check.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds an optional pre-parse gate on `POST /request` that consults Backend-Service's new `POST /auth/check-request-ban` endpoint ([BS#1261](https://github.com/WXYC/Backend-Service/issues/1261)) so abusive listeners are blocked before consuming Groq TPM, LML cache budget, or Slack noise. Behind the `ENFORCE_REQUEST_BANS` feature flag (default off) so the code can land and deploy before iOS 3.2 (WXYC/wxyc-ios-64#351) reaches App Store rollout.

### Behavior matrix

| caller state | result |
| --- | --- |
| valid JWT, unbanned | proceed (LML + Slack as usual) |
| banned (user or fingerprint) | 403, no Groq/LML/Slack, `request_blocked` PostHog event with `user_id` + `fingerprint` + `ban_reason` + `ban_source` |
| BS returns 401 (invalid/expired JWT) or 404 (user not found) | proceed-as-unauth — caller MUST NOT see 401 on `POST /request` |
| neither header present | skip BS call entirely (matches v3.1 iOS clients in prod) |
| BS unreachable | fail-open: Sentry breadcrumb, `degraded_mode=ban_check_unavailable`, proceed |
| feature flag off | dependency provider returns None; ban check never runs |

### Why not forward `X-Internal-Key`?

The ticket asks for it, but BS#1261's `apps/auth/app.ts` registration explicitly comments that the endpoint is "intentionally public (no X-Internal-Key gate)" — callers authenticate per-request via JWT + fingerprint, and BS bounds the cost with per-IP rate limiting. Forwarding the header would be a no-op at best and confusing at worst, so we don't. `BS_INTERNAL_KEY` is still parsed into settings because ROM holds the same secret for future internal calls (e.g. ROM#151's admin API path on BS).

### Files

- `services/ban_check_client.py` (new) — typed httpx wrapper. `BanCheckResult` (frozen dataclass), `BanCheckUnavailableError`. Treats BS 401/404 as proceed-as-unauth; raises on network/timeout/5xx/400 so the router can fail open.
- `routers/request.py` — ban check runs after the empty-message guard and before parse, exactly per the ticket. New `ban_check_unavailable` degraded mode + always-on `ban_check_degraded` telemetry property so LML-down and ban-check-down show up together in PostHog.
- `core/dependencies.py` — `get_ban_check_client` returns None unless both flag and URL are set, so the router has a single guard.
- `config/settings.py` — `bs_check_request_ban_url`, `bs_internal_key`, `enforce_request_bans` (default False).
- `tests/unit/test_ban_check_client.py` (new, 12 tests) — client contract: happy paths, proceed-as-unauth, fail-open, request shape.
- `tests/unit/test_request_ban_enforcement.py` (new, 11 tests) — router behavior matrix, including the LML-down × BS-down precedence case.
- `tests/unit/test_dependencies.py` — `get_ban_check_client` provider gating (flag off, URL unset, both set).
- `tests/integration/test_ban_enforcement_e2e.py` (new, `external_api`) — live BS contract smoke; skipped unless `BS_CHECK_REQUEST_BAN_URL` is set so it's safe to leave in the default CI matrix.
- `docs/architecture.md`, `docs/env-vars.md`, `.env.example` — flow + env-var documentation.

### Local checks

- `ruff check .` clean
- `ruff format --check .` clean
- `mypy .` clean (63 files)
- `pytest tests/unit/ -q` → 378 passed (+24 new)
- `check_marker_ci_sync.py` → PASS

## Test plan

- [x] Unit: valid + unbanned → proceed
- [x] Unit: valid + banned → 403, no Slack, no Groq, no LML, `request_blocked` emitted with all 4 properties
- [x] Unit: invalid JWT (BS 401) → proceed-as-unauth (200, not 401)
- [x] Unit: user not found (BS 404) → proceed-as-unauth
- [x] Unit: no headers → proceed AND don't call BS
- [x] Unit: fingerprint-only + banned → 403
- [x] Unit: BS unreachable → fail-open + `degraded_mode=ban_check_unavailable`
- [x] Unit: BS unreachable + LML down → `degraded_mode=search_unavailable` (more severe wins) + `ban_check_degraded=true` (independent property)
- [x] Unit: feature flag off → dependency provider returns None, BS never called
- [x] Unit: dependency provider gating (flag off, URL unset, both set)
- [ ] Manual: against staging once BS#1261 is deployed there (`BS_CHECK_REQUEST_BAN_URL=... TEST_ENV=staging pytest tests/integration/test_ban_enforcement_e2e.py -m external_api`)
- [ ] Manual: flip `ENFORCE_REQUEST_BANS=true` on staging and verify a known-banned fingerprint gets 403 from staging ROM

## Related

- Blocked by WXYC/Backend-Service#1261 (BS validation endpoint — shipped)
- Cross-repo: WXYC/wxyc-ios-64#351 (iOS 3.2 ships the JWT + fingerprint headers)
- Part of WXYC/request-o-matic#148 (cross-repo tracker)
- Supersedes WXYC/request-o-matic#146

Closes #150