### PR TITLE
fix(test): introspect routes via OpenAPI schema, not app.routes/.path

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -17,11 +17,17 @@ def _openapi_paths(app) -> set[str]:
 
 
 def _operation_tags(app, path: str) -> set[str]:
-    """Union of OpenAPI tags across every HTTP method of ``path``."""
+    """Union of OpenAPI tags across every HTTP method of ``path``.
+
+    A path-item object can hold non-operation keys (a path-level ``parameters``
+    list, ``summary``/``description`` strings, ``servers``); skip anything that
+    isn't an operation dict so this can't ``AttributeError`` on them.
+    """
     operations = app.openapi().get("paths", {}).get(path, {})
     tags: set[str] = set()
     for operation in operations.values():
-        tags.update(operation.get("tags", []) or [])
+        if isinstance(operation, dict):
+            tags.update(operation.get("tags", []) or [])
     return tags
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -3,6 +3,28 @@
 from unittest.mock import patch
 
 
+def _openapi_paths(app) -> set[str]:
+    """Registered URL paths, read from the OpenAPI schema.
+
+    FastAPI >=0.137 includes sub-routers lazily as ``fastapi.routing._IncludedRouter``
+    wrappers that don't expose ``.path`` on ``app.routes`` (older FastAPI eagerly
+    flattened sub-router routes into ``app.routes`` with a ``.path``). Introspecting
+    ``app.routes``/``.path`` therefore silently misses every included route. The
+    OpenAPI schema reflects every registered path regardless of inclusion strategy,
+    so it is the version-stable surface to assert against.
+    """
+    return set(app.openapi().get("paths", {}).keys())
+
+
+def _operation_tags(app, path: str) -> set[str]:
+    """Union of OpenAPI tags across every HTTP method of ``path``."""
+    operations = app.openapi().get("paths", {}).get(path, {})
+    tags: set[str] = set()
+    for operation in operations.values():
+        tags.update(operation.get("tags", []) or [])
+    return tags
+
+
 class TestAppConfiguration:
     """Tests for FastAPI app configuration."""
 
@@ -26,15 +48,15 @@ class TestAppConfiguration:
 
             from main import app
 
-            routes = [route.path for route in app.routes if hasattr(route, "path")]
+            paths = _openapi_paths(app)
 
             # Check for health endpoints
-            assert "/health" in routes
-            assert "/health/ready" in routes
+            assert "/health" in paths
+            assert "/health/ready" in paths
 
             # Check for versioned API routes
-            assert any("/api/v1/request" in route for route in routes)
-            assert any("/api/v1/parse" in route for route in routes)
+            assert "/api/v1/request" in paths
+            assert "/api/v1/parse" in paths
 
     def test_app_has_legacy_routes(self):
         """Test that app has legacy (non-versioned) routes for backwards compatibility."""
@@ -45,11 +67,11 @@ class TestAppConfiguration:
 
             from main import app
 
-            routes = [route.path for route in app.routes if hasattr(route, "path")]
+            paths = _openapi_paths(app)
 
             # Check for legacy routes
-            assert any("/request" in route and "/api/v1" not in route for route in routes)
-            assert any("/parse" in route and "/api/v1" not in route for route in routes)
+            assert any("/request" in path and "/api/v1" not in path for path in paths)
+            assert any("/parse" in path and "/api/v1" not in path for path in paths)
 
     def test_app_has_admin_bans_routes(self):
         """Pin that ``/admin/bans`` (#151) is mounted at the root, not under /api/v1.
@@ -65,12 +87,12 @@ class TestAppConfiguration:
 
             from main import app
 
-            routes = [route.path for route in app.routes if hasattr(route, "path")]
+            paths = _openapi_paths(app)
 
-            assert "/admin/bans" in routes
-            assert "/admin/bans/{fingerprint}" in routes
+            assert "/admin/bans" in paths
+            assert "/admin/bans/{fingerprint}" in paths
             # Must NOT have been accidentally namespaced under /api/v1
-            assert not any("/api/v1/admin" in r for r in routes)
+            assert not any("/api/v1/admin" in path for path in paths)
 
     def test_app_has_description(self):
         """Test that app has a description."""
@@ -100,7 +122,7 @@ class TestAppRouterTags:
     """Tests for router tags."""
 
     def test_health_router_tag(self):
-        """Test that health router has correct tag."""
+        """Test that the health route is tagged "health"."""
         with patch.dict("os.environ", {"GROQ_API_KEY": "test_key"}):
             from config.settings import get_settings
 
@@ -108,14 +130,11 @@ class TestAppRouterTags:
 
             from main import app
 
-            # Find health route and check tags
-            for route in app.routes:
-                if hasattr(route, "path") and route.path == "/health":
-                    assert hasattr(route, "tags") and "health" in route.tags
-                    break
+            assert "/health" in _openapi_paths(app), "/health route is not registered"
+            assert "health" in _operation_tags(app, "/health")
 
     def test_versioned_routes_have_tags(self):
-        """Test that versioned routes have appropriate tags."""
+        """Test that versioned routes exist and carry tags."""
         with patch.dict("os.environ", {"GROQ_API_KEY": "test_key"}):
             from config.settings import get_settings
 
@@ -123,9 +142,13 @@ class TestAppRouterTags:
 
             from main import app
 
-            # Find API routes and check tags
-            api_routes = [r for r in app.routes if hasattr(r, "path") and "/api/v1" in r.path]
-            assert len(api_routes) > 0  # Should have versioned routes
+            paths = _openapi_paths(app)
+
+            api_paths = [path for path in paths if "/api/v1" in path]
+            assert len(api_paths) > 0  # Should have versioned routes
+            # Every versioned route should carry at least one tag.
+            for path in api_paths:
+                assert _operation_tags(app, path), f"versioned route {path} has no tags"
 
 
 class TestAppLifespan:


### PR DESCRIPTION
## Problem

The `Unit Tests` CI job is red on four `tests/unit/test_main.py` tests with no app code change:

```
E  AssertionError: assert '/health' in ['/openapi.json', '/docs', '/docs/oauth2-redirect', '/redoc']
```

Root cause is dependency drift: `requirements.txt` pins `fastapi>=0.104.0`, and **FastAPI 0.137** changed `include_router` to append lazy `fastapi.routing._IncludedRouter` wrappers (no `.path`) instead of eagerly flattening sub-router routes into `app.routes`. The tests enumerate `app.routes` + `.path`, so they now see only FastAPI's built-in docs routes. CI was green on this exact behavior at `f0363ce` on 2026-06-09.

The **app is unaffected** — `GET /health` → 200, `/admin/bans` → 403 (registered, auth-gated), and `app.openapi()["paths"]` lists every route. This is purely a test-introspection bug.

## Fix

Introspect the OpenAPI schema (`app.openapi()["paths"]`), which reflects every registered path regardless of inclusion strategy and is stable across FastAPI versions. New `_openapi_paths`/`_operation_tags` helpers; the five route/tag tests rewritten against them.

`test_health_router_tag` was silently passing as a **no-op** (its `app.routes` loop matched nothing under the new wrappers) — it now asserts the `health` tag for real.

## Verification

- `pytest tests/unit/test_main.py` → 9 passed (was 4 failed) on FastAPI 0.137.2.
- Full `tests/unit/` suite → 503 passed.
- `ruff format --check`, `ruff check`, `mypy` clean.
- No other tests use the `app.routes`/`.path` pattern (grepped).

## Scope note

Out of scope: whether to also pin/cap FastAPI in `requirements.txt`. The app runs fine on 0.137, so this fixes the tests rather than freezing the dependency. Surfaced while fixing #162 (PR #163), whose CI was blocked by these unrelated failures; #163 will be rebased on this once merged.

Closes #164