### PR TITLE
test(integration): pin Plug 'Me and Mr Jones' lookups to library id 38167

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -30,6 +30,7 @@ from tests.scenarios import (
     ORB_ON_ALBUM,
     PLUG_ALIAS,
     PLUG_COMMA_FORMAT,
+    PLUG_NO_ALBUM,
     QUIXOTIC_SPECIAL_CHARS,
     SARA_FLEETWOOD_MAC_GREETING,
     SNEAKER_PIMPS_TRACK_VALIDATION,
@@ -1589,4 +1590,63 @@ class TestFullRequestIntegration:
         assert len(results) > 0, (
             "Should find results for 'me and mr jones by plug'. "
             "Plug is an alias for Luke Vibert on Discogs."
+        )
+        # NOTE: this stays a weak `len>0` on purpose. Ideally it would assert the
+        # in-library original ("Drum 'n' Bass for Papa"), but two separate bugs
+        # block that today: (1) the LLM parser does not reliably extract the album
+        # from the "... from <album>" clause here (returns album=None), so the
+        # request falls to track search; (2) track search then hits the empty
+        # discogs-cache index (WXYC/discogs-etl#298) and returns the remix. The
+        # album-less companion below pins the track-search half as an xfail; the
+        # parser-extraction half is tracked separately.
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(reason=PLUG_NO_ALBUM.xfail_reason or "", strict=False)
+    async def test_plug_me_and_mr_jones_no_album_finds_library_original(self, base_url):
+        """Album-LESS 'me and mr. jones by plug' must surface the in-library
+        original, not the non-library remix.
+
+        Without the album the lookup can't use the ARTIST_PLUS_ALBUM album-title
+        path; it falls to track search. The in-library original "Me & Mr Jones"
+        is on Discogs release 3192 (WXYC library id 38167, cataloged under
+        "Luke Vibert"); the remix "Me & Mr. Jones (Boymerang Remix)" is on the
+        non-library release 1643641 ("Me & Mr. Sutton").
+
+        XFAIL (non-strict): blocked by WXYC/discogs-etl#298 — the discogs-cache
+        track index was emptied ~2026-07-01, so release 3192 is unindexed and
+        search_releases_by_track can only return the write-back-indexed remix.
+        Remove the marker once the cache is repopulated.
+        """
+        import httpx
+
+        s = PLUG_NO_ALBUM
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{base_url}/request",
+                json={"message": s.raw_message, "skip_slack": True},
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        results = data.get("library_results", [])
+        print("\n📚 Library Results (album-less):")
+        for r in results:
+            print(f"  - {r.get('artist')} - {r.get('title')}")
+
+        assert results, "Album-less lookup should return the in-library original."
+        # The remix release must NOT be what we surface.
+        assert not any("sutton" in (r.get("title") or "").lower() for r in results), (
+            "Surfaced the non-library remix 'Me & Mr. Sutton' instead of the "
+            "in-library original — discogs-etl#298."
+        )
+        # The in-library original must be present.
+        assert any(
+            "papa" in (r.get("title") or "").lower()
+            or "drum" in (r.get("title") or "").lower()
+            or "vibert" in (r.get("artist") or "").lower()
+            for r in results
+        ), (
+            "Album-less lookup should surface 'Drum 'n' Bass for Papa' "
+            f"(Luke Vibert / library id 38167), got: "
+            f"{[(r.get('artist'), r.get('title')) for r in results]}"
         )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1562,7 +1562,8 @@ class TestFullRequestIntegration:
         levels: Discogs track validation, album resolution filtering, and library artist
         filtering all rejected the alias mismatch.
 
-        Expected: Should return "Drum 'n' Bass for Papa" (or similar Plug/Luke Vibert album).
+        Expected: Should surface "Drum 'n' Bass for Papa (+ Plug EPs 1,2 & 3)"
+        (WXYC library id 38167).
         """
         import httpx
 
@@ -1587,35 +1588,23 @@ class TestFullRequestIntegration:
         for r in results:
             print(f"  - {r.get('artist')} - {r.get('title')}")
 
-        assert len(results) > 0, (
-            "Should find results for 'me and mr jones by plug'. "
-            "Plug is an alias for Luke Vibert on Discogs."
+        assert any(r.get("id") == 38167 for r in results), (
+            "Should surface the in-library original 'Drum 'n' Bass for Papa' "
+            "(library id 38167); Plug is an alias for Luke Vibert on Discogs. Got: "
+            f"{[(r.get('id'), r.get('artist'), r.get('title')) for r in results]}"
         )
-        # NOTE: this stays a weak `len>0` on purpose. Ideally it would assert the
-        # in-library original ("Drum 'n' Bass for Papa"), but two separate bugs
-        # block that today: (1) the LLM parser does not reliably extract the album
-        # from the "... from <album>" clause here (returns album=None), so the
-        # request falls to track search; (2) track search then hits the empty
-        # discogs-cache index (WXYC/discogs-etl#298) and returns the remix. The
-        # album-less companion below pins the track-search half as an xfail; the
-        # parser-extraction half is tracked separately.
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason=PLUG_NO_ALBUM.xfail_reason or "", strict=False)
     async def test_plug_me_and_mr_jones_no_album_finds_library_original(self, base_url):
         """Album-LESS 'me and mr. jones by plug' must surface the in-library
         original, not the non-library remix.
 
         Without the album the lookup can't use the ARTIST_PLUS_ALBUM album-title
-        path; it falls to track search. The in-library original "Me & Mr Jones"
-        is on Discogs release 3192 (WXYC library id 38167, cataloged under
-        "Luke Vibert"); the remix "Me & Mr. Jones (Boymerang Remix)" is on the
-        non-library release 1643641 ("Me & Mr. Sutton").
-
-        XFAIL (non-strict): blocked by WXYC/discogs-etl#298 — the discogs-cache
-        track index was emptied ~2026-07-01, so release 3192 is unindexed and
-        search_releases_by_track can only return the write-back-indexed remix.
-        Remove the marker once the cache is repopulated.
+        path; it falls to track search. The remix "Me & Mr. Jones (Boymerang
+        Remix)" (release 1643641, "Me & Mr. Sutton") is non-library, so it is
+        row-less and can never reach library_results (routers/request.py keeps
+        only id > 0); the meaningful pin is that the in-library original
+        (library id 38167) is present. See PLUG_NO_ALBUM in tests/scenarios.py.
         """
         import httpx
 
@@ -1628,25 +1617,21 @@ class TestFullRequestIntegration:
             response.raise_for_status()
             data = response.json()
 
+        parsed = data.get("parsed") or {}
         results = data.get("library_results", [])
         print("\n📚 Library Results (album-less):")
         for r in results:
             print(f"  - {r.get('artist')} - {r.get('title')}")
 
-        assert results, "Album-less lookup should return the in-library original."
-        # The remix release must NOT be what we surface.
-        assert not any("sutton" in (r.get("title") or "").lower() for r in results), (
-            "Surfaced the non-library remix 'Me & Mr. Sutton' instead of the "
-            "in-library original — discogs-etl#298."
+        # Distinguish outages and parser regressions from lookup regressions.
+        assert data.get("degraded_mode") is None, (
+            f"degraded_mode={data.get('degraded_mode')!r}: outage, not a lookup regression"
         )
-        # The in-library original must be present.
-        assert any(
-            "papa" in (r.get("title") or "").lower()
-            or "drum" in (r.get("title") or "").lower()
-            or "vibert" in (r.get("artist") or "").lower()
-            for r in results
-        ), (
+        assert parsed.get("artist") == s.artist, (
+            f"Parser regression: expected artist {s.artist!r}, got {parsed.get('artist')!r}"
+        )
+        assert any(r.get("id") == 38167 for r in results), (
             "Album-less lookup should surface 'Drum 'n' Bass for Papa' "
-            f"(Luke Vibert / library id 38167), got: "
-            f"{[(r.get('artist'), r.get('title')) for r in results]}"
+            "(Luke Vibert, library id 38167), got: "
+            f"{[(r.get('id'), r.get('artist'), r.get('title')) for r in results]}"
         )

--- a/tests/scenarios.py
+++ b/tests/scenarios.py
@@ -101,6 +101,29 @@ PLUG_COMMA_FORMAT = _register(
     tags=frozenset({"parser", "artist_substitution", "comma_format"}),
 )
 
+# Same track as PLUG_ALIAS but WITHOUT the album, so the lookup can't ride the
+# ARTIST_PLUS_ALBUM album-title path and must find the original via track search.
+# The in-library original "Me & Mr Jones" is on Discogs release 3192 (WXYC library
+# id 38167, cataloged under "Luke Vibert"); a non-library remix "Me & Mr. Jones
+# (Boymerang Remix)" lives on release 1643641 ("Me & Mr. Sutton"). The album-less
+# lookup should surface the in-library original, not the remix.
+#
+# Currently xfail: blocked by WXYC/discogs-etl#298 — the discogs-cache track index
+# (release_track / release_artist) was emptied ~2026-07-01, so release 3192 is
+# unindexed and search_releases_by_track can only surface the write-back-indexed
+# remix. Flip to a hard assertion once the cache is repopulated.
+PLUG_NO_ALBUM = _register(
+    id="plug_no_album",
+    description="album-less 'me and mr. jones by plug' should surface the in-library original, not the non-library remix",
+    raw_message="me and mr. jones by plug",
+    artist="Plug",
+    song="Me And Mr Jones",
+    bug="Album-less track lookup surfaced non-library remix 'Me & Mr. Sutton' (release 1643641) row-less instead of in-library original 'Drum 'n' Bass for Papa' (library id 38167)",
+    tags=frozenset({"alias", "track_search", "compilation"}),
+    xfail=True,
+    xfail_reason="blocked by WXYC/discogs-etl#298: discogs-cache track index empty, release 3192 unindexed",
+)
+
 SNEAKER_PIMPS_TRACK_VALIDATION = _register(
     id="sneaker_pimps_track_validation",
     description="6 Underground is on Becoming X but not Kiss & Swallow",

--- a/tests/scenarios.py
+++ b/tests/scenarios.py
@@ -103,25 +103,23 @@ PLUG_COMMA_FORMAT = _register(
 
 # Same track as PLUG_ALIAS but WITHOUT the album, so the lookup can't ride the
 # ARTIST_PLUS_ALBUM album-title path and must find the original via track search.
-# The in-library original "Me & Mr Jones" is on Discogs release 3192 (WXYC library
-# id 38167, cataloged under "Luke Vibert"); a non-library remix "Me & Mr. Jones
-# (Boymerang Remix)" lives on release 1643641 ("Me & Mr. Sutton"). The album-less
-# lookup should surface the in-library original, not the remix.
-#
-# Currently xfail: blocked by WXYC/discogs-etl#298 — the discogs-cache track index
-# (release_track / release_artist) was emptied ~2026-07-01, so release 3192 is
-# unindexed and search_releases_by_track can only surface the write-back-indexed
-# remix. Flip to a hard assertion once the cache is repopulated.
+# The in-library original is "Drum 'n' Bass for Papa (+ Plug EPs 1,2 & 3)" (Discogs
+# release 3192, WXYC library id 38167, cataloged under "Luke Vibert").
 PLUG_NO_ALBUM = _register(
     id="plug_no_album",
-    description="album-less 'me and mr. jones by plug' should surface the in-library original, not the non-library remix",
+    description=(
+        "album-less 'me and mr. jones by plug' should surface the in-library original, "
+        "not the non-library remix"
+    ),
     raw_message="me and mr. jones by plug",
     artist="Plug",
     song="Me And Mr Jones",
-    bug="Album-less track lookup surfaced non-library remix 'Me & Mr. Sutton' (release 1643641) row-less instead of in-library original 'Drum 'n' Bass for Papa' (library id 38167)",
+    bug=(
+        "Album-less track lookup surfaced non-library remix 'Me & Mr. Sutton' (release 1643641) "
+        "row-less at the LML layer instead of in-library original 'Drum 'n' Bass for Papa' "
+        "(library id 38167)"
+    ),
     tags=frozenset({"alias", "track_search", "compilation"}),
-    xfail=True,
-    xfail_reason="blocked by WXYC/discogs-etl#298: discogs-cache track index empty, release 3192 unindexed",
 )
 
 SNEAKER_PIMPS_TRACK_VALIDATION = _register(


### PR DESCRIPTION
Closes the CI-coverage gap where `test_plug_me_and_mr_jones_finds_album` asserted only `len(results)>0` — it stayed green even when the lookup returned the wrong (remix) release.

## What

- New `PLUG_NO_ALBUM` scenario: `me and mr. jones by plug` (no album), so the lookup must find the original via **track search** rather than the album-title path.
- New `test_plug_me_and_mr_jones_no_album_finds_library_original` asserting the in-library original *Drum 'n' Bass for Papa (+ Plug EPs 1,2 & 3)* (WXYC library id 38167) is present by **id**, plus preconditions that `degraded_mode is None` and the parsed artist is `Plug`, so outages and parser regressions fail distinctly from lookup regressions.
- The existing album-ful test is strengthened from `len>0` to the same id-38167 assertion.

## Why no xfail

The original version of this PR marked the new test `xfail` on WXYC/discogs-etl#298 (emptied discogs-cache track index). Verification against staging (4 album-less + 2 album-ful runs) shows both lookups deterministically return exactly library id 38167 with a stable parse — the row-less remix *Me & Mr. Sutton* (release 1643641) was observed at the **LML** layer, and `routers/request.py` filters row-less externals (`id > 0`) out of `library_results` by construction. That filter also made a "remix must not appear" negative assertion structurally vacuous, so the meaningful pin is the original's presence by id. #298 remains an LML/discogs-etl concern but does not block this repo's results.

A claim in the earlier revision that the LLM parser drops the `from <album>` clause was incorrect: the deterministic album pre-pass (#140) extracts it (verified: staging parses `album='drum n bass for papa'`).

## Notes

- These are `external_api` tests (manual-only `external-api.yml` workflow), so they don't run in push CI. Verified locally: ruff clean, unit suite (519) green, and both tests **pass against staging**.

## Related

- WXYC/discogs-etl#298 — discogs-cache track-index outage (LML-layer concern; no longer gates this PR).
- WXYC/library-metadata-lookup#740 — latent LML ranking fix from the same investigation.