### PR TITLE
fix(lookup-client): raise per-attempt timeout to 20s; stop retrying on TimeoutException

### DIFF
--- a/services/lookup_client.py
+++ b/services/lookup_client.py
@@ -26,7 +26,12 @@ class LookupServiceClient:
         per_attempt_timeout: Per-attempt timeout in seconds (overrides the client default)
     """
 
-    _RETRYABLE = (httpx.ConnectError, httpx.TimeoutException)
+    # Only retry transient connection-establishment failures. TimeoutException
+    # is deliberately excluded: a lookup that already spent the per-attempt
+    # budget is doing real work on LML's side and won't be faster on retry,
+    # while the concurrent duplicate doubles LML's Discogs/Apple Music load
+    # because LML cannot cancel work when the rom socket disconnects.
+    _RETRYABLE = (httpx.ConnectError,)
 
     def __init__(
         self,
@@ -36,7 +41,7 @@ class LookupServiceClient:
         api_key: str | None = None,
         max_attempts: int = 2,
         retry_delay: float = 1.0,
-        per_attempt_timeout: float = 10.0,
+        per_attempt_timeout: float = 20.0,
     ):
         self.base_url = base_url.rstrip("/")
         self.http_client = http_client
@@ -51,8 +56,8 @@ class LookupServiceClient:
     async def lookup(self, request: LookupRequest, skip_cache: bool = False) -> LookupResponse:
         """Call the lookup service and return parsed response.
 
-        Retries on transient network errors (``ConnectError``, ``TimeoutException``).
-        HTTP status errors are raised immediately without retry.
+        Retries on ``ConnectError`` only. ``TimeoutException`` and HTTP status
+        errors are raised immediately without retry.
 
         Args:
             request: Lookup request with artist/song/album/raw_message
@@ -64,7 +69,7 @@ class LookupServiceClient:
         Raises:
             httpx.HTTPStatusError: On 4xx/5xx responses (no retry)
             httpx.ConnectError: If the service is unreachable after all attempts
-            httpx.TimeoutException: If the request times out after all attempts
+            httpx.TimeoutException: If the request times out (no retry)
         """
         params = {"skip_cache": "true"} if skip_cache else {}
         last_exc: Exception | None = None

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -343,22 +343,18 @@ class TestLookupRetry:
         assert isinstance(response, LookupResponse)
 
     @pytest.mark.asyncio
-    async def test_retry_on_timeout_then_success(self):
-        """First call raises ReadTimeout, second succeeds."""
+    async def test_no_retry_on_timeout(self):
+        """ReadTimeout raises immediately; retrying a slow lookup just doubles LML load."""
         calls = []
 
         async def handler(request: httpx.Request) -> httpx.Response:
             calls.append(1)
-            if len(calls) == 1:
-                raise httpx.ReadTimeout("Read timed out")
-            return httpx.Response(200, json=SAMPLE_RESPONSE)
+            raise httpx.ReadTimeout("Read timed out")
 
         client = _make_client(handler)
-        response = await client.lookup(
-            LookupRequest(artist="Cat Power", raw_message="play cat power")
-        )
-        assert len(calls) == 2
-        assert isinstance(response, LookupResponse)
+        with pytest.raises(httpx.ReadTimeout):
+            await client.lookup(LookupRequest(artist="Cat Power", raw_message="play cat power"))
+        assert len(calls) == 1
 
     @pytest.mark.asyncio
     async def test_retry_exhausted_connect_error(self):
@@ -372,20 +368,6 @@ class TestLookupRetry:
         client = _make_client(handler)
         with pytest.raises(httpx.ConnectError):
             await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
-        assert len(calls) == 2
-
-    @pytest.mark.asyncio
-    async def test_retry_exhausted_timeout(self):
-        """Both calls raise ReadTimeout. Exception propagates."""
-        calls = []
-
-        async def handler(request: httpx.Request) -> httpx.Response:
-            calls.append(1)
-            raise httpx.ReadTimeout("Read timed out")
-
-        client = _make_client(handler)
-        with pytest.raises(httpx.ReadTimeout):
-            await client.lookup(LookupRequest(artist="Cat Power", raw_message="play cat power"))
         assert len(calls) == 2
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Raise `LookupServiceClient.per_attempt_timeout` from 10s → 20s so cold-path LML lookups (sequential Discogs release validations + Apple Music fallback) have room to return successfully before rom drops to the `search_unavailable` degraded mode.
- Drop `httpx.TimeoutException` from `_RETRYABLE`. A lookup that already burned the full per-attempt budget is doing real work on LML's side and will not be faster on retry; the concurrent duplicate doubles LML's Discogs + Apple Music fan-out because LML cannot cancel work when the rom socket disconnects. `ConnectError` is still retried, since that is the case the retry was designed for.

Closes #158

## Test plan

- [x] `pytest tests/unit/` — 503 passing locally.
- [x] `ruff check` + `ruff format --check` clean on touched files.
- [x] `mypy services/lookup_client.py tests/unit/test_lookup_client.py` clean.
- [ ] Staging deploy + manual spot-check of `POST /api/v1/request` with `Whale song - modest mouse` (the original incident prompt) to confirm a single in-flight LML call and a non-degraded Slack post.