### PR TITLE
fix: omit broken WXYC link for row-less external results (LML#631)

### DIFF
--- a/services/slack.py
+++ b/services/slack.py
@@ -26,10 +26,16 @@ def build_slack_blocks(
             f"_{item.call_number}_",
         ]
         if artwork and artwork.release_url:
-            links = f"<{artwork.release_url}|Discogs> | <{item.library_url}|WXYC>"
+            # A row-less external result (LML#631) has no WXYC catalog page —
+            # it carries id=0 and an empty library_url. Omit the WXYC link in
+            # that case rather than emitting a malformed empty-target <|WXYC>;
+            # the "(external)" call number already marks it as not-in-library.
+            link_parts = [f"<{artwork.release_url}|Discogs>"]
+            if item.library_url:
+                link_parts.append(f"<{item.library_url}|WXYC>")
             if (preview := preview_url(artwork)) is not None:
-                links += f" | <{preview}|Preview>"
-            text_lines.append(links)
+                link_parts.append(f"<{preview}|Preview>")
+            text_lines.append(" | ".join(link_parts))
 
         block: dict = {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(text_lines)}}
 

--- a/tests/unit/test_slack_service.py
+++ b/tests/unit/test_slack_service.py
@@ -103,6 +103,29 @@ class TestBuildSlackBlocks:
         assert "WXYC" in text
         assert "discogs.com" in text
 
+    def test_rowless_external_item_omits_broken_wxyc_link(self):
+        """A row-less external result (LML#631) carries id=0 and an empty
+        ``library_url`` — there is no WXYC catalog page for it. The Discogs link
+        must still surface, but the WXYC link must be omitted rather than emitted
+        as a malformed ``<|WXYC>`` (empty-target Slack link)."""
+        item = make_library_item(id=0, call_number="(external)", library_url="")
+        artwork = make_release_metadata(
+            release_id=99999,
+            release_url="https://www.discogs.com/release/99999",
+            artwork_url="https://example.com/artwork.jpg",
+        )
+
+        blocks = build_slack_blocks(
+            message="Result:",
+            items_with_artwork=[(item, artwork)],
+        )
+
+        text = blocks[1]["text"]["text"]
+        assert "<https://www.discogs.com/release/99999|Discogs>" in text
+        # No WXYC link at all — and certainly not the malformed empty-target form.
+        assert "WXYC" not in text
+        assert "<|WXYC>" not in text
+
     @pytest.mark.parametrize(
         "streaming_field",
         ["spotify_url", "apple_music_url", "youtube_music_url", "bandcamp_url", "soundcloud_url"],


### PR DESCRIPTION
Sibling to WXYC/library-metadata-lookup#631 / WXYC/library-metadata-lookup#656.

## Problem

LML#631 surfaces non-library listener requests row-less: a resolved Discogs release with no WXYC catalog row, carried as a `LibraryItem` with `id=0` and an empty `library_url`. `build_slack_blocks` emitted the WXYC link unconditionally whenever there was a Discogs release, so a row-less result would post a malformed empty-target `<|WXYC>` link to Slack.

## Change

Build the link list conditionally — the WXYC link is included only when `library_url` is non-empty. The `"(external)"` call number already marks the result as not-in-library, so dropping the dead link is sufficient (no extra "not in our library" note needed). Library-backed results are unchanged.

## Tests

- New: a row-less external item (`id=0`, empty `library_url`) surfaces the Discogs link but no WXYC link, and never the malformed `<|WXYC>`.
- Existing: the library-backed both-links test (Discogs + WXYC) still passes.

Full unit suite: 517 passed. Lint + format clean.

## Note on ordering

Harmless without LML#631: this only changes behavior when `library_url` is empty, which doesn't occur from this path until LML#631 ships and its flag (`LML_RESOLVE_NONLIBRARY_RELEASE`, default off) is flipped. Can merge independently.