### PR TITLE
fix: exclude non-library results from the Slack request channel

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,8 @@
 3. **Parse**: Groq AI (`llama-3.1-8b-instant`) extracts artist/song/album from message
 4. **Early return**: Non-request messages (feedback, DJ messages) are posted to Slack without search
 5. **Delegate**: Search is delegated to [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) via HTTP (`LOOKUP_SERVICE_URL`).
-6. **Slack**: Post enriched results with artwork to Slack
+6. **Filter to library**: Non-library results are dropped. LML can surface albums not in the WXYC catalog as row-less items (LML#631: `library_item.id == 0`, empty `library_url`, `call_number="(external)"`); a DJ can't pull a non-shelved album, so the request channel keeps only real library releases (`library_item.id > 0`). If this leaves nothing, the Slack post falls through to the "No results found" message.
+7. **Slack**: Post enriched results with artwork to Slack
 
 ## Degraded Modes
 Slack is the only hard dependency. When Groq or LML are unavailable the listener's message still reaches Slack, with a context line explaining what's missing. The response is `200` with a `degraded_mode` field:

--- a/routers/request.py
+++ b/routers/request.py
@@ -425,6 +425,13 @@ async def handle_request(
         # Extract results for Slack posting. Generated LookupResponse fields
         # are nullable in the schema; coerce to non-null defaults for callers.
         results = lookup_response.results or []
+        # Exclude non-library results from the request channel. LML surfaces
+        # albums not in the WXYC catalog as row-less items (LML#631: id=0, empty
+        # library_url, call_number="(external)"). A DJ can't pull a non-shelved
+        # album, so these don't belong in the request feed. When this empties the
+        # list, the Slack post falls through to the existing "No results found"
+        # branch in post_results_to_slack.
+        results = [item for item in results if item.library_item.id > 0]
         library_results = [item.library_item for item in results]
         items_with_artwork = [(item.library_item, item.artwork) for item in results]
         search_type = str(lookup_response.search_type or "none")

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -1,5 +1,6 @@
 """Unit tests for the lookup delegation branch in handle_request."""
 
+import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -58,14 +59,20 @@ def sample_lookup_response():
 
 
 @pytest.fixture
-def app(mock_lookup_client):
+def mock_slack():
+    """A mock SlackService whose ``post_blocks`` calls can be inspected."""
+    slack = AsyncMock()
+    slack.webhook_url = "https://hooks.slack.com/test"
+    return slack
+
+
+@pytest.fixture
+def app(mock_lookup_client, mock_slack):
     """Create a test app with the request router and delegation enabled."""
     app = FastAPI()
     app.include_router(router, prefix="/api/v1")
 
     mock_groq = Mock()
-    mock_slack = AsyncMock()
-    mock_slack.webhook_url = "https://hooks.slack.com/test"
 
     app.dependency_overrides[get_groq_client] = lambda: mock_groq
     app.dependency_overrides[get_slack_service] = lambda: mock_slack
@@ -388,6 +395,94 @@ class TestDelegationBranch:
         assert lookup_req.song == "la paradoja"
         assert lookup_req.album == "DOGA"
         assert lookup_req.raw_message == "play la paradoja by juana molina"
+
+    @pytest.mark.asyncio
+    async def test_rowless_nonlibrary_results_excluded(self, app, mock_lookup_client, mock_slack):
+        """Row-less, non-library results (LML#631: ``id=0``, empty ``library_url``,
+        ``call_number="(external)"``) are albums not in the WXYC catalog. A DJ can't
+        pull them off the shelf, so they must not reach the request channel — neither
+        the response's ``library_results`` nor the Slack post."""
+        mock_lookup_client.lookup.return_value = LookupResponse(
+            results=[
+                LookupResultItem(
+                    library_item=make_library_item(
+                        id=42, title="Aluminum Tunes", artist="Stereolab"
+                    ),
+                    artwork=None,
+                ),
+                LookupResultItem(
+                    library_item=make_library_item(
+                        id=0,
+                        title="Unshelved Bootleg",
+                        artist="Not In Library",
+                        call_number="(external)",
+                        library_url="",
+                    ),
+                    artwork=make_release_metadata(release_id=999),
+                ),
+            ],
+            search_type=SearchType.direct,
+        )
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post("/api/v1/request", json={"message": "play stereolab"})
+
+        data = response.json()
+        # Only the shelved release survives in the response.
+        assert [r["id"] for r in data["library_results"]] == [42]
+
+        # The Slack post mentions the library item but never the non-library one.
+        mock_slack.post_blocks.assert_awaited_once()
+        posted = json.dumps(mock_slack.post_blocks.call_args.args[0])
+        assert "Aluminum Tunes" in posted
+        assert "Not In Library" not in posted
+        assert "Unshelved Bootleg" not in posted
+
+    @pytest.mark.asyncio
+    async def test_all_nonlibrary_results_post_no_results_found(
+        self, app, mock_lookup_client, mock_slack
+    ):
+        """When every match is a row-less non-library result, filtering empties the
+        list and the request channel falls through to the existing 'No results found'
+        message rather than posting a non-library item."""
+        mock_lookup_client.lookup.return_value = LookupResponse(
+            results=[
+                LookupResultItem(
+                    library_item=make_library_item(
+                        id=0,
+                        title="Unshelved Bootleg",
+                        artist="Not In Library",
+                        call_number="(external)",
+                        library_url="",
+                    ),
+                    artwork=make_release_metadata(release_id=999),
+                ),
+            ],
+            search_type=SearchType.direct,
+        )
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request", json={"message": "play obscure bootleg"}
+                )
+
+        data = response.json()
+        assert data["library_results"] == []
+
+        mock_slack.post_blocks.assert_awaited_once()
+        posted = json.dumps(mock_slack.post_blocks.call_args.args[0])
+        assert "No results found" in posted
+        assert "Not In Library" not in posted
 
 
 class TestDelegatedCacheStats:


### PR DESCRIPTION
## Summary

Non-library results stopped leaking into the Slack request channel. LML#631 surfaces albums that aren't in the WXYC catalog as *row-less* results (`library_item.id == 0`, empty `library_url`, `call_number == "(external)"`). The `/request` handler posted everything LML returned with no library/non-library branching, so those items appeared in Slack even though a DJ can't pull a non-shelved album.

## Change

Filter `results` to real library releases (`library_item.id > 0`) at the single point where they're extracted in `routers/request.py`, so both the API response's `library_results` and the Slack post derive from the filtered list. When the filter empties the list, the handler falls through to the existing `_No results found_` message. The fix lives entirely in request-o-matic and deliberately does not touch LML's lookup pipeline.

## Testing

- `tests/unit/test_delegation.py` — added `test_rowless_nonlibrary_results_excluded` (mixed library + row-less: only the library item reaches the response and the rendered Slack blocks) and `test_all_nonlibrary_results_post_no_results_found` (all row-less → empty `library_results` and a "No results found" Slack post). Both written red-first.
- Full unit suite: 519 passed. `ruff check` and `ruff format --check` clean on the changed Python files.

## Docs

`docs/architecture.md` now documents the "filter to library" step in the request flow.

Closes #173
