### PR TITLE
docs: document the `skip_cache` request flag in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ curl -X POST "http://localhost:8000/api/v1/request" \
   -d '{"message": "Play la paradoja by Juana Molina"}'
 ```
 
+**Full request workflow (bypass the lookup cache):**
+```bash
+curl -X POST "http://localhost:8000/api/v1/request" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Play la paradoja by Juana Molina", "skip_cache": true}'
+```
+
+The `skip_cache` flag is forwarded as `?skip_cache=true` to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup), bypassing that service's caches so the lookup resolves against fresh data. Useful for benchmarking and cache A/B comparisons — see `scripts/benchmark_requests.py` and [`docs/benchmark-results.md`](docs/benchmark-results.md).
+
 **Health check:**
 ```bash
 curl "http://localhost:8000/health"


### PR DESCRIPTION
Documents the `skip_cache` flag on `POST /request` in the README's Example Requests section, which previously omitted it.

`skip_cache` is a `RequestBody` field (`routers/request.py`) forwarded as `?skip_cache=true` to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup), bypassing that service's caches. It is exercised by `scripts/benchmark_requests.py` and documented in `docs/benchmark-results.md`, but was undiscoverable from the README. The new note describes it accurately: it flows through to LML, and does **not** bypass a request-o-matic-local Discogs cache (that `discogs/cache_service.py` no longer exists in this repo).

Docs-only change; no Python touched.

Closes #170