### PR TITLE
Add install script for the lookup CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ CLAUDE.md is a router for the always-loaded reference card. Topic depth lives in
 - **[`docs/admin-bans.md`](docs/admin-bans.md)** — Operator runbook for `/admin/bans` (request-line ban management): endpoints, curl examples, status codes, where to find a fingerprint. Both the HTTP admin router (#151) and the future Slack-native router (#152) share `services/ban_service.py`.
 - **[`docs/testing.md`](docs/testing.md)** — Unit / integration / performance test layout, pytest markers (`external_api`, `slow`, `contract`), TEST_ENV configuration, local server testing, bug-fix protocol
 - **[`docs/deployment.md`](docs/deployment.md)** — Railway hosting, branch → environment mapping, dependency management (`uv.lock` source of truth, generated `requirements*.txt`, regenerate/bump procedure, `deps-sync` gate), CI pin maintenance (Railway CLI version, workflow `permissions:`, `@gha/v1` reusable refs)
-- **[`docs/scripts.md`](docs/scripts.md)** — `scripts/lookup.py`, `scripts/repl.py`, `scripts/create_posthog_dashboard.py`
+- **[`docs/scripts.md`](docs/scripts.md)** — `scripts/install-lookup.sh` (install `lookup` as a global command), `scripts/lookup.py`, `scripts/repl.py`, `scripts/create_posthog_dashboard.py`
 
 Read the relevant topic doc before doing work in that area.
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,5 +1,24 @@
 # Scripts
 
+## Installing `lookup` as a global command
+
+`scripts/install-lookup.sh` makes the `lookup` CLI runnable from anywhere. Because `lookup.py` is a thin HTTP client (its only runtime dependency is `httpx`), the installer builds a small isolated virtualenv containing just `httpx` and drops a `lookup` launcher on your PATH that runs this repo's `scripts/lookup.py` through that venv — it does **not** pull in the FastAPI/Groq service dependency tree.
+
+```bash
+scripts/install-lookup.sh              # install or update the `lookup` command
+lookup "play la paradoja by juana molina"
+lookup --staging "jessica pratt on your own love again"
+scripts/install-lookup.sh --uninstall  # remove the launcher and its venv
+```
+
+The launcher points back at this repo, so:
+- edits to `scripts/lookup.py` take effect immediately, with no reinstall, and
+- the repo must stay where it is — moving or deleting it, or pruning the git worktree you installed from, breaks `lookup` (re-run the installer from the new location to fix it).
+
+Defaults are overridable via environment variables: `PYTHON` (interpreter used to build the venv, default `python3`, requires >= 3.10), `LOOKUP_VENV` (venv location, default `$XDG_DATA_HOME/wxyc/lookup-venv`), and `BIN_DIR` (launcher directory, default `~/.local/bin`). If `BIN_DIR` isn't on your PATH the installer prints the line to add to your shell profile.
+
+The installer's control flow (arg dispatch, guard clauses) is covered by fast, network-free tests in `tests/unit/test_install_lookup_cli.py` that run in the default suite. The full build-a-real-venv path is covered by `slow`-marked end-to-end tests in `tests/integration/test_install_lookup.py` (run them with `pytest -m slow`).
+
 ## Manual Testing Tools
 - **`scripts/lookup.py`** - One-off lookups against production (default) or local (`--local`).
 - **`scripts/repl.py`** - Interactive REPL with command history, server switching (`:local`/`:prod`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ warn_required_dynamic_aliases = true
 # and are run manually against staging/production.
 #
 # ci-sync-skip: contract reason: manual-only; verifies external Slack/Groq API contract shape against deployed staging/production
-# ci-sync-skip: slow reason: only the performance suite is slow and it is run manually against staging/production with TEST_ENV set
+# ci-sync-skip: slow reason: slow tests build a real venv (install-lookup.sh e2e) or hit staging/production perf endpoints; both are run manually, never in the fast CI lane
 [tool.pytest.ini_options]
 markers = [
     "external_api: needs network egress + a real third-party API key (Groq, Slack)",

--- a/scripts/install-lookup.sh
+++ b/scripts/install-lookup.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# install-lookup.sh — install the WXYC `lookup` diagnostic CLI as a global command.
+#
+# Builds a small httpx-only virtualenv and drops a `lookup` launcher on your
+# PATH that runs this repo's scripts/lookup.py through it. The launcher points
+# back at this checkout, so it must stay in place — moving or deleting the repo
+# (including pruning the git worktree you installed from) breaks `lookup`.
+# Run with --help for full usage and environment overrides.
+
+set -euo pipefail
+
+# --- Resolve paths ----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOOKUP_SCRIPT="$SCRIPT_DIR/lookup.py"
+
+# --- Configuration (overridable via environment) ----------------------------
+PYTHON="${PYTHON:-python3}"
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+LOOKUP_VENV="${LOOKUP_VENV:-$XDG_DATA_HOME/wxyc/lookup-venv}"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+LAUNCHER="$BIN_DIR/lookup"
+MIN_PY_MAJOR=3
+MIN_PY_MINOR=10
+
+# --- Logging helpers --------------------------------------------------------
+if [ -t 1 ]; then
+    C_BLUE=$'\033[1;34m'; C_YELLOW=$'\033[1;33m'; C_RED=$'\033[1;31m'
+    C_GREEN=$'\033[1;32m'; C_RESET=$'\033[0m'
+else
+    C_BLUE=''; C_YELLOW=''; C_RED=''; C_GREEN=''; C_RESET=''
+fi
+info() { printf '%s==>%s %s\n' "$C_BLUE" "$C_RESET" "$*"; }
+ok()   { printf '%s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+warn() { printf '%swarning:%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+err()  { printf '%serror:%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; }
+
+# POSIX single-quote a string so it embeds literally in the generated /bin/sh
+# launcher — a $, backtick, or quote in the path is then not re-evaluated when
+# `lookup` runs. Wraps in single quotes, escaping any embedded single quote.
+_sq() { printf "'%s'" "${1//\'/\'\\\'\'}"; }
+
+trap 'err "install failed at line $LINENO"; exit 1' ERR
+
+usage() {
+    cat <<'EOF'
+install-lookup.sh — install the WXYC `lookup` diagnostic CLI as a global command.
+
+The lookup utility (scripts/lookup.py) is a thin HTTP client whose only runtime
+dependency is httpx. This installer builds a small isolated virtualenv with just
+httpx and drops a `lookup` launcher on your PATH that runs scripts/lookup.py
+through it — it does not pull in the FastAPI/Groq service dependency tree.
+
+The launcher points back at this checkout, so edits to scripts/lookup.py take
+effect immediately, but the repo must stay in place: moving or deleting it (or
+pruning the git worktree you installed from) breaks `lookup`.
+
+Usage:
+  scripts/install-lookup.sh              # install or update the `lookup` command
+  scripts/install-lookup.sh --uninstall  # remove the launcher and its venv
+  scripts/install-lookup.sh --help
+
+Environment overrides:
+  PYTHON        Python interpreter used to build the venv  (default: python3)
+  LOOKUP_VENV   Where the isolated venv is created         (default: $XDG_DATA_HOME/wxyc/lookup-venv)
+  BIN_DIR       Directory the launcher is installed into   (default: ~/.local/bin)
+EOF
+}
+
+uninstall() {
+    local removed=0
+    # -L also catches a dangling symlink, which -e misses.
+    if [ -e "$LAUNCHER" ] || [ -L "$LAUNCHER" ]; then
+        rm -f "$LAUNCHER"
+        ok "Removed launcher $LAUNCHER"
+        removed=1
+    fi
+    if [ -d "$LOOKUP_VENV" ]; then
+        rm -rf "$LOOKUP_VENV"
+        ok "Removed venv $LOOKUP_VENV"
+        removed=1
+        # Drop the parent (e.g. .../wxyc) if uninstalling left it empty.
+        rmdir "$(dirname "$LOOKUP_VENV")" 2>/dev/null || true
+    fi
+    if [ "$removed" -eq 0 ]; then
+        info "Nothing to uninstall (no launcher or venv found)."
+    fi
+}
+
+install() {
+    if [ ! -f "$LOOKUP_SCRIPT" ]; then
+        err "Cannot find lookup CLI at $LOOKUP_SCRIPT"
+        exit 1
+    fi
+
+    if ! command -v "$PYTHON" >/dev/null 2>&1; then
+        err "Python interpreter '$PYTHON' not found. Set PYTHON=/path/to/python3 and retry."
+        exit 1
+    fi
+    if ! "$PYTHON" -c "import sys; sys.exit(0 if sys.version_info[:2] >= ($MIN_PY_MAJOR, $MIN_PY_MINOR) else 1)"; then
+        err "Python >= $MIN_PY_MAJOR.$MIN_PY_MINOR required, found $("$PYTHON" -V 2>&1)."
+        exit 1
+    fi
+
+    if [ -x "$LOOKUP_VENV/bin/python" ]; then
+        info "Reusing existing virtualenv at $LOOKUP_VENV"
+    else
+        info "Creating virtualenv at $LOOKUP_VENV"
+        "$PYTHON" -m venv "$LOOKUP_VENV"
+    fi
+    local venv_py="$LOOKUP_VENV/bin/python"
+
+    # A venv without pip (e.g. Debian/Ubuntu missing python3-venv, so ensurepip
+    # never ran) can't install httpx. Guide the user rather than delete the dir:
+    # LOOKUP_VENV may point at a venv they supplied, and this script must never
+    # remove data it did not create.
+    if ! "$venv_py" -m pip --version >/dev/null 2>&1; then
+        err "The virtualenv at $LOOKUP_VENV has no pip; cannot install httpx."
+        err "Your '$PYTHON' may lack the venv/ensurepip module (Debian/Ubuntu: sudo apt install python3-venv)."
+        err "Then remove $LOOKUP_VENV, or point LOOKUP_VENV at a fresh path, and re-run."
+        exit 1
+    fi
+
+    info "Installing httpx into the virtualenv"
+    "$venv_py" -m pip install --quiet --disable-pip-version-check 'httpx>=0.25'
+
+    info "Writing launcher to $LAUNCHER"
+    mkdir -p "$BIN_DIR"
+    # Write to a temp file and atomically rename into place: this replaces any
+    # pre-existing launcher (or symlink) without truncating through it, and is
+    # safe against a concurrent install. The baked paths are single-quoted so
+    # the generated /bin/sh does not re-evaluate a $, backtick, or quote in them.
+    local tmp_launcher="$LAUNCHER.tmp.$$"
+    cat > "$tmp_launcher" <<EOF
+#!/bin/sh
+# Auto-generated by request-o-matic scripts/install-lookup.sh — do not edit.
+# Runs the WXYC lookup CLI from $REPO_ROOT via an isolated httpx-only venv.
+exec $(_sq "$venv_py") $(_sq "$LOOKUP_SCRIPT") "\$@"
+EOF
+    chmod +x "$tmp_launcher"
+    mv -f "$tmp_launcher" "$LAUNCHER"
+
+    ok "Installed 'lookup' -> $LOOKUP_SCRIPT"
+    echo
+    info "Try it:"
+    echo "    lookup \"play la paradoja by juana molina\""
+    echo "    lookup --staging \"jessica pratt on your own love again\""
+
+    case ":$PATH:" in
+        *":$BIN_DIR:"*) ;;
+        *)
+            echo
+            warn "$BIN_DIR is not on your PATH."
+            warn "Add this line to your shell profile (~/.zshrc or ~/.bashrc):"
+            warn "    export PATH=\"$BIN_DIR:\$PATH\""
+            ;;
+    esac
+}
+
+main() {
+    case "${1:-}" in
+        -h|--help) usage; exit 0 ;;
+        --uninstall) uninstall; exit 0 ;;
+        "") install ;;
+        *) err "unknown argument: $1"; echo; usage; exit 2 ;;
+    esac
+}
+
+main "$@"

--- a/tests/integration/test_install_lookup.py
+++ b/tests/integration/test_install_lookup.py
@@ -1,0 +1,160 @@
+"""End-to-end tests for ``scripts/install-lookup.sh``.
+
+These build a real (httpx-only) virtualenv and install the ``lookup`` launcher
+into a temp bin dir, so they are marked ``slow`` (network + venv creation) and
+excluded from the default fast suite. Run them explicitly with::
+
+    pytest -m slow tests/integration/test_install_lookup.py
+
+The fast, network-free control-flow tests live in
+``tests/unit/test_install_lookup_cli.py``.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install-lookup.sh"
+
+
+@pytest.fixture(autouse=True)
+def ensure_server_running():
+    """Override ``tests/integration/conftest.py``'s autouse server fixture.
+
+    These installer tests are fully self-contained — they build their own venv
+    and shell out to the script — so they must not boot ``uvicorn main:app``,
+    which that conftest's autouse fixture would otherwise start for every test
+    in this directory (coupling the run to the whole FastAPI app importing and
+    a 30s health probe). Redefining the fixture name here shadows it for this
+    module without requesting ``local_server``.
+    """
+    yield
+
+
+def _clean_env(tmp_path: Path) -> dict:
+    """A hermetic environment for the installer.
+
+    Starts from the real environment (so ``bash``/``pip`` still find PATH, a
+    proxy, etc.) but strips anything that would perturb venv creation, pip, or
+    import resolution — a leaked ``PYTHONPATH``/``PYTHONHOME``/``VIRTUAL_ENV``
+    or ``PIP_*`` mirror flag could otherwise flip these tests green or red for
+    reasons unrelated to the installer. HOME/BIN_DIR/LOOKUP_VENV are redirected
+    under ``tmp_path`` so nothing touches the real system.
+    """
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("PIP_", "PYTHON", "VIRTUAL_ENV", "XDG_"))
+    }
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    env["HOME"] = str(home)
+    env["PYTHON"] = sys.executable
+    env["BIN_DIR"] = str(tmp_path / "bin")
+    env["LOOKUP_VENV"] = str(tmp_path / "venv")
+    return env
+
+
+def _run_installer(tmp_path: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run the installer with all its outputs redirected under ``tmp_path``."""
+    return subprocess.run(
+        ["bash", str(INSTALL_SCRIPT), *args],
+        env=_clean_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_launcher(tmp_path: Path, launcher: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run the installed launcher under the same hermetic environment."""
+    return subprocess.run(
+        [str(launcher), *args],
+        env=_clean_env(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.slow
+def test_installer_creates_working_launcher(tmp_path: Path) -> None:
+    result = _run_installer(tmp_path)
+    assert result.returncode == 0, result.stderr
+    # BIN_DIR (a fresh temp dir) is never on PATH, so the installer must warn
+    # and print the exact export line — lock that user-facing guidance in.
+    assert "not on your PATH" in result.stderr
+
+    launcher = tmp_path / "bin" / "lookup"
+    assert launcher.is_file()
+    assert os.access(launcher, os.X_OK)
+
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    content = launcher.read_text()
+    assert str(venv_python) in content
+    assert "lookup.py" in content
+
+    # The launcher runs end-to-end: --help exits 0 before any network call,
+    # which proves the venv python, httpx, and scripts._common all resolve.
+    help_result = _run_launcher(tmp_path, launcher, "--help")
+    assert help_result.returncode == 0, help_result.stderr
+    assert "usage" in help_result.stdout.lower()
+    assert "/request endpoint" in help_result.stdout
+
+
+@pytest.mark.slow
+def test_installer_is_idempotent(tmp_path: Path) -> None:
+    first = _run_installer(tmp_path)
+    assert first.returncode == 0, first.stderr
+    second = _run_installer(tmp_path)
+    assert second.returncode == 0, second.stderr
+    # The second run must take the reuse path, not rebuild the venv — otherwise
+    # "idempotent" would pass even on a full, slow rebuild.
+    assert "Reusing existing virtualenv" in second.stdout
+
+    launcher = tmp_path / "bin" / "lookup"
+    help_result = _run_launcher(tmp_path, launcher, "--help")
+    assert help_result.returncode == 0, help_result.stderr
+
+
+@pytest.mark.slow
+def test_uninstall_removes_launcher_and_venv(tmp_path: Path) -> None:
+    setup = _run_installer(tmp_path)
+    assert setup.returncode == 0, setup.stderr
+    launcher = tmp_path / "bin" / "lookup"
+    venv = tmp_path / "venv"
+    assert launcher.is_file()
+    assert venv.is_dir()
+
+    result = _run_installer(tmp_path, "--uninstall")
+    assert result.returncode == 0, result.stderr
+    assert not launcher.exists()
+    assert not venv.exists()
+
+
+@pytest.mark.slow
+def test_installer_handles_metacharacters_in_paths(tmp_path: Path) -> None:
+    """A venv path with shell metacharacters must not be re-evaluated at runtime.
+
+    The generated /bin/sh launcher bakes in the venv-python and script paths; if
+    they aren't quoted literally, a ``$`` (or backtick) in the path is expanded
+    by /bin/sh on every ``lookup`` call — breaking the path or executing code.
+    Installing under a dir containing a space and a ``$`` and then running the
+    launcher exercises exactly that.
+    """
+    weird = tmp_path / "we ird$dir"
+    weird.mkdir()
+    env = _clean_env(tmp_path)
+    env["BIN_DIR"] = str(weird / "bin")
+    env["LOOKUP_VENV"] = str(weird / "venv")
+
+    result = subprocess.run(["bash", str(INSTALL_SCRIPT)], env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+    launcher = weird / "bin" / "lookup"
+    assert launcher.is_file()
+    help_result = subprocess.run([str(launcher), "--help"], env=env, capture_output=True, text=True)
+    assert help_result.returncode == 0, help_result.stderr
+    assert "/request endpoint" in help_result.stdout

--- a/tests/unit/test_install_lookup_cli.py
+++ b/tests/unit/test_install_lookup_cli.py
@@ -1,0 +1,90 @@
+"""Fast, network-free tests for ``scripts/install-lookup.sh`` control flow.
+
+These exercise the installer's argument dispatch and guard clauses *without*
+building a venv or hitting the network, so they run in the default fast suite
+(CI's ``pytest tests/unit/``). The expensive real-venv end-to-end coverage lives
+in ``tests/integration/test_install_lookup.py`` (``slow``-marked).
+
+Every invocation redirects HOME/BIN_DIR/LOOKUP_VENV under ``tmp_path`` so no
+test touches the real ``~/.local`` tree.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install-lookup.sh"
+
+
+def _run(tmp_path: Path, *args: str, python: str = "python3") -> subprocess.CompletedProcess:
+    """Run the installer with filesystem side effects confined to ``tmp_path``."""
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["BIN_DIR"] = str(tmp_path / "bin")
+    env["LOOKUP_VENV"] = str(tmp_path / "venv")
+    env["PYTHON"] = python
+    return subprocess.run(
+        ["bash", str(INSTALL_SCRIPT), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_help_exits_zero_and_prints_usage(tmp_path: Path) -> None:
+    result = _run(tmp_path, "--help")
+    assert result.returncode == 0, result.stderr
+    assert "Usage:" in result.stdout
+    # Regression guard: usage() must not leak shell source. The old sed-based
+    # extraction over-read its own header and spilled `set -euo pipefail` (and
+    # blank lines) into --help output.
+    assert "set -euo pipefail" not in result.stdout
+
+
+def test_h_alias_matches_help(tmp_path: Path) -> None:
+    assert _run(tmp_path, "-h").stdout == _run(tmp_path, "--help").stdout
+
+
+def test_unknown_argument_exits_two(tmp_path: Path) -> None:
+    result = _run(tmp_path, "--bogus")
+    assert result.returncode == 2
+    assert "unknown argument" in result.stderr
+    # An unknown arg should still show usage to orient the user.
+    assert "Usage:" in result.stdout
+
+
+def test_uninstall_with_nothing_installed_is_a_noop(tmp_path: Path) -> None:
+    result = _run(tmp_path, "--uninstall")
+    assert result.returncode == 0, result.stderr
+    assert "Nothing to uninstall" in result.stdout
+
+
+def test_missing_python_interpreter_is_rejected(tmp_path: Path) -> None:
+    # Points PYTHON at a path that does not exist: install() must fail fast,
+    # before creating any venv, rather than trip over it later.
+    result = _run(tmp_path, python=str(tmp_path / "no-such-python"))
+    assert result.returncode == 1
+    assert "not found" in result.stderr
+    assert not (tmp_path / "venv").exists()
+
+
+def test_old_python_is_rejected(tmp_path: Path) -> None:
+    # A Python that reports < 3.10 must be rejected before any venv is built.
+    # The stub mimics just enough of the interpreter: the version-probe `-c`
+    # exits non-zero (i.e. version_info < (3, 10)) and `-V` prints an old label.
+    stub = tmp_path / "old-python"
+    stub.write_text(
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        "  -V) echo 'Python 3.9.18' ;;\n"
+        "  -c) exit 1 ;;\n"
+        "  *) exit 1 ;;\n"
+        "esac\n"
+    )
+    stub.chmod(0o755)
+
+    result = _run(tmp_path, python=str(stub))
+    assert result.returncode == 1
+    assert "3.10" in result.stderr
+    assert not (tmp_path / "venv").exists()


### PR DESCRIPTION
Closes #177.

## What

Adds `scripts/install-lookup.sh`, which makes the `lookup` diagnostic CLI runnable as a global command. Because `scripts/lookup.py` is a thin HTTP client whose only runtime dependency is `httpx`, the installer builds a small isolated virtualenv containing just `httpx` and drops a `lookup` launcher on the user's PATH that runs the repo's `lookup.py` through that venv — it does **not** pull in the FastAPI/Groq service dependency tree that installing the package's `[project.scripts]` entry point would require.

```bash
scripts/install-lookup.sh              # install or update the `lookup` command
lookup "play la paradoja by juana molina"
scripts/install-lookup.sh --uninstall  # remove the launcher and its venv
```

## Design trade-off

The launcher points back at this repo checkout, so:

- edits to `scripts/lookup.py` take effect immediately with no reinstall, and
- the repo must stay where it is — moving or deleting it breaks `lookup`.

This is the deliberate choice for a small-footprint diagnostic client under active development, versus the heavyweight `uv tool install .` path.

## Behavior

- Idempotent — reuses the venv, rewrites the launcher, upgrades `httpx`.
- Configurable via `PYTHON` / `LOOKUP_VENV` / `BIN_DIR`; warns (with the exact `export` line) when `BIN_DIR` is not on PATH.
- `set -euo pipefail` + an `ERR` trap; validates the CLI path and Python >= 3.10 before touching anything.
- `--uninstall` removes the launcher and venv.

## Tests

`tests/integration/test_install_lookup.py` — three `slow`-marked end-to-end tests (build a real venv, install, run `lookup --help`, idempotency, uninstall). Run with `pytest -m slow`; deselected from the default fast suite.

Verified locally: `slow` tests pass, `shellcheck` clean, and the standard CI gates (`ruff format --check .`, `ruff check .`, `mypy . --ignore-missing-imports`, `pytest tests/unit/`) all pass.
