### PR TITLE
chore: regenerate api_models from wxyc-shared main + add codegen-freshness CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,41 @@ jobs:
       - name: Lint with ruff
         run: ruff check .
 
+  codegen-check:
+    # Fails fast when generated/api_models.py lags the wxyc-shared api.yaml
+    # contract. Without this gate the committed models drifted silently across
+    # many wxyc-shared releases (fixed in #175). PR-only: it regenerates and
+    # diffs, which needs the codegen toolchain that normal jobs don't carry.
+    # Mirrors library-metadata-lookup's codegen-check job.
+    name: Codegen Freshness
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        # requirements-dev.txt pins datamodel-code-generator + ruff, so a new
+        # release with different generated-code formatting cannot silently fail
+        # this job on an unrelated PR (same rationale as the lint job's pins).
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Regenerate API models
+        # No sibling wxyc-shared checkout exists in CI, so the script downloads
+        # api.yaml from wxyc-shared main and regenerates generated/api_models.py.
+        run: bash scripts/generate_api_models.sh
+
+      - name: Check for drift
+        # A non-empty diff means the committed models are stale: regenerate with
+        # `bash scripts/generate_api_models.sh` and commit the result.
+        run: git diff --exit-code generated/
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1350,6 +1350,29 @@ class DiscogsArtistCredit(BaseModel):
     )
 
 
+class Provenance(StrEnum):
+    track = "track"
+    release = "release"
+
+
+class DiscogsWriterCredits(BaseModel):
+    names: list[str] = Field(
+        ..., description="Distinct songwriter/composer names for the resolved track."
+    )
+    roles: list[str] | None = Field(
+        None,
+        description='The verbatim Discogs role strings the names were drawn from (e.g. "Written-By", "Words By, Music By"), for auditability of the writer-role mapping.\n',
+    )
+    provenance: Provenance = Field(
+        ...,
+        description="`track` = scoped to the resolved track's per-track credits (precise); `release` = a release-level credit applied to the whole release (approximate for an individual track, mirroring tubafrenzy's auto-fill-from-artist fallback). Populated as `release` in the initial rollout; `track` is added when per-track resolution lands.\n",
+    )
+    track_position: str | None = Field(
+        None,
+        description='The resolved track\'s position (e.g. "A1", "5") when `provenance` is `track`; null for release-level credits.\n',
+    )
+
+
 class DiscogsLabelCredit(BaseModel):
     label_id: int | None = None
     name: str
@@ -1877,6 +1900,7 @@ class DiscogsMatchResult(BaseModel):
         None,
         description="Pre-parsed structured tokens from the artist's `profile` markup, using a cache-only resolver — references to entities not in the local PG cache fall through as plain-text tokens (no inline Discogs API calls on the read path). Populated only when `extended` is true. Field name matches `DiscogsArtistDetails.profile_tokens` so callers can share rendering code across the two payloads. Pair with `LookupRequest.warm_cache=true` on write-path calls to progressively populate the cache so subsequent reads render richer.\n",
     )
+    writer_credits: DiscogsWriterCredits | None = None
 
 
 class LookupResultItem(BaseModel):

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -5,10 +5,19 @@ from __future__ import annotations
 
 from datetime import date as date_aliased
 from datetime import time as time_aliased
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import Any, Literal
 
-from pydantic import AwareDatetime, BaseModel, Field, RootModel, confloat, conint
+from pydantic import (
+    AnyUrl,
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    confloat,
+    conint,
+)
 
 
 class ApiErrorResponse(BaseModel):
@@ -32,6 +41,34 @@ class PaginationInfo(BaseModel):
 class DateTimeEntry(BaseModel):
     day: str = Field(..., description='Day string (e.g., "Monday")')
     time: str = Field(..., description='Time string (e.g., "14:00")')
+
+
+class Status(StrEnum):
+    healthy = "healthy"
+    degraded = "degraded"
+    unhealthy = "unhealthy"
+
+
+class HealthCheckResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="allow",
+    )
+    status: Status = Field(
+        ...,
+        description="Service-reported health. `healthy` = fully operational; `degraded`\n= serving but with reduced capability; `unhealthy` = should not\nreceive traffic.\n",
+    )
+
+
+class Services(StrEnum):
+    ok = "ok"
+    unavailable = "unavailable"
+    timeout = "timeout"
+
+
+class ReadinessResponse(HealthCheckResponse):
+    services: dict[str, Services] = Field(
+        ..., description="Per-dependency readiness map keyed by dependency name."
+    )
 
 
 class Genre(StrEnum):
@@ -76,30 +113,6 @@ class FlowsheetEntryBase(BaseModel):
     show_id: int
 
 
-class FlowsheetEntryResponse(FlowsheetEntryBase):
-    album_id: int | None = None
-    track_title: str | None = None
-    album_title: str | None = None
-    artist_name: str | None = None
-    record_label: str | None = None
-    label_id: int | None = None
-    rotation_id: int | None = None
-    rotation_bin: RotationBin | None = None
-    request_flag: bool
-    segue: bool | None = None
-    message: str | None = None
-    artwork_url: str | None = None
-    discogs_url: str | None = None
-    release_year: int | None = None
-    spotify_url: str | None = None
-    apple_music_url: str | None = None
-    youtube_music_url: str | None = None
-    bandcamp_url: str | None = None
-    soundcloud_url: str | None = None
-    artist_bio: str | None = None
-    artist_wikipedia_url: str | None = None
-
-
 class FlowsheetSongEntry(FlowsheetEntryBase):
     track_title: str
     artist_name: str
@@ -111,6 +124,10 @@ class FlowsheetSongEntry(FlowsheetEntryBase):
     album_id: int | None = None
     rotation_id: int | None = None
     rotation_bin: RotationBin | None = None
+    track_position: str | None = Field(
+        None,
+        description='Track position on the release (e.g., "A1", "B2", "5"). Optional; populated by the dj-site picker when a release with a resolvable tracklist is chosen (catalog-track-search plan §5.3 / Track 3). Free-text `track_title` remains the source of truth; this field is additive metadata for future enrichment + analytics.\n',
+    )
 
 
 class FlowsheetShowBlockEntry(FlowsheetEntryBase, DateTimeEntry):
@@ -129,6 +146,10 @@ class FlowsheetBreakpointEntry(FlowsheetMessageEntry, DateTimeEntry):
 class FlowsheetCreateSongFromCatalog(BaseModel):
     album_id: int
     track_title: str
+    track_position: str | None = Field(
+        None,
+        description='Track position on the release (e.g., "A1", "B2", "5", "1-12"). Written by the dj-site flowsheet picker (catalog-track-search plan §5.3 / Track 3) when the DJ selects a track from the resolved release. Omitted when the DJ enters a free-text track_title without a tracklist lookup or when the release has no resolvable identity. String-typed to match Discogs\'s `release_track.position` (vinyl side notation, multi-disc prefixes).\n',
+    )
     rotation_id: int | None = None
     request_flag: bool
     segue: bool | None = None
@@ -143,6 +164,10 @@ class FlowsheetCreateSongFreeform(BaseModel):
     segue: bool | None = None
     record_label: str | None = None
     label_id: int | None = None
+    rotation_id: int | None = Field(
+        None,
+        description="Rotation linkage for a track on a rotation album that isn't in the WXYC library catalog (BS#1308). The Backend snapshot/else branch persists `rotation_id` alongside `album_id IS NULL` so the V2 read path can JOIN back to `rotation` for `rotation_bin` and the iOS rotation-artwork resolver can find the entry. `rotation_bin` is derived on read and intentionally not declared here.\n",
+    )
 
 
 class EntryType(StrEnum):
@@ -161,6 +186,10 @@ class FlowsheetCreateMessage(BaseModel):
 
 class FlowsheetUpdateRequest(BaseModel):
     track_title: str | None = None
+    track_position: str | None = Field(
+        None,
+        description='Track position on the release (e.g., "A1", "B2", "5", "1-12"). Set when re-picking a track via the flowsheet picker; cleared (omitted) when a DJ edits the entry to a free-text track_title. String-typed to match Discogs\'s `release_track.position`.\n',
+    )
     artist_name: str | None = None
     album_title: str | None = None
     record_label: str | None = None
@@ -237,33 +266,6 @@ class EntryType1(StrEnum):
     track = "track"
 
 
-class FlowsheetV2TrackEntry(FlowsheetV2Base):
-    entry_type: Literal["track"]
-    album_id: int | None = None
-    rotation_id: int | None = None
-    artist_name: str | None = None
-    album_title: str | None = None
-    track_title: str | None = None
-    record_label: str | None = None
-    request_flag: bool
-    segue: bool | None = None
-    rotation_bin: RotationBin | None = None
-    artwork_url: str | None = None
-    discogs_url: str | None = None
-    release_year: int | None = None
-    spotify_url: str | None = None
-    apple_music_url: str | None = None
-    youtube_music_url: str | None = None
-    bandcamp_url: str | None = None
-    soundcloud_url: str | None = None
-    artist_bio: str | None = None
-    artist_wikipedia_url: str | None = None
-    on_streaming: bool | None = Field(
-        None,
-        description="Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.",
-    )
-
-
 class EntryType2(StrEnum):
     show_start = "show_start"
 
@@ -317,6 +319,10 @@ class EntryType7(StrEnum):
 
 class FlowsheetV2BreakpointEntry(FlowsheetV2Base):
     entry_type: Literal["breakpoint"]
+    radio_hour: AwareDatetime | None = Field(
+        None,
+        description="Exact top-of-hour this breakpoint marks (ISO 8601), sourced from tubafrenzy's RADIO_HOUR. Distinct from `add_time`, which is the row's logging instant (~1 min before the hour). Optional and nullable: absent on servers predating the producer rollout, null for breakpoint rows not yet backfilled. Clients use `radio_hour` for the hour-marker label when present and fall back to `add_time` otherwise.",
+    )
     message: str | None = None
 
 
@@ -327,38 +333,6 @@ class EntryType8(StrEnum):
 class FlowsheetV2MessageEntry(FlowsheetV2Base):
     entry_type: Literal["message"]
     message: str
-
-
-class Entries(
-    RootModel[
-        FlowsheetV2TrackEntry
-        | FlowsheetV2ShowStartEntry
-        | FlowsheetV2ShowEndEntry
-        | FlowsheetV2DJJoinEntry
-        | FlowsheetV2DJLeaveEntry
-        | FlowsheetV2TalksetEntry
-        | FlowsheetV2BreakpointEntry
-        | FlowsheetV2MessageEntry
-    ]
-):
-    root: (
-        FlowsheetV2TrackEntry
-        | FlowsheetV2ShowStartEntry
-        | FlowsheetV2ShowEndEntry
-        | FlowsheetV2DJJoinEntry
-        | FlowsheetV2DJLeaveEntry
-        | FlowsheetV2TalksetEntry
-        | FlowsheetV2BreakpointEntry
-        | FlowsheetV2MessageEntry
-    ) = Field(..., discriminator="entry_type")
-
-
-class FlowsheetV2PaginatedResponse(BaseModel):
-    entries: list[Entries]
-    page: int
-    limit: int
-    total: int = Field(..., description="Total number of entries")
-    totalPages: int = Field(..., description="Total number of pages")
 
 
 class OnAirDJ(BaseModel):
@@ -386,27 +360,9 @@ class ShowDJ(BaseModel):
     active: bool | None = None
 
 
-class ShowPlaylist(BaseModel):
-    show_name: str | None = None
-    specialty_show: str | None = None
-    start_time: AwareDatetime | None = None
-    end_time: AwareDatetime | None = None
-    show_djs: list[OnAirDJ] | None = None
-    entries: list[FlowsheetEntryResponse] | None = None
-
-
 class Dj(BaseModel):
     dj_id: int | None = None
     dj_name: str | None = None
-
-
-class ShowPeek(BaseModel):
-    show: int | None = None
-    show_name: str | None = None
-    date: AwareDatetime | None = None
-    djs: list[Dj] | None = None
-    specialty_show: str | None = None
-    preview: list[FlowsheetEntryResponse] | None = None
 
 
 class Artist(BaseModel):
@@ -439,38 +395,43 @@ class Album(BaseModel):
     )
 
 
-class AlbumSearchResult(BaseModel):
+class CatalogExportRow(BaseModel):
     id: int
-    add_date: AwareDatetime
+    artist_name: str = Field(
+        ...,
+        description="Authoritative artist name. The server COALESCEs the denormalized library.artist_name to artists.artist_name (NOT NULL), so this never ships as null even before the denormalization backfill completes.\n",
+    )
     album_title: str
-    artist_name: str
-    code_letters: str
-    code_number: int
-    code_artist_number: int
-    format_name: str
+    code_letters: str = Field(..., description='Shelf call-number letters (e.g. "AU").')
+    code_number: int = Field(..., description="Shelf call-number release number.")
+    code_artist_number: int = Field(
+        ..., description="Shelf call-number artist number (genre-scoped)."
+    )
+    label: str | None = None
     genre_name: str
-    label: str
-    label_id: int | None = None
-    album_dist: float | None = None
-    artist_dist: float | None = None
-    rotation_bin: RotationBin | None = None
-    rotation_id: int | None = None
-    plays: int | None = None
+    format_name: str
     on_streaming: bool | None = Field(
         None,
-        description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
+        description="True if on >=1 streaming service; false if physical-only; null if unknown.",
     )
-    album_artist: str | None = Field(None, description="Credited album artist for compilations.")
-    date_lost: AwareDatetime | None = Field(
+    plays: int | None = Field(
         None,
-        description="When the release was marked missing from the physical library. Null if in library.",
+        description="Per-pressing LINKED play count for THIS catalog row (from album_plays). The honest per-release number; to rank by real popularity across all pressings of a logical album, use `popularity` instead.\n",
     )
-    date_found: AwareDatetime | None = Field(
-        None, description="When a previously missing release was found. Null if never lost."
+    popularity: int | None = Field(
+        None,
+        description="Attribution-corrected popularity (BS#1486 Phase-2 Track 3): a play count for this row's LOGICAL album rather than this single pressing. Pressings that resolve to the same Discogs master (~90% of RESOLVED library rows) collapse into one count; release-only and unresolved rows keep a per-release or per-library key, with no cross-pressing collapse. It also adds the free-text/unlinked plays Track 1 has resolved to the same release/master (the ~43% free-text tail is the ceiling, not all of it — only the resolved subset counts), which the linked-only `plays` cannot see. Rank releases by `popularity`. null when the album_popularity signal has no row for this row's logical key. Distinct from `plays`, which stays the per-pressing linked count.\n",
     )
     artwork_url: str | None = Field(
+        None, description="Album cover URL from Discogs; null if not yet fetched."
+    )
+    rotation_bin: str | None = Field(
         None,
-        description="Album cover artwork URL from Discogs. Null if artwork has not been fetched yet or is unavailable.",
+        description="RAW current-rotation bin — the most-recently-ADDED rotation record for this album — NOT the CURRENT_DATE-filtered value AlbumSearchResult returns. Nominal values are H/M/L/S (see RotationBin) but it is typed as a free string, NOT the RotationBin enum, so a value outside those cohorts (e.g. 'N', a current server-enum member — NOT legacy) cannot break a strict-enum decoder. Evaluate live rotation client-side together with rotation_kill_date:\n  in rotation  ==  rotation_bin != null\n                  AND (rotation_kill_date == null\n                       OR rotation_kill_date > today-in-client-tz)\nThe daily kill-date expiry is a clock event no DB trigger can observe, which is why this endpoint ships raw and defers expiry to the client.\n",
+    )
+    rotation_kill_date: date_aliased | None = Field(
+        None,
+        description="Date (YYYY-MM-DD; server ::text cast) the current rotation record expires, or null if it has none. Used with rotation_bin to evaluate live rotation client-side. Absent from AlbumSearchResult — a client that reuses AlbumSearchResult for this endpoint silently loses it.\n",
     )
 
 
@@ -757,20 +718,6 @@ class MatchType(StrEnum):
     partial = "partial"
 
 
-class LibraryMatch(BaseModel):
-    album: AlbumSearchResult
-    confidence: confloat(ge=0.0, le=1.0)
-    matchType: MatchType
-    reasoning: str | None = None
-
-
-class EnhancedRequest(SongRequest):
-    parsed: ParsedSongRequest | None = None
-    matches: list[LibraryMatch] | None = None
-    artwork_url: str | None = None
-    discogs_url: str | None = None
-
-
 class DeviceRegistration(BaseModel):
     device_id: str
     registered_at: AwareDatetime
@@ -779,6 +726,132 @@ class DeviceRegistration(BaseModel):
 class DeviceToken(BaseModel):
     token: str
     expires_at: AwareDatetime
+
+
+class DeviceAuthCodeRequest(BaseModel):
+    client_id: str = Field(
+        ..., description="The client ID of the application requesting authorization."
+    )
+    scope: str | None = Field(None, description="Optional space-separated list of OAuth scopes.")
+    user_id: str | None = Field(
+        None,
+        description="Optional. The user ID to which the device code should be pre-bound (a better-auth 1.6.20+ plugin field). WXYC's shared-computer QR flow does not send this — the DJ is identified later at /auth/device/approve — but it is mirrored here for runtime fidelity.\n",
+    )
+
+
+class DeviceAuthCodeResponse(BaseModel):
+    device_code: str = Field(
+        ..., description="The device verification code, polled at /auth/device/token."
+    )
+    user_code: str = Field(..., description="The short code shown to the user / encoded in the QR.")
+    verification_uri: AnyUrl = Field(..., description="URL where the user verifies the code.")
+    verification_uri_complete: AnyUrl = Field(
+        ..., description="verification_uri with user_code pre-filled as a query parameter."
+    )
+    expires_in: int = Field(
+        ..., description="Lifetime of the device/user code in seconds (WXYC config: 300 = 5min)."
+    )
+    interval: int = Field(..., description="Minimum polling interval in seconds (WXYC config: 5).")
+
+
+class GrantType(StrEnum):
+    urn_ietf_params_oauth_grant_type_device_code = "urn:ietf:params:oauth:grant-type:device_code"
+
+
+class DeviceAuthTokenRequest(BaseModel):
+    grant_type: GrantType = Field(..., description="RFC 8628 device-flow grant type (fixed value).")
+    device_code: str = Field(..., description="The device_code returned by /auth/device/code.")
+    client_id: str = Field(..., description="The client ID of the application.")
+
+
+class TokenType(StrEnum):
+    Bearer = "Bearer"
+
+
+class DeviceAuthTokenResponse(BaseModel):
+    access_token: str = Field(..., description="The session bearer token for the browser.")
+    token_type: TokenType
+    expires_in: int = Field(
+        ...,
+        description="Token lifetime in seconds. WXYC's auth-service (Backend-Service#1495, hooks.after on /device/token) rewrites the plugin's session-derived value to a fixed 43200 (12h). The vanilla-plugin value would otherwise be the global ~7-day session TTL.\n",
+    )
+    scope: str = Field(..., description="Granted scopes (empty string when none were requested).")
+
+
+class DeviceAuthStatus(StrEnum):
+    pending = "pending"
+    approved = "approved"
+    denied = "denied"
+
+
+class DeviceAuthVerifyResponse(BaseModel):
+    user_code: str
+    status: DeviceAuthStatus
+
+
+class DeviceAuthApproveRequest(BaseModel):
+    userCode: str = Field(
+        ...,
+        description="The user code to approve. NOTE: camelCase on the wire — the plugin's approve/deny bodies differ from the snake_case code/token bodies.\n",
+    )
+
+
+class DeviceAuthDenyRequest(BaseModel):
+    userCode: str = Field(
+        ...,
+        description="The user code to deny. NOTE: camelCase on the wire (see DeviceAuthApproveRequest).\n",
+    )
+
+
+class DeviceAuthActionResponse(BaseModel):
+    success: bool = Field(..., description="Always true on success. Shared by /approve and /deny.")
+
+
+class DeviceAuthCodeErrorCode(StrEnum):
+    invalid_request = "invalid_request"
+    invalid_client = "invalid_client"
+
+
+class DeviceAuthCodeError(BaseModel):
+    error: DeviceAuthCodeErrorCode
+    error_description: str
+
+
+class DeviceAuthTokenErrorCode(StrEnum):
+    authorization_pending = "authorization_pending"
+    slow_down = "slow_down"
+    expired_token = "expired_token"
+    access_denied = "access_denied"
+    invalid_request = "invalid_request"
+    invalid_grant = "invalid_grant"
+    server_error = "server_error"
+
+
+class DeviceAuthTokenError(BaseModel):
+    error: DeviceAuthTokenErrorCode
+    error_description: str
+
+
+class DeviceAuthVerifyErrorCode(StrEnum):
+    invalid_request = "invalid_request"
+    expired_token = "expired_token"
+
+
+class DeviceAuthVerifyError(BaseModel):
+    error: DeviceAuthVerifyErrorCode
+    error_description: str
+
+
+class DeviceAuthActionErrorCode(StrEnum):
+    invalid_request = "invalid_request"
+    expired_token = "expired_token"
+    unauthorized = "unauthorized"
+    access_denied = "access_denied"
+
+
+class DeviceAuthActionError(BaseModel):
+    error: DeviceAuthActionErrorCode
+    error_description: str
 
 
 class RateLimitInfo(BaseModel):
@@ -800,6 +873,14 @@ class MetadataSource(StrEnum):
     apple_music = "apple_music"
     cache = "cache"
     none = "none"
+
+
+class MetadataStatus(StrEnum):
+    pending = "pending"
+    enriching = "enriching"
+    enriched_match = "enriched_match"
+    enriched_no_match = "enriched_no_match"
+    failed_no_retry = "failed_no_retry"
 
 
 class AlbumMetadata(BaseModel):
@@ -898,6 +979,19 @@ class StreamingLinks(BaseModel):
     soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
 
 
+class ReconciledIdentity(BaseModel):
+    discogs_artist_id: int | None = Field(None, description="Discogs artist ID")
+    musicbrainz_artist_id: str | None = Field(None, description="MusicBrainz artist UUID")
+    wikidata_qid: str | None = Field(None, description='Wikidata QID (e.g. "Q12345")')
+    spotify_artist_id: str | None = Field(
+        None, description="Spotify artist ID (the Spotify URI suffix)"
+    )
+    apple_music_artist_id: str | None = Field(None, description="Apple Music artist ID")
+    bandcamp_id: str | None = Field(
+        None, description="Bandcamp slug (the subdomain in `<slug>.bandcamp.com`)"
+    )
+
+
 class LookupRequest(BaseModel):
     artist: str | None = Field(None, description="Parsed artist name")
     song: str | None = Field(None, description="Parsed song/track title")
@@ -906,10 +1000,25 @@ class LookupRequest(BaseModel):
         None,
         description="Original request message (used for ambiguous format detection). Optional when structured fields (artist, album, song) are provided.\n",
     )
+    include_identity: bool | None = Field(
+        False,
+        description="Per cross-cache-identity plan §3.2.2 (E2-LML write contract). When true, the response carries an additional `identity` block (the §3.2.5 cascade's per-source resolution detail), and `api_version` is set to 2. When false (the default), the response is byte-identical to v0.5.0 — `identity` is absent and `api_version` is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets this to true on every call; other consumers (catalog search, dj-site proxy, iOS apps) leave it false.\n",
+    )
+    extended: bool | None = Field(
+        None,
+        description="When true, the top-1 result's `artwork` block is populated with additional fields LML already fetches during enrichment but normally discards: `discogs_artist_id`, `tracklist`, `genres`, `styles`, `label`, `full_release_date`, `artist_image_url`, and `profile_tokens` (cache-only deep parse of the artist's profile markup). Lets a caller obtain a full playcut metadata payload in a single `/lookup` call instead of following up with separate `/discogs/release/{id}` and `/discogs/artist/{id}` requests. Absent or false leaves the response shape unchanged.\n",
+    )
+    warm_cache: bool | None = Field(
+        None,
+        description="When true, LML schedules a fire-and-forget background task after the response is built that runs a *deep* async parse of the top-1 artist's bio. The task resolves all `[a…]`/`[r…]`/`[m…]` references against the Discogs API where the local cache misses, warming the PG cache so subsequent reads of the same artist render richer bio tokens. Intended for write-path callers (e.g. Backend-Service's flowsheet-linkage service committing a new DJ entry); read-path callers should leave this absent/false to avoid doubling the Discogs-API load per request.\n",
+    )
 
 
 class LibraryCatalogItem(BaseModel):
-    id: int = Field(..., description="Unique identifier in the library database")
+    id: int = Field(
+        ...,
+        description='Unique identifier in the library database. `0` means there is no WXYC catalog row for this result (a row-less / "(external)" item, e.g. a Discogs-only library miss); any positive value is a real shelved release.\n',
+    )
     title: str | None = Field(None, description="Album/release title")
     artist: str | None = Field(None, description="Artist name")
     call_letters: str | None = Field(None, description="Library call letter code")
@@ -933,26 +1042,28 @@ class LibraryCatalogItem(BaseModel):
     )
 
 
-class DiscogsMatchResult(BaseModel):
-    album: str | None = Field(None, description="Release title")
-    artist: str | None = Field(None, description="Release artist")
-    release_id: int = Field(..., description="Discogs release ID")
-    release_url: str = Field(..., description="URL to the release on Discogs")
-    artwork_url: str | None = Field(None, description="Artwork image URL")
-    confidence: confloat(ge=0.0, le=1.0) | None = Field(0, description="Match confidence score")
-    release_year: int | None = Field(None, description="Release year from Discogs")
-    artist_bio: str | None = Field(None, description="Artist biography from Discogs profile")
-    wikipedia_url: str | None = Field(None, description="Wikipedia URL for the artist")
-    spotify_url: str | None = Field(None, description="Spotify album URL")
-    apple_music_url: str | None = Field(None, description="Apple Music album URL")
-    youtube_music_url: str | None = Field(None, description="YouTube Music search URL")
-    bandcamp_url: str | None = Field(None, description="Bandcamp album URL")
-    soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
+class CacheStats(BaseModel):
+    memory_hits: conint(ge=0) = Field(
+        ..., description="Hits in LML's per-process in-memory TTL cache"
+    )
+    pg_hits: conint(ge=0) = Field(..., description="Hits in the discogs-cache PostgreSQL cache")
+    pg_misses: conint(ge=0) = Field(
+        ...,
+        description="Misses in the discogs-cache PostgreSQL cache (forced an API call or fallback)",
+    )
+    api_calls: conint(ge=0) = Field(
+        ..., description="Number of Discogs API calls made during the lookup"
+    )
+    pg_time_ms: confloat(ge=0.0) = Field(
+        ..., description="Total milliseconds spent in PostgreSQL cache lookups"
+    )
+    api_time_ms: confloat(ge=0.0) = Field(
+        ..., description="Total milliseconds spent in Discogs API calls"
+    )
 
 
-class LookupResultItem(BaseModel):
-    library_item: LibraryCatalogItem
-    artwork: DiscogsMatchResult | None = None
+class ApiVersion(IntEnum):
+    integer_2 = 2
 
 
 class SearchType(StrEnum):
@@ -964,59 +1075,263 @@ class SearchType(StrEnum):
     none = "none"
 
 
-class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field([], validate_default=True)
-    search_type: SearchType | None = Field(
-        "none",
-        description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",
+class IdentitySource(StrEnum):
+    discogs = "discogs"
+    musicbrainz = "musicbrainz"
+    wikidata = "wikidata"
+    spotify = "spotify"
+    apple_music = "apple_music"
+    bandcamp = "bandcamp"
+
+
+class IdentityMethod(StrEnum):
+    manual = "manual"
+    cross_source_agreement = "cross_source_agreement"
+    exact_match = "exact_match"
+    name_variation = "name_variation"
+    member_group = "member_group"
+    alias_match = "alias_match"
+    trigram = "trigram"
+    llm = "llm"
+
+
+class IdentitySkipReason(StrEnum):
+    error = "error"
+    manual_override_protected = "manual_override_protected"
+    disabled = "disabled"
+    prerequisite_failed = "prerequisite_failed"
+
+
+class IdentityResolution(BaseModel):
+    source: IdentitySource
+    attempted: bool = Field(
+        ...,
+        description="True when this source's leg actually ran (whether or not it found a match). False when it was skipped — `reason` is populated, `external_id`/`method`/`confidence` are NULL.\n",
     )
-    song_not_found: bool | None = Field(
-        False,
-        description="True if search fell back to artist-only (track not confirmed on results)",
+    external_id: str | None = Field(
+        None,
+        description="The external identifier this leg resolved to (Discogs release ID, MusicBrainz MBID, Wikidata QID, Spotify URI suffix, Apple Music ID, Bandcamp slug). Stored as a string regardless of the source's native type so the API surface is uniform; Backend casts to the per-source column type when writing `library_identity_source`. NULL when `attempted: false`, or when the leg ran but found no match.\n",
     )
-    found_on_compilation: bool | None = Field(
-        False, description="True if the track was found on a compilation album"
+    method: IdentityMethod | None = Field(
+        None,
+        description="The matcher method that produced the resolution. NULL when `attempted: false` or when the leg ran but found no match.\n",
     )
-    context_message: str | None = Field(
-        None, description="Human-readable context string for display"
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(
+        None,
+        description="Confidence in [0, 1]. Must fall within the method's locked range from plan §3.4.1 — Backend's writer rejects rows where confidence is out of range. NULL when `attempted: false` or when the leg ran but found no match.\n",
     )
-    corrected_artist: str | None = Field(
-        None, description="Fuzzy-corrected artist name if different from the original"
-    )
-    cache_stats: dict[str, Any] | None = Field(
-        None, description="Cache hit/miss statistics from the lookup"
+    reason: IdentitySkipReason | None = Field(
+        None, description="Required when `attempted: false`; absent or NULL otherwise.\n"
     )
 
 
-class DiscogsSearchRequest(BaseModel):
-    artist: str | None = None
-    album: str | None = None
-    track: str | None = None
-    label: str | None = None
-    format: str | None = None
+class LookupIdentityBlock(BaseModel):
+    resolved: list[IdentityResolution] = Field(
+        ...,
+        description="One entry per known source. Order is stable (matches the `IdentitySource` enum order). Always populated even when no source resolved — the array carries `attempted: false` entries in that case.\n",
+    )
 
 
-class DiscogsEnrichedSearchResult(BaseModel):
-    album: str | None = None
-    artist: str | None = None
-    release_id: int
-    release_url: str
-    artwork_url: str | None = None
-    confidence: float | None = 0
-    release_year: int | None = None
-    artist_bio: str | None = None
-    wikipedia_url: str | None = None
-    spotify_url: str | None = None
-    apple_music_url: str | None = None
-    youtube_music_url: str | None = None
-    bandcamp_url: str | None = None
-    soundcloud_url: str | None = None
+class BulkResolveInput(BaseModel):
+    library_id: int = Field(..., description="Backend `wxyc_schema.library.id` (FK target).")
+    artist_name: str = Field(
+        ..., description="Hint — Backend's denormalized artist name for the row."
+    )
+    album_title: str = Field(
+        ..., description="Hint — Backend's denormalized album title for the row."
+    )
 
 
-class DiscogsSearchResponse(BaseModel):
-    results: list[DiscogsEnrichedSearchResult] | None = Field([], validate_default=True)
-    total: int | None = 0
-    cached: bool | None = False
+class BulkResolveResultKind(StrEnum):
+    single_artist = "single_artist"
+    compilation = "compilation"
+    unresolved = "unresolved"
+
+
+class BulkResolveProvenanceEntry(BaseModel):
+    source: IdentitySource
+    method: IdentityMethod
+    confidence: confloat(ge=0.0, le=1.0) = Field(
+        ...,
+        description="Per-source confidence in [0, 1], within the source's locked method range from §3.4.1. NULL when `external_id` is NULL — the source ran but produced no candidate, so confidence is undefined (not zero). When non-null, equal to or greater than the top-level `confidence` (composition rules either MIN or boost, never lower a per-source row).\n",
+    )
+    external_id: str | None = Field(
+        None,
+        description="The external identifier this source resolved to (Discogs release ID, MusicBrainz MBID, Wikidata QID, Spotify URI suffix, etc.). NULL when the source ran but found no match (the row is still surfaced so consumers see the leg ran); `confidence` is also NULL in that case.\n",
+    )
+
+
+class BulkResolveTrackIdentity(BaseModel):
+    track_position: str = Field(..., description="Track position; matches the request input.")
+    sources: list[BulkResolveProvenanceEntry] = Field(
+        ...,
+        description="One per-source row per source LML composed the track from. Empty array means LML attempted resolution at track grain and found no matches.\n",
+    )
+
+
+class BulkResolveResult(BaseModel):
+    kind: BulkResolveResultKind
+    library_id: int = Field(..., description="Backend `library.id` for this result.")
+    main: ReconciledIdentity | None = Field(
+        None,
+        description="Composed external IDs for `kind: single_artist`. NULL for every other `kind`. URL construction is the consumer's job (see existing ReconciledIdentity contract).\n",
+    )
+    method: IdentityMethod | None = Field(
+        None,
+        description="The composed top-level method LML's bulk-resolve handler picked per §3.4.1.1 (typically the strongest leg's method, or `cross_source_agreement` when Rule 2 boosted). NULL for `kind: unresolved`.\n",
+    )
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(
+        None,
+        description="Composed top-level confidence in [0, 1] — the MIN of resolved sources' confidences after composition (§3.4.1.1 Rule 4), unless boosted by cross-source agreement (Rule 2). NULL for `kind: unresolved`.\n",
+    )
+    provenance: list[BulkResolveProvenanceEntry] = Field(
+        ...,
+        description="Per-source rows feeding LML's composition. Always present; empty array means LML attempted the cascade and no source produced a row above the §3.4.1.1 Rule 6 floor.\n",
+    )
+    tracks: list[BulkResolveTrackIdentity] | None = Field(
+        None,
+        description="Set only for `kind: compilation`; absent for every other `kind`. Empty array when LML has no per-track data for the V/A row yet. Two states (present-array or absent), not three.\n",
+    )
+
+
+class BulkResolveLibrariesResponse(BaseModel):
+    results: list[BulkResolveResult]
+    cache_stats: CacheStats | None = None
+
+
+class IdentityKind(StrEnum):
+    release = "release"
+
+
+class ReleaseIdentitySource(StrEnum):
+    discogs_release = "discogs_release"
+    discogs_master = "discogs_master"
+    bandcamp = "bandcamp"
+    apple_music_album = "apple_music_album"
+
+
+class ReleaseIdentityResolveRequest(BaseModel):
+    kind: IdentityKind
+    source: ReleaseIdentitySource
+    external_id: str = Field(
+        ...,
+        description="Source-specific identifier. For `discogs_release` / `discogs_master` it is the positive integer ID as a string; zero and negative values are rejected with 422 (Discogs uses `0` for the unknown-release sentinel). For `bandcamp` it is the canonical album URL (e.g. `https://autechre.bandcamp.com/album/confield`); LML URL-canonicalises before mint so trailing-slash and equivalent variants converge on one identity row. Non-album Bandcamp URLs (track URLs, bare subdomain) are rejected with 422. For `apple_music_album` it is the numeric Apple Music album ID as a string (e.g. `1234567890`); zero, negative, and non-numeric values are rejected with 422.\n",
+    )
+
+
+class ReleaseIdentityResolveResponse(BaseModel):
+    identity_id: int = Field(
+        ...,
+        description="`entity.release_identity.id` for the resolved row. Stable across calls with the same `(kind, source, external_id)`.\n",
+    )
+    kind: IdentityKind
+    minted: bool = Field(
+        ...,
+        description="`true` when this call inserted a new row, `false` when an existing row was returned. Useful for callers that want to observe whether they were the first to surface a given release.\n",
+    )
+
+
+class ArtistSearchAliasSource(StrEnum):
+    discogs_name_variation = "discogs_name_variation"
+    discogs_alias = "discogs_alias"
+    discogs_member = "discogs_member"
+    wxyc_library_alt = "wxyc_library_alt"
+
+
+class ArtistSearchAliasMethod(StrEnum):
+    name_variation = "name_variation"
+    alias = "alias"
+    member = "member"
+    alt_curated = "alt_curated"
+
+
+class ArtistSearchAliasVariant(BaseModel):
+    source: ArtistSearchAliasSource
+    variant: str = Field(..., description='The searchable string (e.g. "Thee Oh Sees").')
+    related_external_id: str | None = Field(
+        None,
+        description='For alias / member kinds, the namespaced source-side id of the related artist (e.g. "discogs:artist:67890", "musicbrainz:artist:<mbid>"). NULL for name_variation and alt_curated.\n',
+    )
+    related_name: str | None = Field(
+        None,
+        description="For alias / member kinds, the canonical name of the related artist as the source records it. NULL otherwise.\n",
+    )
+    active: bool | None = Field(
+        None,
+        description="For member kind only — Discogs records active/inactive band membership. NULL for other kinds.\n",
+    )
+    method: ArtistSearchAliasMethod
+    confidence: confloat(ge=0.0, le=1.0) = Field(
+        ...,
+        description="Per-source default confidence (e.g. 0.95 for discogs_name_variation, 0.85 for discogs_alias / wxyc_library_alt, 0.70 for discogs_member). v1 search ignores this; stored for v2 ranking calibration.\n",
+    )
+
+
+class ArtistSearchAliasesResult(BaseModel):
+    name: str = Field(..., description="The WXYC canonical artist name from the request.")
+    variants: list[ArtistSearchAliasVariant]
+    sources_present: list[ArtistSearchAliasSource] = Field(
+        ...,
+        description="Sources the composer actually queried for this artist. A source appears here iff the composer reached its fetch code path — independent of whether that path produced any variants. Consumers use this to scope reconciliation: only delete cached rows whose `source` is listed here. Sources skipped because of missing prerequisites (e.g., no `discogs_artist_id` in `entity.identity`) are ABSENT from this list, and the consumer must leave their cached rows alone — that source did not run, so its absence is not evidence of upstream deletion. Modeled on the empty-provenance semantic of `BulkResolveProvenanceEntry`.\n",
+    )
+
+
+class ArtistSearchAliasesBulkRequest(BaseModel):
+    names: list[str] = Field(
+        ..., description="WXYC canonical artist names.", max_length=1000, min_length=1
+    )
+
+
+class ArtistSearchAliasesBulkResponse(BaseModel):
+    artists: list[ArtistSearchAliasesResult]
+    missing: list[str] = Field(
+        ...,
+        description="Input names with no `entity.identity` row in LML — i.e., LML doesn't know any external IDs for these. BS can choose to retry later (after a discogs-cache rebuild and entity-resolution campaign) or leave them.\n",
+    )
+    cache_stats: CacheStats | None = None
+
+
+class CacheRefreshSourceOutcome(StrEnum):
+    success = "success"
+    error = "error"
+    not_implemented = "not_implemented"
+
+
+class CacheRefreshItemStatus(StrEnum):
+    warmed = "warmed"
+    not_found = "not_found"
+    not_implemented = "not_implemented"
+    error = "error"
+
+
+class CacheRefreshArtistOutcome(BaseModel):
+    external_id: str
+    outcome: CacheRefreshSourceOutcome
+    message: str | None = Field(
+        None,
+        description="Exception class name when `outcome != success`. Bare `str()` of the exception is intentionally NOT serialized — it may carry upstream error bodies, SQL fragments, or file paths. Full traceback lands in Sentry.\n",
+    )
+
+
+class CacheRefreshSourceResult(BaseModel):
+    release_outcome: CacheRefreshSourceOutcome
+    artists: list[CacheRefreshArtistOutcome] | None = Field([], validate_default=True)
+    message: str | None = None
+
+
+class CacheRefreshResultItem(BaseModel):
+    identity_id: int
+    status: CacheRefreshItemStatus
+    sources: dict[str, CacheRefreshSourceResult] | None = None
+    message: str | None = None
+
+
+class BulkCacheRefreshRequest(BaseModel):
+    identity_ids: list[int] = Field(..., min_length=1)
+
+
+class BulkCacheRefreshResponse(BaseModel):
+    results: list[CacheRefreshResultItem]
 
 
 class DiscogsTrackItem(BaseModel):
@@ -1050,6 +1365,10 @@ class DiscogsReleaseVideo(BaseModel):
 
 class DiscogsReleaseMetadata(BaseModel):
     release_id: int
+    master_id: int | None = Field(
+        None,
+        description="Discogs master ID for this release, when the release belongs to a master. `null` when Discogs has no master (one-offs, self-released). Lets a caller collapse multiple pressings/formats of one logical album into a single record keyed on the master.\n",
+    )
     title: str
     artist: str
     year: int | None = None
@@ -1060,6 +1379,14 @@ class DiscogsReleaseMetadata(BaseModel):
     styles: list[str] | None = []
     tracklist: list[DiscogsTrackItem] | None = Field([], validate_default=True)
     artwork_url: str | None = None
+    artwork_checked_at: AwareDatetime | None = Field(
+        None,
+        description="Timestamp of the most recent live Discogs API call that resolved\nthis release's artwork. `null` means LML's bulk loader populated\nthe row but the live API has not been queried yet (the \"never\nasked\" state); a value means LML hit the live API and either\npopulated `artwork_url` or confirmed Discogs has no cover. LML\nuses this to distinguish bulk-loader gaps (which it back-fills)\nfrom genuinely-imageless releases (which it does not refetch).\nSee WXYC/discogs-etl#239 + WXYC/library-metadata-lookup#423.\n",
+    )
+    not_found: bool | None = Field(
+        False,
+        description='Tombstone marker for Discogs 404s on `get_release`. `true` means\nLML hit the live Discogs API for this release id and Discogs\nreturned 404; subsequent reads short-circuit on this flag rather\nthan re-burning the rate-limit budget. The tombstone row carries\n`title = ""` and `artist = ""` as identifier sentinels;\nconsumers must guard against rendering those empty strings as\nreal values. `release_url` is identifier-derived\n(`https://www.discogs.com/release/{release_id}`) and remains\nvalid even on a tombstone. LML\'s public boundary translates\n`not_found = true` back to `None` for direct callers; this flag\nis observable only by consumers that read the cache row\ndirectly (none of which exist in LML\'s public API today, but\nthe contract is exposed here for future cross-service readers).\nSee WXYC/library-metadata-lookup#510.\n',
+    )
     release_url: str
     cached: bool | None = False
     artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)
@@ -1138,6 +1465,37 @@ class DiscogsTrackReleasesResponse(BaseModel):
     cached: bool | None = False
 
 
+class TrackMatchSource(StrEnum):
+    cta = "cta"
+    discogs_release = "discogs_release"
+    discogs_master = "discogs_master"
+    library_identity = "library_identity"
+
+
+class TrackMatchHint(BaseModel):
+    title: str = Field(..., description="The track title as stored in the source.")
+    artist_credit: str | None = Field(
+        None,
+        description="Per-track artist credit (for compilations, where each track may credit a distinct artist). Null for non-comp tracks where the release-level artist applies.\n",
+    )
+    position: str | None = Field(
+        None,
+        description='Track position on the release as stored in the source (e.g., "A1", "B2", "5"). String-typed to match Discogs\'s `release_track.position` shape, which uses vinyl-side notation for LP releases. Null when position is unknown or inapplicable (e.g., CTA-derived matches, since `compilation_track_artist` has no position column).\n',
+    )
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(
+        None,
+        description="Confidence score for the underlying identity match. Sourced from `library_identity.confidence` post-cross-cache-identity, from `canonical_entity_confidence` pre-cross-cache-identity, or fixed at 1.0 for `cta`-source hits (the curated VA-disambiguation data is treated as authoritative). Used by the UI to render qualitative tooltips on the chip; consumers should not assume null for `cta` source.\n",
+    )
+    source: TrackMatchSource
+
+
+class ArtistMatchHint(BaseModel):
+    matched_variant: str = Field(
+        ..., description="The cached alias string that trigram-matched the query."
+    )
+    source: ArtistSearchAliasSource
+
+
 class LibrarySearchItem(BaseModel):
     id: int
     title: str | None = None
@@ -1152,6 +1510,14 @@ class LibrarySearchItem(BaseModel):
     on_streaming: bool | None = None
     call_number: str | None = Field(None, description='Computed call number (e.g. "Rock CD S 1/1")')
     library_url: str | None = Field(None, description="URL to the release on wxyc.info")
+    matched_via: list[TrackMatchHint] | None = Field(
+        None,
+        description="Populated when a track-title match drove this release into the results (catalog-track-search plan §5.1). Empty or absent when the release matched on artist / title normally. Backward-compatible — existing consumers ignore the field.\n",
+    )
+    matched_via_alias: list[ArtistMatchHint] | None = Field(
+        None,
+        description="Sibling to `matched_via`. Reserved for the day LML composes artist-alias hits itself; not produced in v1 of the artist-search-alias plan (BS-local cache only). Optional and backward-compatible.\n",
+    )
 
 
 class LibrarySearchResponse(BaseModel):
@@ -1180,9 +1546,13 @@ class StreamingCheckSources(BaseModel):
 class StreamingCheckResponse(BaseModel):
     on_streaming: bool = Field(
         ...,
-        description="True if found on any service, false if absent on all, null if inconclusive.",
+        description='True if found on any service, false if all services confirmed absent (no errors),\nnull if inconclusive — either no services checked OR at least one service raised\nan error (see `errored_sources`). Treat null as "do not persist" / "retry later".\n',
     )
     sources: StreamingCheckSources
+    errored_sources: list[str] | None = Field(
+        None,
+        description="Names of services whose check raised an exception (transient network/rate-limit/\nscraping failure). Empty when every dispatched check completed without raising.\nWhen non-empty, callers should consider the listed services unchecked and may\nschedule a selective retry. Independent of `on_streaming`: a service can both\nmatch (populating `sources.<service>`) and other services can error.\n",
+    )
 
 
 class AppConfig(BaseModel):
@@ -1254,3 +1624,331 @@ class SpotifyTrackResponse(BaseModel):
     artist: str = Field(..., description="Primary artist name")
     album: str = Field(..., description="Album name")
     artworkUrl: str | None = Field(None, description="Album artwork URL from Spotify")
+
+
+class Type3(StrEnum):
+    update = "update"
+
+
+class Type4(StrEnum):
+    refetch = "refetch"
+
+
+class Payload(BaseModel):
+    source: str = Field(
+        ..., description="Free-text label naming the upstream cause (telemetry only)."
+    )
+
+
+class LiveFsRefetchEvent(BaseModel):
+    type: Literal["refetch"]
+    payload: Payload
+    timestamp: AwareDatetime
+
+
+class FlowsheetEntryResponse(FlowsheetEntryBase):
+    album_id: int | None = None
+    track_title: str | None = None
+    album_title: str | None = None
+    artist_name: str | None = None
+    record_label: str | None = None
+    label_id: int | None = None
+    rotation_id: int | None = None
+    rotation_bin: RotationBin | None = None
+    request_flag: bool
+    segue: bool | None = None
+    message: str | None = None
+    artwork_url: str | None = None
+    discogs_url: str | None = None
+    release_year: int | None = None
+    spotify_url: str | None = None
+    apple_music_url: str | None = None
+    youtube_music_url: str | None = None
+    bandcamp_url: str | None = None
+    soundcloud_url: str | None = None
+    artist_bio: str | None = None
+    artist_wikipedia_url: str | None = None
+    track_position: str | None = Field(
+        None,
+        description='Track position on the release (e.g., "A1", "B2", "5"). Populated when the flowsheet entry was created via the dj-site picker after release selection (catalog-track-search plan §5.3 / Track 3). String-typed to match Discogs\'s `release_track.position`. Null for free-text entries and legacy rows.\n',
+    )
+    metadata_status: MetadataStatus | None = None
+
+
+class FlowsheetV2TrackEntry(FlowsheetV2Base):
+    entry_type: Literal["track"]
+    album_id: int | None = None
+    rotation_id: int | None = None
+    artist_name: str | None = None
+    album_title: str | None = None
+    track_title: str | None = None
+    track_position: str | None = Field(
+        None,
+        description='Track position on the release (e.g., "A1", "B2", "5", "1-12"). Set by the dj-site flowsheet picker (catalog-track-search plan §5.3 / Track 3) when the DJ selected a track from the resolved release; null when the track_title was entered free-form or the release had no resolvable identity. String-typed to match Discogs\'s `release_track.position`.\n',
+    )
+    record_label: str | None = None
+    request_flag: bool
+    segue: bool | None = None
+    rotation_bin: RotationBin | None = None
+    artwork_url: str | None = None
+    discogs_url: str | None = None
+    release_year: int | None = None
+    spotify_url: str | None = None
+    apple_music_url: str | None = None
+    youtube_music_url: str | None = None
+    bandcamp_url: str | None = None
+    soundcloud_url: str | None = None
+    artist_bio: str | None = None
+    artist_wikipedia_url: str | None = None
+    on_streaming: bool | None = Field(
+        None,
+        description="Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.",
+    )
+    metadata_status: MetadataStatus | None = None
+    genres: list[str] | None = Field(
+        None, description="Discogs genre tags surfaced on the Playcut Detail card."
+    )
+    styles: list[str] | None = Field(
+        None, description="Discogs style tags (finer-grained than genres)."
+    )
+
+
+class Entries(
+    RootModel[
+        FlowsheetV2TrackEntry
+        | FlowsheetV2ShowStartEntry
+        | FlowsheetV2ShowEndEntry
+        | FlowsheetV2DJJoinEntry
+        | FlowsheetV2DJLeaveEntry
+        | FlowsheetV2TalksetEntry
+        | FlowsheetV2BreakpointEntry
+        | FlowsheetV2MessageEntry
+    ]
+):
+    root: (
+        FlowsheetV2TrackEntry
+        | FlowsheetV2ShowStartEntry
+        | FlowsheetV2ShowEndEntry
+        | FlowsheetV2DJJoinEntry
+        | FlowsheetV2DJLeaveEntry
+        | FlowsheetV2TalksetEntry
+        | FlowsheetV2BreakpointEntry
+        | FlowsheetV2MessageEntry
+    ) = Field(..., discriminator="entry_type")
+
+
+class FlowsheetV2PaginatedResponse(BaseModel):
+    entries: list[Entries]
+    page: int
+    limit: int
+    total: int = Field(..., description="Total number of entries")
+    totalPages: int = Field(..., description="Total number of pages")
+
+
+class ShowPlaylist(BaseModel):
+    show_name: str | None = None
+    specialty_show: str | None = None
+    start_time: AwareDatetime | None = None
+    end_time: AwareDatetime | None = None
+    show_djs: list[OnAirDJ] | None = None
+    entries: list[FlowsheetEntryResponse] | None = None
+
+
+class ShowPeek(BaseModel):
+    show: int | None = None
+    show_name: str | None = None
+    date: AwareDatetime | None = None
+    djs: list[Dj] | None = None
+    specialty_show: str | None = None
+    preview: list[FlowsheetEntryResponse] | None = None
+
+
+class AlbumSearchResult(BaseModel):
+    id: int
+    add_date: AwareDatetime
+    album_title: str
+    artist_name: str
+    code_letters: str
+    code_number: int
+    code_artist_number: int
+    format_name: str
+    genre_name: str
+    label: str
+    label_id: int | None = None
+    album_dist: float | None = None
+    artist_dist: float | None = None
+    rotation_bin: RotationBin | None = None
+    rotation_id: int | None = None
+    plays: int | None = None
+    on_streaming: bool | None = Field(
+        None,
+        description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
+    )
+    album_artist: str | None = Field(None, description="Credited album artist for compilations.")
+    date_lost: AwareDatetime | None = Field(
+        None,
+        description="When the release was marked missing from the physical library. Null if in library.",
+    )
+    date_found: AwareDatetime | None = Field(
+        None, description="When a previously missing release was found. Null if never lost."
+    )
+    artwork_url: str | None = Field(
+        None,
+        description="Album cover artwork URL from Discogs. Null if artwork has not been fetched yet or is unavailable.",
+    )
+    matched_via: list[TrackMatchHint] | None = Field(
+        None,
+        description="Populated by Backend's catalog `/library/` search when a track-title match (CTA or LML proxy fallback) drove this release into the results, per catalog-track-search plan §5.1. Empty or absent on normal artist/album hits. Backward-compatible — existing consumers ignore the field.\n",
+    )
+    matched_via_alias: list[ArtistMatchHint] | None = Field(
+        None,
+        description="Populated by Backend's catalog search when an artist-alias match (from `artist_search_alias`) drove this release into the results, per artist-search-alias plan PR 5. Sibling field to `matched_via` (which is track-title provenance). Empty or absent on normal artist/album hits. Backward-compatible — existing consumers ignore the field.\n",
+    )
+
+
+class LibraryMatch(BaseModel):
+    album: AlbumSearchResult
+    confidence: confloat(ge=0.0, le=1.0)
+    matchType: MatchType
+    reasoning: str | None = None
+
+
+class EnhancedRequest(SongRequest):
+    parsed: ParsedSongRequest | None = None
+    matches: list[LibraryMatch] | None = None
+    artwork_url: str | None = None
+    discogs_url: str | None = None
+
+
+class DiscogsMatchResult(BaseModel):
+    album: str | None = Field(None, description="Release title")
+    artist: str | None = Field(None, description="Release artist")
+    release_id: int = Field(
+        ...,
+        description='Discogs release ID. `> 0` is a real release identity; `0` is the streaming-only sentinel (paired with `release_url == ""`, BS#1185) and is not a linkable Discogs release.\n',
+    )
+    master_id: int | None = Field(
+        None,
+        description="Discogs master ID for the release, when the release belongs to a master. `null` when Discogs has no master for this release (one-offs, self-released) or for the streaming-only sentinel (`release_id == 0`). Lets a caller collapse multiple pressings/formats of one logical album into a single record keyed on the master. Populated from the resolved release's `master_id` field on `/lookup` (single and bulk).\n",
+    )
+    release_url: str = Field(
+        ...,
+        description="URL to the release on Discogs. Non-empty for a real release identity; the empty string accompanies the `release_id == 0` streaming-only sentinel.\n",
+    )
+    artwork_url: str | None = Field(None, description="Artwork image URL")
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(0, description="Match confidence score")
+    release_year: int | None = Field(None, description="Release year from Discogs")
+    artist_bio: str | None = Field(None, description="Artist biography from Discogs profile")
+    wikipedia_url: str | None = Field(None, description="Wikipedia URL for the artist")
+    spotify_url: str | None = Field(None, description="Spotify album URL")
+    apple_music_url: str | None = Field(None, description="Apple Music album URL")
+    youtube_music_url: str | None = Field(None, description="YouTube Music search URL")
+    bandcamp_url: str | None = Field(None, description="Bandcamp album URL")
+    soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
+    discogs_artist_id: int | None = Field(
+        None,
+        description="Discogs artist ID for this release. Populated only when the originating `LookupRequest.extended` is true. Lets a caller key an artist-metadata cache without a follow-up release fetch.\n",
+    )
+    tracklist: list[DiscogsTrackItem] | None = Field(
+        None,
+        description="Release tracklist with per-track artist credits where available. Populated only when `extended` is true.\n",
+    )
+    genres: list[str] | None = Field(
+        None,
+        description='Discogs genre tags (e.g. "Rock", "Electronic"). Populated only when `extended` is true.\n',
+    )
+    styles: list[str] | None = Field(
+        None,
+        description='Discogs style tags (finer-grained than genres; e.g. "Indie Rock", "Ambient"). Populated only when `extended` is true.\n',
+    )
+    label: str | None = Field(
+        None,
+        description="Primary record-label name from the Discogs release. Distinct from `LibraryCatalogItem.label` (which comes from the WXYC catalog's rotation-release join). Populated only when `extended` is true.\n",
+    )
+    full_release_date: str | None = Field(
+        None,
+        description='Release date as an ISO string (e.g. "1997-09-22"). May be year-only ("1997") or year-month ("1997-09") if Discogs lacks the full date. Populated only when `extended` is true.\n',
+    )
+    artist_image_url: str | None = Field(
+        None,
+        description="Primary artist image URL from Discogs (the artist's profile photo, not the release artwork). Populated only when `extended` is true.\n",
+    )
+    profile_tokens: list[DiscogsResolvedToken] | None = Field(
+        None,
+        description="Pre-parsed structured tokens from the artist's `profile` markup, using a cache-only resolver — references to entities not in the local PG cache fall through as plain-text tokens (no inline Discogs API calls on the read path). Populated only when `extended` is true. Field name matches `DiscogsArtistDetails.profile_tokens` so callers can share rendering code across the two payloads. Pair with `LookupRequest.warm_cache=true` on write-path calls to progressively populate the cache so subsequent reads render richer.\n",
+    )
+
+
+class LookupResultItem(BaseModel):
+    library_item: LibraryCatalogItem
+    artwork: DiscogsMatchResult | None = None
+    reconciled_identity: ReconciledIdentity | None = None
+    matched_via: list[TrackMatchHint] | None = Field(
+        None,
+        description="Populated when a track-title match (LML's new SONG_AS_TRACK strategy) drove this release into the results, per catalog-track-search plan §5.1. Empty or absent when the release matched via artist/album strategies. Backward-compatible — existing consumers ignore the field.\n",
+    )
+    matched_via_alias: list[ArtistMatchHint] | None = Field(
+        None,
+        description="Sibling to `matched_via`. Reserved for the day LML composes artist-alias hits itself; not produced in v1 of the artist-search-alias plan (BS-local cache only). Optional and backward-compatible.\n",
+    )
+
+
+class LookupResponse(BaseModel):
+    api_version: ApiVersion | None = Field(
+        None,
+        description="Present and equal to 2 only when the request set `include_identity: true`. Absent for the v1-compatible shape so existing consumers see byte-identical responses.\n",
+    )
+    results: list[LookupResultItem] | None = Field([], validate_default=True)
+    search_type: SearchType | None = Field(
+        "none",
+        description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",
+    )
+    song_not_found: bool | None = Field(
+        False,
+        description="True if search fell back to artist-only (track not confirmed on results)",
+    )
+    found_on_compilation: bool | None = Field(
+        False, description="True if the track was found on a compilation album"
+    )
+    context_message: str | None = Field(
+        None, description="Human-readable context string for display"
+    )
+    corrected_artist: str | None = Field(
+        None, description="Fuzzy-corrected artist name if different from the original"
+    )
+    cache_stats: CacheStats | None = None
+    identity: LookupIdentityBlock | None = None
+    timeout: bool | None = Field(
+        False,
+        description='True when LML\'s server-side hard cap fired and the search pipeline was abandoned mid-execution (LML#370). `results` may be partial or empty in that case. Callers can use this to distinguish "no match" (empty `results`, `timeout: false`) from "ran out of time" (`results` may be empty, `timeout: true`). The hard cap is an internal LML safety floor independent of the caller\'s `X-Caller-Budget-Ms` header; see LML#338 / LML#340 / LML#370 for the cascade-budget design.\n',
+    )
+
+
+class BulkResolveLibrariesRequest(BaseModel):
+    inputs: list[BulkResolveInput] = Field(
+        ...,
+        description="Inputs to resolve. Order preserved in `BulkResolveLibrariesResponse.results`.\n",
+        max_length=1000,
+        min_length=1,
+    )
+
+
+class LiveFsUpdateEvent(BaseModel):
+    type: Literal["update"]
+    payload: FlowsheetEntryResponse
+    timestamp: AwareDatetime
+
+
+class LiveFsEvent(RootModel[LiveFsUpdateEvent | LiveFsRefetchEvent]):
+    root: LiveFsUpdateEvent | LiveFsRefetchEvent = Field(
+        ...,
+        description="Discriminated union of events emitted on the `live-fs-topic`. Every event has the same `{ type, payload, timestamp }` envelope — pinned by `CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE`.\n",
+        discriminator="type",
+    )
+
+
+class LibraryQueryResponse(BaseModel):
+    results: list[AlbumSearchResult]
+    total: int
+    page: int
+    totalPages: int

--- a/routers/request.py
+++ b/routers/request.py
@@ -441,8 +441,13 @@ async def handle_request(
 
         # Prefer the lookup service's cache stats over local counters,
         # which stay at 0 since all Discogs/cache work is delegated.
-        if lookup_response.cache_stats:
-            cache_stats_override = lookup_response.cache_stats
+        # wxyc-shared tightened LookupResponse.cache_stats from a free-form
+        # object to the structured CacheStats model, so a parsed response
+        # carries a CacheStats here; flatten it back to a plain dict for the
+        # UnifiedResponse wire shape (and tolerate a raw dict defensively).
+        stats = lookup_response.cache_stats
+        if stats:
+            cache_stats_override = stats if isinstance(stats, dict) else stats.model_dump()
 
     with telemetry.track_step("slack_post"):
         if not request.skip_slack:

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -52,7 +52,14 @@ SAMPLE_RESPONSE = {
     "found_on_compilation": False,
     "context_message": None,
     "corrected_artist": None,
-    "cache_stats": {"hits": 1, "misses": 0},
+    "cache_stats": {
+        "memory_hits": 1,
+        "pg_hits": 0,
+        "pg_misses": 0,
+        "api_calls": 0,
+        "pg_time_ms": 0.0,
+        "api_time_ms": 0.0,
+    },
 }
 
 
@@ -299,6 +306,9 @@ class TestLookupModels:
             "song": "la paradoja",
             "album": "DOGA",
             "raw_message": "msg",
+            # include_identity is a non-optional bool with a False default, so it
+            # survives exclude_none (added to the LookupRequest contract upstream).
+            "include_identity": False,
         }
 
     def test_lookup_response_defaults(self):

--- a/tests/unit/test_request_ban_enforcement.py
+++ b/tests/unit/test_request_ban_enforcement.py
@@ -31,7 +31,7 @@ from core.dependencies import (
     get_posthog_client,
     get_slack_service,
 )
-from generated.api_models import SearchType
+from generated.api_models import CacheStats, SearchType
 from routers.request import router
 from services.ban_check_client import (
     BanCheckClient,
@@ -54,7 +54,14 @@ EMPTY_LOOKUP = LookupResponse(
     found_on_compilation=False,
     context_message=None,
     corrected_artist=None,
-    cache_stats={"hits": 0, "misses": 0},
+    cache_stats=CacheStats(
+        memory_hits=0,
+        pg_hits=0,
+        pg_misses=0,
+        api_calls=0,
+        pg_time_ms=0.0,
+        api_time_ms=0.0,
+    ),
 )
 
 

--- a/tests/unit/test_ua_gate.py
+++ b/tests/unit/test_ua_gate.py
@@ -26,7 +26,7 @@ from core.dependencies import (
     get_posthog_client,
     get_slack_service,
 )
-from generated.api_models import SearchType
+from generated.api_models import CacheStats, SearchType
 from routers.request import router
 from services.ban_check_client import BanCheckClient
 from services.lookup_client import LookupResponse, LookupServiceClient
@@ -50,7 +50,14 @@ EMPTY_LOOKUP = LookupResponse(
     found_on_compilation=False,
     context_message=None,
     corrected_artist=None,
-    cache_stats={"hits": 0, "misses": 0},
+    cache_stats=CacheStats(
+        memory_hits=0,
+        pg_hits=0,
+        pg_misses=0,
+        api_calls=0,
+        pg_time_ms=0.0,
+        api_time_ms=0.0,
+    ),
 )
 
 


### PR DESCRIPTION
## What

1. Regenerates `generated/api_models.py` from the current `wxyc-shared` `api.yaml` contract (`main`), bringing the committed Pydantic models back in sync after they drifted across many releases.
2. **Adds the missing codegen-freshness CI gate** so the next drift fails fast. request-o-matic generated these models from `wxyc-shared/api.yaml` via `scripts/generate_api_models.sh` but — unlike `library-metadata-lookup` — had no CI check that regenerated and diffed, which is exactly why the models were able to drift silently in the first place.

## Why

The immediate trigger for the regen is **BS#1486 Phase-2 Track 3** in `wxyc-shared`: a new `CatalogExportRow.popularity` field (attribution-corrected, master-level play count) plus a reworded `plays` description. The committed models predated that and a good deal more, so this is a catch-up regeneration rather than a one-field bump. Adding the CI gate in the same PR ties the regen to the mechanism that keeps it fresh.

## Commits

1. `chore: regenerate api_models from wxyc-shared main` — models-only regeneration.
2. `fix: adapt request handling and tests to the tightened cache_stats contract` — the minimal call-site changes the regen forces.
3. `chore: catch api_models up to the wxyc-shared DiscogsWriterCredits contract` — `wxyc-shared` main moved ~5 min after the first regen (added `DiscogsWriterCredits` for BMI songwriter/composer reporting); this picks it up so the new gate is green against current `main`. Purely additive (`Provenance` enum, `DiscogsWriterCredits` model, optional `writer_credits` field on `DiscogsMatchResult`) — no hand-written call site touched.
4. `ci: add codegen-freshness check` — the gate itself.

## The CI gate

New PR-only `codegen-check` job in `.github/workflows/ci.yml`, mirroring `library-metadata-lookup`'s `codegen-check`:

- `if: github.event_name == 'pull_request'` (it regenerates + diffs, which needs the codegen toolchain normal jobs don't carry).
- Installs the **pinned** `datamodel-code-generator` + `ruff` from `requirements-dev.txt` (same pins the lint/typecheck/test jobs use), so a new upstream release can't silently fail unrelated PRs.
- Runs `bash scripts/generate_api_models.sh` (downloads `api.yaml` from `wxyc-shared` main in CI, since there's no sibling checkout).
- `git diff --exit-code generated/` fails on any drift.
- Inherits the workflow-level `permissions: contents: read`; not a dependency of any deploy gate (PR-only).

## Verification (all run locally)

- Regenerated with the script's exact flags (`datamodel-codegen` 0.57.0, `ruff` 0.15.1, `pydantic_v2.BaseModel`) against `wxyc-shared` current `main`. **Idempotent** on re-run; regenerating against the GitHub-`main` spec the gate downloads produces no diff.
- `ruff format --check .` and `ruff check .` pass; `mypy . --ignore-missing-imports` clean (72 files); `pytest tests/unit/` = 519 passed; `uv lock --locked` in sync.