### PR TITLE
feat: User-Agent gate for known-client strict mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ ENFORCE_REQUEST_BANS=false
 # Full URL of BS apps/auth POST /auth/check-request-ban (port 8082)
 BS_CHECK_REQUEST_BAN_URL=
 
+# User-Agent gate (WXYC/request-o-matic#155). Default OFF; flip to true once
+# iOS 3.2 has reached enough App Store rollout that the strict-mode 403 won't
+# bounce real users. Independent of ENFORCE_REQUEST_BANS — this is a
+# structural check on known clients, not a ban decision.
+STRICT_FINGERPRINT_FOR_KNOWN_CLIENTS=false
+
 # Shared secret for BS internal endpoints. Used by /admin/bans (forwarded as
 # X-Internal-Key to BS /internal/banned-fingerprints) and held in shared
 # scope for both #150 (request-time check) and #151 (admin CRUD).

--- a/config/settings.py
+++ b/config/settings.py
@@ -103,6 +103,22 @@ class Settings(BaseSettings):
         ),
     )
 
+    # User-Agent gate for known-client strict mode (WXYC/request-o-matic#155).
+    # When True, requests whose User-Agent identifies a registered WXYC client
+    # at-or-above its strict-mode version (currently WXYC-iOS >= 3.2) are
+    # rejected 403 if X-Device-Fingerprint is absent. Unknown UAs (curl,
+    # browsers, v3.1 iOS, etc.) are unaffected. Independent of
+    # enforce_request_bans: this gate is a structural requirement on known
+    # clients, not a ban decision.
+    strict_fingerprint_for_known_clients: bool = Field(
+        default=False,
+        description=(
+            "Feature flag for the User-Agent gate (WXYC/request-o-matic#155). "
+            "When True, known WXYC clients (iOS >= 3.2) must send "
+            "X-Device-Fingerprint or the request is rejected 403."
+        ),
+    )
+
     # Application Metadata
     app_name: str = Field(default="Request-O-Matic", description="Application name")
     app_version: str = Field(default="1.0.0", description="Application version")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,11 +1,12 @@
 # Architecture
 
 ## Request Flow
-1. **Ban check (optional)**: When `ENFORCE_REQUEST_BANS=true` and the caller supplies `Authorization` and/or `X-Device-Fingerprint`, ROM consults Backend-Service's `POST /auth/check-request-ban` ([BS#1261](https://github.com/WXYC/Backend-Service/issues/1261)) before parsing. Banned callers get 403 with no Slack, no Groq, no LML; everyone else proceeds. See `services/ban_check_client.py` and [`docs/env-vars.md`](env-vars.md) for the full flow + flag.
-2. **Parse**: Groq AI (`llama-3.1-8b-instant`) extracts artist/song/album from message
-3. **Early return**: Non-request messages (feedback, DJ messages) are posted to Slack without search
-4. **Delegate**: Search is delegated to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) via HTTP (`LOOKUP_SERVICE_URL`).
-5. **Slack**: Post enriched results with artwork to Slack
+1. **UA gate (optional)**: When `STRICT_FINGERPRINT_FOR_KNOWN_CLIENTS=true` and the request's `User-Agent` matches a registered WXYC client at-or-above its strict-mode version (currently `WXYC-iOS >= 3.2`, registry in `services/ua_gate.py`), missing `X-Device-Fingerprint` triggers a 403 *before* the BS round-trip. Independent of the ban-check flag — this is a structural requirement on known clients, not a ban decision. Unknown UAs (browsers, curl, v3.1 iOS) keep the existing lenient contract. See [`docs/env-vars.md`](env-vars.md) for the flip sequence.
+2. **Ban check (optional)**: When `ENFORCE_REQUEST_BANS=true` and the caller supplies `Authorization` and/or `X-Device-Fingerprint`, ROM consults Backend-Service's `POST /auth/check-request-ban` ([BS#1261](https://github.com/WXYC/Backend-Service/issues/1261)) before parsing. Banned callers get 403 with no Slack, no Groq, no LML; everyone else proceeds. See `services/ban_check_client.py` and [`docs/env-vars.md`](env-vars.md) for the full flow + flag.
+3. **Parse**: Groq AI (`llama-3.1-8b-instant`) extracts artist/song/album from message
+4. **Early return**: Non-request messages (feedback, DJ messages) are posted to Slack without search
+5. **Delegate**: Search is delegated to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) via HTTP (`LOOKUP_SERVICE_URL`).
+6. **Slack**: Post enriched results with artwork to Slack
 
 ## Degraded Modes
 Slack is the only hard dependency. When Groq or LML are unavailable the listener's message still reaches Slack, with a context line explaining what's missing. The response is `200` with a `degraded_mode` field:
@@ -25,6 +26,7 @@ If Slack itself fails the endpoint returns `502` — there is no further fallbac
 - `services/parser.py` - Groq AI message parsing
 - `services/lookup_client.py` - HTTP client for library-metadata-lookup delegation
 - `services/ban_check_client.py` - HTTP client for Backend-Service `POST /auth/check-request-ban` (BS#1261). Fails open (raises `BanCheckUnavailableError`) on network errors, timeouts, or 5xx; treats BS 401/404 as proceed-as-unauth so the caller is never 401'd on `POST /request`.
+- `services/ua_gate.py` - Pure-function matcher `is_known_strict_client(user_agent)` for the UA gate (#155). Maintains the `_STRICT_CLIENT_REGISTRY` of product-token → minimum-version pairs. Adding `WXYC-Android` here is a one-line change when that team ships ban-aware code.
 - `services/slack.py` - Slack message formatting and posting
 - `core/dependencies.py` - FastAPI dependency injection (HTTP client, Groq, Slack, PostHog). Sentry, telemetry, cache stats, and PostHog client construction live in [`wxyc-fastapi`](https://github.com/WXYC/wxyc-fastapi); `core/dependencies.get_posthog_client` only wraps the shared singleton with the rom-side `enable_telemetry` flag.
 - `core/groq_tracing.py` - Sentry instrumentation for Groq parse calls: a `groq_parse_span` context manager wrapping `services.parser.parse_request` (op `ai.parse`, tagged with model, input length, token counts, and parse-result fields), and an `install_groq_retry_breadcrumbs()` filter on the `groq._base_client` logger that converts the SDK's silent 429-retry log lines into structured `groq.retry` breadcrumbs. Installed once from `main.py` after `init_sentry`.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -24,3 +24,13 @@ Request-line ban enforcement ([WXYC/request-o-matic#150](https://github.com/WXYC
 - `BS_CHECK_REQUEST_BAN_URL` - Full URL of Backend-Service's `POST /auth/check-request-ban` endpoint (apps/auth service, port 8082), e.g. `https://wxyc-auth-staging.up.railway.app/auth/check-request-ban`. When unset, the ban check is disabled regardless of `ENFORCE_REQUEST_BANS`.
 
 Flow when enforcement is on and the caller supplies `Authorization: Bearer <jwt>` and/or `X-Device-Fingerprint: <uuid>`: ROM POSTs both headers to `BS_CHECK_REQUEST_BAN_URL` before parse. `banned: true` short-circuits to 403 (no Slack, no Groq, no LML) and emits a `request_blocked` PostHog event with `user_id`, `fingerprint`, `ban_reason`, `ban_source`. `banned: false` proceeds. BS 401 (invalid JWT) and 404 (user not found) proceed-as-unauth — the caller MUST NOT see a 401 on `POST /request`, since v3.1 iOS clients send no Authorization header. When BS is unreachable, ROM fails open: log a Sentry breadcrumb, emit `degraded_mode=ban_check_unavailable` telemetry, proceed.
+
+User-Agent gate ([WXYC/request-o-matic#155](https://github.com/WXYC/request-o-matic/issues/155)):
+- `STRICT_FINGERPRINT_FOR_KNOWN_CLIENTS` - Feature flag for the User-Agent gate. Default `false`. When `true`, requests whose `User-Agent` identifies a registered WXYC client at-or-above its strict-mode version (currently `WXYC-iOS >= 3.2`) are rejected `403` if `X-Device-Fingerprint` is absent. Unknown UAs (curl, browsers, v3.1 iOS, anything not registered in `services/ua_gate.py`) are unaffected — the existing lenient contract still holds. The gate is independent of `ENFORCE_REQUEST_BANS`: it's a structural check on the request shape from known clients, not a ban decision. Rejection emits a `request_blocked` PostHog event with `ban_source='rom_strict_mode'`, `ban_reason='ua_gate_missing_fingerprint'`, and the received `user_agent`.
+
+Operator flip sequence (after iOS 3.2 ships):
+1. Deploy ROM with the gate code (default-off).
+2. Verify iOS 3.2 fingerprint pipeline against staging.
+3. Wait for App Store rollout to reach ~90% (App Store Connect → Analytics → App Versions).
+4. Flip `STRICT_FINGERPRINT_FOR_KNOWN_CLIENTS=true` on staging, watch PostHog for `request_blocked` events keyed on `ban_source='rom_strict_mode'`. Spikes here indicate either a 3.2 fingerprint regression or active evasion attempts; a slow trickle is expected.
+5. Flip on production. Rollback recipe: set the var to `false` and restart; legitimate traffic recovers within one restart cycle.

--- a/routers/request.py
+++ b/routers/request.py
@@ -31,6 +31,7 @@ from groq import AsyncGroq
 from pydantic import BaseModel
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
 
+from config.settings import Settings, get_settings
 from core.dependencies import (
     SlackService,
     get_ban_check_client,
@@ -47,6 +48,11 @@ from services.ban_check_client import BanCheckClient, BanCheckUnavailableError
 from services.lookup_client import LookupRequest, LookupServiceClient
 from services.parser import MessageType, ParsedRequest, parse_request
 from services.slack import build_simple_slack_blocks, build_slack_blocks
+from services.ua_gate import (
+    UA_GATE_BAN_REASON,
+    UA_GATE_BAN_SOURCE,
+    is_known_strict_client,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -212,8 +218,10 @@ async def handle_request(
     posthog_client: Posthog | None = Depends(get_posthog_client),
     lookup_client: LookupServiceClient | None = Depends(get_lookup_client),
     ban_check_client: BanCheckClient | None = Depends(get_ban_check_client),
+    settings: Settings = Depends(get_settings),
     authorization: str | None = Header(default=None),
     x_device_fingerprint: str | None = Header(default=None),
+    user_agent: str | None = Header(default=None),
 ):
     """Parse a request, search the library, and post to Slack.
 
@@ -229,6 +237,40 @@ async def handle_request(
         distinct_id="request-o-matic-service",
         event_prefix="request",
     )
+
+    # User-Agent gate (WXYC/request-o-matic#155). Runs BEFORE the BS ban check
+    # so a known-client request missing its fingerprint is rejected without an
+    # extra BS round-trip. Unknown UAs (v3.1 iOS, browsers, curl, anything not
+    # in the registry) keep the existing lenient behavior — see services/ua_gate.py.
+    # The gate is independent of ENFORCE_REQUEST_BANS: it's a structural check
+    # on the request shape from known clients, not a ban decision.
+    if (
+        settings.strict_fingerprint_for_known_clients
+        and not x_device_fingerprint
+        and is_known_strict_client(user_agent)
+    ):
+        if posthog_client is not None:
+            # Wrap PostHog capture in the same try/except as the BS-ban path
+            # below — a PostHog outage must not flip the response away from 403.
+            try:
+                posthog_client.capture(
+                    distinct_id="request-o-matic-service",
+                    event="request_blocked",
+                    properties={
+                        "user_id": None,
+                        "fingerprint": None,
+                        "ban_reason": UA_GATE_BAN_REASON,
+                        "ban_source": UA_GATE_BAN_SOURCE,
+                        "user_agent": user_agent,
+                    },
+                )
+            except Exception:
+                logger.exception("PostHog request_blocked capture failed (ua_gate)")
+        logger.info(
+            "Blocked known-client request missing X-Device-Fingerprint (user_agent=%s)",
+            user_agent,
+        )
+        raise HTTPException(status_code=403, detail="Request blocked")
 
     # Request-line ban enforcement (WXYC/request-o-matic#150 + BS#1261).
     # Runs BEFORE parse so an abusive listener does not consume Groq TPM or

--- a/services/ua_gate.py
+++ b/services/ua_gate.py
@@ -1,0 +1,85 @@
+"""User-Agent gate for request-line ban enforcement (WXYC/request-o-matic#155).
+
+The BS ban check (#150) blocks requests when BS confirms the caller is banned.
+That defends against every evasion path except "strip both Authorization and
+X-Device-Fingerprint headers entirely" — for which ROM proceeds-as-unauth (a
+v3.1 backward-compatibility constraint).
+
+This module closes that gap for *known* clients. iOS 3.2+ unconditionally sends
+``User-Agent: WXYC-iOS/<version>`` plus ``X-Device-Fingerprint``. If the UA
+identifies the caller as a recent WXYC client AND the fingerprint header is
+missing, the request is rejected (403) before reaching the BS round-trip.
+
+Unknown UAs (curl, browsers, v3.1 iOS, anything not registered below) keep the
+existing lenient behavior so legacy traffic isn't broken.
+
+Spoofing the UA is in scope but not a blocker: an attacker who claims to be
+``WXYC-iOS/3.2.0`` has to then also send a fingerprint, at which point they're
+back on the fingerprint-banned path the BS ban check (#150) enforces.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+__all__ = ["UA_GATE_BAN_REASON", "UA_GATE_BAN_SOURCE", "is_known_strict_client"]
+
+logger = logging.getLogger(__name__)
+
+# Constants for the PostHog ``request_blocked`` event emitted when this gate
+# rejects. Kept here next to the matcher so a future Android entry can introduce
+# its own reason without scattering literals across the router.
+UA_GATE_BAN_SOURCE = "rom_strict_mode"
+UA_GATE_BAN_REASON = "ua_gate_missing_fingerprint"
+
+# Map from product token (the part before the slash in a User-Agent product
+# clause) to the minimum version tuple at-or-above which the client is expected
+# to send ``X-Device-Fingerprint`` unconditionally. Adding ``"WXYC-Android"``
+# with its own threshold here is the only change needed when the Android team
+# ships ban-aware code.
+_STRICT_CLIENT_REGISTRY: dict[str, tuple[int, ...]] = {
+    "WXYC-iOS": (3, 2),
+}
+
+# Matches "<product>/<version>" tokens. Captures the dotted-numeric version
+# directly after the slash and ignores any ``-beta`` or ``+metadata`` suffix.
+# Apple-style URLSession user agents append " CFNetwork/... Darwin/..." which
+# this regex picks up as separate tokens; non-registered products are skipped.
+_PRODUCT_TOKEN_RE = re.compile(r"([A-Za-z0-9\-]+)/(\d+(?:\.\d+)*)")
+
+
+def is_known_strict_client(user_agent: str | None) -> bool:
+    """Return True iff ``user_agent`` claims a registered client at-or-above its strict-mode version.
+
+    Returning True means "we know this client *should* be sending the
+    fingerprint; if it isn't, treat that as evasion." Returning False means
+    "we have no opinion about this caller; proceed under the existing lenient
+    contract."
+
+    Args:
+        user_agent: Raw value of the ``User-Agent`` request header, or None.
+
+    Returns:
+        True when the UA contains a registered product token whose version is
+        ``>=`` the registry minimum. False otherwise (unknown clients,
+        malformed UAs, or no UA at all).
+    """
+    if not user_agent:
+        return False
+
+    for product, version in _PRODUCT_TOKEN_RE.findall(user_agent):
+        minimum = _STRICT_CLIENT_REGISTRY.get(product)
+        if minimum is None:
+            continue
+        try:
+            parsed = tuple(int(part) for part in version.split("."))
+        except ValueError:
+            # Defense-in-depth: the regex already restricts to dotted-numeric,
+            # so int() should never fail. Keep the guard so a future regex
+            # loosening doesn't silently turn malformed UAs into True.
+            continue
+        if parsed >= minimum:
+            return True
+
+    return False

--- a/tests/unit/test_ua_gate.py
+++ b/tests/unit/test_ua_gate.py
@@ -1,0 +1,491 @@
+"""Unit tests for the User-Agent gate (WXYC/request-o-matic#155).
+
+Covers two surfaces:
+
+* ``services.ua_gate.is_known_strict_client`` — pure-function matcher for
+  product-token + minimum-version pairs in the User-Agent header.
+* The router wiring in ``handle_request`` — when
+  ``STRICT_FINGERPRINT_FOR_KNOWN_CLIENTS=true``, a known-client request that
+  omits ``X-Device-Fingerprint`` is rejected with 403 before parse, before
+  the BS ban check, and without consuming Groq/LML budget.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import Settings, get_settings
+from core.dependencies import (
+    get_ban_check_client,
+    get_groq_client,
+    get_lookup_client,
+    get_posthog_client,
+    get_slack_service,
+)
+from generated.api_models import SearchType
+from routers.request import router
+from services.ban_check_client import BanCheckClient
+from services.lookup_client import LookupResponse, LookupServiceClient
+from services.ua_gate import (
+    UA_GATE_BAN_REASON,
+    UA_GATE_BAN_SOURCE,
+    is_known_strict_client,
+)
+from tests.conftest import make_parsed_request
+
+SAMPLE_PARSED = make_parsed_request(
+    song="la paradoja",
+    artist="Juana Molina",
+    raw_message="play la paradoja by juana molina",
+)
+
+EMPTY_LOOKUP = LookupResponse(
+    results=[],
+    search_type=SearchType.none,
+    song_not_found=False,
+    found_on_compilation=False,
+    context_message=None,
+    corrected_artist=None,
+    cache_stats={"hits": 0, "misses": 0},
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure matcher: services.ua_gate.is_known_strict_client
+# ---------------------------------------------------------------------------
+
+
+class TestUAMatcher:
+    """Behavior of ``is_known_strict_client`` against every UA category we expect."""
+
+    @pytest.mark.parametrize(
+        "ua",
+        [
+            None,
+            "",
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) Safari/605.1.15",
+            "curl/8.6.0",
+            "python-requests/2.31.0",
+            "PostmanRuntime/7.36.1",
+        ],
+        ids=["none", "empty", "browser", "curl", "requests", "postman"],
+    )
+    def test_unknown_uas_return_false(self, ua: str | None) -> None:
+        assert is_known_strict_client(ua) is False
+
+    @pytest.mark.parametrize(
+        "ua",
+        [
+            "WXYC-iOS/3.2",
+            "WXYC-iOS/3.2.0",
+            "WXYC-iOS/3.2.1",
+            "WXYC-iOS/3.3",
+            "WXYC-iOS/3.10.0",
+            "WXYC-iOS/4.0.0",
+            # URLSession-style with trailing CFNetwork/Darwin tokens
+            "WXYC-iOS/3.2.0 CFNetwork/1568.300.101 Darwin/24.4.0",
+            "WXYC-iOS/3.2.0 (Build 103)",
+        ],
+        ids=[
+            "v3.2-bare",
+            "v3.2.0",
+            "v3.2.1",
+            "v3.3",
+            "v3.10.0",
+            "v4.0.0",
+            "v3.2.0-with-cfnetwork",
+            "v3.2.0-with-build",
+        ],
+    )
+    def test_known_strict_client_returns_true(self, ua: str) -> None:
+        assert is_known_strict_client(ua) is True
+
+    @pytest.mark.parametrize(
+        "ua",
+        [
+            "WXYC-iOS/3.0",
+            "WXYC-iOS/3.0.0",
+            "WXYC-iOS/3.1",
+            "WXYC-iOS/3.1.99",
+            "WXYC-iOS/2.0",
+            "WXYC-iOS/1.5",
+            # Version 3 without a minor — Python's tuple-compare treats (3,) < (3, 2)
+            "WXYC-iOS/3",
+        ],
+        ids=["v3.0", "v3.0.0", "v3.1", "v3.1.99", "v2.0", "v1.5", "v3-bare"],
+    )
+    def test_below_minimum_returns_false(self, ua: str) -> None:
+        assert is_known_strict_client(ua) is False
+
+    def test_malformed_version_returns_false(self) -> None:
+        # The product-token regex restricts to dotted-numeric so this case is
+        # already filtered upstream, but the guard inside the function is the
+        # one that protects against a future regex loosening.
+        assert is_known_strict_client("WXYC-iOS/three-point-two") is False
+        assert is_known_strict_client("WXYC-iOS/v3.2") is False
+
+    def test_unknown_product_returns_false(self) -> None:
+        # WXYC-Android is not in the registry yet — its absence keeps Android
+        # traffic on the lenient path until that team ships ban-aware code.
+        assert is_known_strict_client("WXYC-Android/3.2.0") is False
+        # Capitalization is exact-match: a stray "wxyc-ios" lowercase doesn't
+        # impersonate the real client.
+        assert is_known_strict_client("wxyc-ios/3.2.0") is False
+
+    def test_mixed_tokens_picks_up_known_one(self) -> None:
+        # Real iOS UAs are space-separated product tokens; the matcher should
+        # find the WXYC-iOS token even when other tokens are present.
+        ua = "Some-Wrapper/1.0 WXYC-iOS/3.2.0 (Build 103) CFNetwork/1568.300.101"
+        assert is_known_strict_client(ua) is True
+
+    def test_first_unknown_token_does_not_short_circuit(self) -> None:
+        # An earlier unregistered product (Mozilla, etc.) must not prevent us
+        # from finding a later WXYC-iOS token.
+        assert is_known_strict_client("Mozilla/5.0 WXYC-iOS/3.2.0") is True
+
+
+# ---------------------------------------------------------------------------
+# Router wiring: the gate fires before the BS ban check
+# ---------------------------------------------------------------------------
+
+
+def _make_app(
+    *,
+    strict_flag: bool,
+    ban_check_client: BanCheckClient | None = None,
+    lookup_client: LookupServiceClient | None = None,
+    slack_service: AsyncMock | None = None,
+    posthog_client: Mock | None = None,
+) -> FastAPI:
+    """Construct a fresh app with the UA-gate flag set to ``strict_flag``."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+
+    test_settings = Settings(
+        groq_api_key="test_groq_key",
+        strict_fingerprint_for_known_clients=strict_flag,
+    )
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_groq_client] = lambda: Mock()
+    app.dependency_overrides[get_slack_service] = lambda: slack_service
+    app.dependency_overrides[get_posthog_client] = lambda: posthog_client
+    app.dependency_overrides[get_lookup_client] = lambda: lookup_client
+    app.dependency_overrides[get_ban_check_client] = lambda: ban_check_client
+    return app
+
+
+@pytest.fixture
+def mock_ban_check_client():
+    return AsyncMock(spec=BanCheckClient)
+
+
+@pytest.fixture
+def mock_lookup_client():
+    client = AsyncMock(spec=LookupServiceClient)
+    client.lookup.return_value = EMPTY_LOOKUP
+    return client
+
+
+@pytest.fixture
+def mock_slack_service():
+    svc = AsyncMock()
+    svc.post_blocks = AsyncMock()
+    svc.webhook_url = "https://hooks.slack.com/test"
+    return svc
+
+
+@pytest.fixture
+def mock_posthog():
+    posthog = Mock()
+    posthog.capture = Mock()
+    return posthog
+
+
+class TestUAGateBlocks:
+    """With the flag on, known-client requests missing fingerprint get 403."""
+
+    @pytest.mark.asyncio
+    async def test_known_client_no_fingerprint_returns_403(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        app = _make_app(
+            strict_flag=True,
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ) as mock_parse:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"User-Agent": "WXYC-iOS/3.2.0"},
+                )
+
+        assert response.status_code == 403
+        # Reject BEFORE both BS round-trip and parse.
+        mock_ban_check_client.check.assert_not_awaited()
+        mock_parse.assert_not_awaited()
+        mock_lookup_client.lookup.assert_not_awaited()
+        mock_slack_service.post_blocks.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_blocked_request_emits_posthog_event_with_ua_source(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        app = _make_app(
+            strict_flag=True,
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await client.post(
+                "/api/v1/request",
+                json={"message": "play la paradoja"},
+                headers={"User-Agent": "WXYC-iOS/3.2.0"},
+            )
+
+        mock_posthog.capture.assert_called_once()
+        call_kwargs = mock_posthog.capture.call_args.kwargs
+        assert call_kwargs["event"] == "request_blocked"
+        # ban_source distinguishes UA-gate rejection (rom_strict_mode) from a
+        # real BS ban (bs); ops dashboards key off this property.
+        assert call_kwargs["properties"]["ban_source"] == UA_GATE_BAN_SOURCE
+        assert call_kwargs["properties"]["ban_reason"] == UA_GATE_BAN_REASON
+        assert call_kwargs["properties"]["user_agent"] == "WXYC-iOS/3.2.0"
+
+    @pytest.mark.asyncio
+    async def test_posthog_capture_failure_does_not_flip_response(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        # Shadow-ban invariant: a PostHog ingest outage must not 500 the
+        # response. The 403 has to land regardless.
+        mock_posthog.capture.side_effect = RuntimeError("posthog down")
+        app = _make_app(
+            strict_flag=True,
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/v1/request",
+                json={"message": "play la paradoja"},
+                headers={"User-Agent": "WXYC-iOS/3.2.0"},
+            )
+
+        assert response.status_code == 403
+
+
+class TestUAGatePasses:
+    """With the flag on, requests that don't match the gate fall through."""
+
+    @pytest.mark.asyncio
+    async def test_known_client_with_fingerprint_passes_to_ban_check(
+        self,
+        mock_ban_check_client,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        # ban_check_client present + headers present → BS is consulted.
+        # Returning banned=False lets the request proceed; we just want to see
+        # the gate did NOT short-circuit before reaching BS.
+        from services.ban_check_client import BanCheckResult
+
+        mock_ban_check_client.check.return_value = BanCheckResult(banned=False)
+        app = _make_app(
+            strict_flag=True,
+            ban_check_client=mock_ban_check_client,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={
+                        "User-Agent": "WXYC-iOS/3.2.0",
+                        "X-Device-Fingerprint": "11111111-2222-4333-8444-555555555555",
+                    },
+                )
+
+        assert response.status_code == 200
+        mock_ban_check_client.check.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_client_no_fingerprint_passes_through(
+        self,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        # No ban_check_client (BS flag off too), unknown UA, no fingerprint.
+        # The gate should not fire and the request should proceed.
+        app = _make_app(
+            strict_flag=True,
+            ban_check_client=None,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"User-Agent": "curl/8.6.0"},
+                )
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_below_minimum_version_passes_through(
+        self,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        # v3.1 iOS in the field today sends no fingerprint and no UA, but if
+        # for some reason a v3.1 build carried a UA, it must still be lenient.
+        app = _make_app(
+            strict_flag=True,
+            ban_check_client=None,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"User-Agent": "WXYC-iOS/3.1.0"},
+                )
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_no_user_agent_passes_through(
+        self,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        # No UA at all — gate cannot identify the client, falls through.
+        app = _make_app(
+            strict_flag=True,
+            ban_check_client=None,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                # AsyncClient sets a default UA; explicitly drop it.
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"User-Agent": ""},
+                )
+
+        assert response.status_code == 200
+
+
+class TestUAGateOff:
+    """With the flag off, the gate is a no-op regardless of other state."""
+
+    @pytest.mark.asyncio
+    async def test_flag_off_lets_known_client_through_without_fingerprint(
+        self,
+        mock_lookup_client,
+        mock_slack_service,
+        mock_posthog,
+    ):
+        # Same shape as the blocked test, but strict_flag=False.
+        app = _make_app(
+            strict_flag=False,
+            ban_check_client=None,
+            lookup_client=mock_lookup_client,
+            slack_service=mock_slack_service,
+            posthog_client=mock_posthog,
+        )
+
+        with patch(
+            "routers.request.parse_request",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_PARSED,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja"},
+                    headers={"User-Agent": "WXYC-iOS/3.2.0"},
+                )
+
+        assert response.status_code == 200
+        mock_posthog.capture.assert_called()
+        # Verify no request_blocked event was emitted.
+        for call in mock_posthog.capture.call_args_list:
+            assert call.kwargs.get("event") != "request_blocked"


### PR DESCRIPTION
Closes #155.

## Summary

- Adds a structural pre-check on `POST /request`: when `STRICT_FINGERPRINT_FOR_KNOWN_CLIENTS=true` and the request's `User-Agent` matches a registered WXYC client at-or-above its strict-mode version (currently `WXYC-iOS >= 3.2`), missing `X-Device-Fingerprint` triggers a 403 before parse and before the BS ban round-trip.
- Default-off via the new env var so the code can deploy without disrupting any existing traffic; flip after iOS 3.2 reaches App Store rollout. Independent of `ENFORCE_REQUEST_BANS` — this is a structural requirement on known clients, not a ban decision.
- Unknown UAs (curl, browsers, v3.1 iOS, anything not in the registry in `services/ua_gate.py`) keep the existing lenient contract. The registry is a one-line addition when WXYC-Android ships its own ban-aware version.
- Telemetry uses `ban_source='rom_strict_mode'` + `ban_reason='ua_gate_missing_fingerprint'` so PostHog dashboards distinguish UA-gate rejections from real BS-driven bans (`ban_source='bs'` from #150).
- PostHog capture is wrapped in try/except mirroring #150's shadow-ban posture: an ingest outage must not flip the 403 to a 500.

## Why this exists

The BS ban check (#150) plugs every ban-evasion vector except "strip both `Authorization` and `X-Device-Fingerprint` headers." ROM's `proceed-as-unauth` on missing headers is required for v3.1 iOS in the App Store (which sends no headers), so we can't reject blank-header requests globally. The UA gate closes the gap for clients that *should* have headers — iOS 3.2+ unconditionally sends fingerprint, so a self-identified 3.2 UA without a fingerprint is by-construction evasion.

UA spoofing is in scope but not a blocker: a determined attacker who spoofs `User-Agent: WXYC-iOS/3.2.0` then has to also send a fingerprint, at which point they're back on the BS fingerprint-banned path.

## Test plan

- 33 new unit tests in `tests/unit/test_ua_gate.py`:
  - Pure matcher: every UA category (none, empty, browser, curl, postman, requests; v3.0–v3.1 + v2.x + v1.x → False; v3.2 → True with bare/dotted/build/CFNetwork suffixes; v3.3 → True; v4.x → True; unknown product → False; lowercase product → False; mixed tokens; first-unknown-then-known)
  - Router wiring: flag-on + known-UA + no FP → 403, no Groq, no LML, no Slack, no BS round-trip
  - Router wiring: flag-on + known-UA + has FP → passes through to BS ban check (200 with `BanCheckResult(banned=False)`)
  - Router wiring: flag-on + unknown UA + no FP → passes through (200)
  - Router wiring: flag-on + v3.1 UA + no FP → passes through (200)
  - Router wiring: flag-on + no UA → passes through (200)
  - Router wiring: PostHog ingest outage during the gate → still returns 403 (shadow-ban invariant)
  - Router wiring: flag-off + known UA + no FP → passes through (200), no `request_blocked` emitted
- Existing 504-test suite unchanged and green.
- `ruff check`, `ruff format --check`, `mypy` all green.