### PR TITLE
feat(#179): forward + merge LML's Server-Timing header on /request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ LOOKUP_SERVICE_URL=https://library-metadata-lookup-staging.up.railway.app/api/v1
 # Bearer token sent to LML. Required when LML has LML_REQUIRE_AUTH=true.
 LML_API_KEY=
 
+# Server-Timing observability header on POST /request (Backend-Service#881).
+# Default on; merges ROM's per-stage timings with LML's forwarded sub-stages.
+# Purely additive/out-of-band (JSON body unchanged). Set false to disable.
+ENABLE_SERVER_TIMING=true
+
 # Error tracking (optional)
 SENTRY_DSN=
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ Request-O-Matic is a FastAPI service for WXYC radio that processes song requests
 
 CLAUDE.md is a router for the always-loaded reference card. Topic depth lives in `docs/`:
 
-- **[`docs/architecture.md`](docs/architecture.md)** — Request flow (parse → delegate → Slack), degraded modes (`parsing_unavailable`, `search_unavailable`), key files, optional Discogs PG cache, daily library.db ETL pipeline, pointer to LML for search-logic details
-- **[`docs/env-vars.md`](docs/env-vars.md)** — Full environment-variable reference (Groq, LML, Slack, Sentry, PostHog, telemetry/integration toggles, admin-bans API)
+- **[`docs/architecture.md`](docs/architecture.md)** — Request flow (parse → delegate → Slack), degraded modes (`parsing_unavailable`, `search_unavailable`), `Server-Timing` observability header (LML sub-stage forward/merge, BS#881), key files, optional Discogs PG cache, daily library.db ETL pipeline, pointer to LML for search-logic details
+- **[`docs/env-vars.md`](docs/env-vars.md)** — Full environment-variable reference (Groq, LML, Slack, Sentry, PostHog, telemetry/integration toggles, `ENABLE_SERVER_TIMING`, admin-bans API)
 - **[`docs/admin-bans.md`](docs/admin-bans.md)** — Operator runbook for `/admin/bans` (request-line ban management): endpoints, curl examples, status codes, where to find a fingerprint. Both the HTTP admin router (#151) and the future Slack-native router (#152) share `services/ban_service.py`.
 - **[`docs/testing.md`](docs/testing.md)** — Unit / integration / performance test layout, pytest markers (`external_api`, `slow`, `contract`), TEST_ENV configuration, local server testing, bug-fix protocol
 - **[`docs/deployment.md`](docs/deployment.md)** — Railway hosting, branch → environment mapping, dependency management (`uv.lock` source of truth, generated `requirements*.txt`, regenerate/bump procedure, `deps-sync` gate), CI pin maintenance (Railway CLI version, workflow `permissions:`, `@gha/v1` reusable refs)
@@ -34,7 +34,7 @@ Branches: **`main`** → staging on push; **`prod`** → production on push. Dev
 
 - **[library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup)** -- The downstream search service. This repo is the caller: every `/request` invokes LML's `POST /api/v1/lookup` (gated by `LML_API_KEY` when LML's `LML_REQUIRE_AUTH=true`). Search logic, Discogs cache fallthrough, strategy pipeline, and lookup-side env vars all live there.
 - **[wxyc-shared](https://github.com/WXYC/wxyc-shared)** -- Shared API contract (`api.yaml`). Defines `LookupRequest`, `LookupResponse`, `LibraryCatalogItem`, `DiscogsMatchResult`. Python models regenerate via `bash scripts/generate_api_models.sh` (committed to `generated/api_models.py`); `models.py` re-exports them under the legacy `LibraryItem` / `ReleaseMetadata` names plus the `preview_url()` streaming-priority helper.
-- **[wxyc-fastapi](https://github.com/WXYC/wxyc-fastapi)** -- Shared FastAPI scaffolding. Owns Sentry init, telemetry, cache stats, and the process-wide PostHog client singleton; this repo's `core/dependencies.get_posthog_client` only wraps it with the rom-side `enable_telemetry` flag.
+- **[wxyc-fastapi](https://github.com/WXYC/wxyc-fastapi)** -- Shared FastAPI scaffolding. Owns Sentry init, telemetry, cache stats, and the process-wide PostHog client singleton; this repo's `core/dependencies.get_posthog_client` only wraps it with the rom-side `enable_telemetry` flag. `RequestTelemetry.as_server_timing` (>=1.1.0) serializes tracked steps into the `/request` `Server-Timing` header.
 - **[discogs-etl](https://github.com/WXYC/discogs-etl)** -- ETL pipeline that builds `library.db` from the WXYC MySQL catalog and uploads it daily to LML staging + production via `POST /admin/upload-library-db`. Also owns the Discogs PG cache schema consumed (optionally) by this service via `DATABASE_URL_DISCOGS`.
 
 ## Example Music Data for Tests

--- a/config/settings.py
+++ b/config/settings.py
@@ -27,6 +27,16 @@ class Settings(BaseSettings):
     # Feature Flags
     enable_slack_integration: bool = Field(default=True, description="Enable Slack notifications")
     enable_telemetry: bool = Field(default=True, description="Enable PostHog telemetry")
+    enable_server_timing: bool = Field(
+        default=True,
+        description=(
+            "Emit a Server-Timing response header on /request that merges rom's own "
+            "per-stage telemetry (parse, lookup_service, slack_post) with the sub-stage "
+            "breakdown LML forwards in its Server-Timing header (Backend-Service#881). "
+            "Purely additive/out-of-band; the JSON body is unchanged. Set "
+            "ENABLE_SERVER_TIMING=false to disable (the Railway kill switch)."
+        ),
+    )
 
     # PostHog Configuration
     posthog_api_key: str | None = Field(None, description="PostHog API key for telemetry")

--- a/core/server_timing.py
+++ b/core/server_timing.py
@@ -14,7 +14,17 @@ natural thing to promote into wxyc-fastapi alongside ``as_server_timing``.
 
 from __future__ import annotations
 
+import math
+import re
+
 __all__ = ["parse_server_timing"]
+
+# A Server-Timing metric name is an RFC 7230 token (the same grammar HTTP header
+# field-names use). Validating against it means a peer value with an interior
+# space, comma, or — critically — a CR/LF never gets copied verbatim into rom's
+# response header, where latin-1 would encode the CR/LF and fail at the ASGI
+# send layer (outside the caller's try/except).
+_TOKEN_RE = re.compile(r"[A-Za-z0-9!#$%&'*+.^_`|~-]+")
 
 
 def parse_server_timing(header: str | None) -> list[tuple[str, float]]:
@@ -31,10 +41,15 @@ def parse_server_timing(header: str | None) -> list[tuple[str, float]]:
     rom's own response:
 
     * ``None`` / empty / whitespace-only -> ``[]``.
+    * An entry whose name is not a valid RFC 7230 token (interior whitespace,
+      comma, control chars) is skipped — it cannot be re-emitted into rom's own
+      ``Server-Timing`` header without corrupting it.
     * An entry with no ``dur`` (a bare metric name) is skipped: it cannot merge
       into ``as_server_timing(extra=...)``, which requires a float.
-    * An entry with a non-numeric ``dur`` is skipped without affecting the
-      other entries.
+    * An entry whose ``dur`` is non-numeric, non-finite (``inf`` / ``nan``), or
+      negative is skipped without affecting the other entries — ``float()``
+      accepts those spellings but they are not valid Server-Timing durations and
+      would render as e.g. ``dur=inf`` downstream.
 
     Order and duplicate names are preserved (a list, not a dict) so the caller
     decides how to de-duplicate before merging.
@@ -50,7 +65,7 @@ def parse_server_timing(header: str | None) -> list[tuple[str, float]]:
 
         parts = entry.split(";")
         name = parts[0].strip()
-        if not name:
+        if not _TOKEN_RE.fullmatch(name):
             continue
 
         dur: float | None = None
@@ -58,9 +73,11 @@ def parse_server_timing(header: str | None) -> list[tuple[str, float]]:
             key, sep, value = param.partition("=")
             if sep and key.strip().lower() == "dur":
                 try:
-                    dur = float(value.strip())
+                    parsed = float(value.strip())
                 except ValueError:
-                    dur = None
+                    break
+                if math.isfinite(parsed) and parsed >= 0:
+                    dur = parsed
                 break
 
         if dur is None:

--- a/core/server_timing.py
+++ b/core/server_timing.py
@@ -1,0 +1,70 @@
+"""Parse an upstream ``Server-Timing`` response header into ordered legs.
+
+request-o-matic forwards library-metadata-lookup's per-stage timings by merging
+LML's ``Server-Timing`` header into its own (see ``routers/request.py``). This
+module holds the one stdlib-only helper that turns LML's header value into the
+``(name, dur_ms)`` pairs rom feeds to
+``wxyc_fastapi.observability.RequestTelemetry.as_server_timing(extra=...)``.
+
+Kept deliberately dependency-free and defensive: a peer's header is untrusted
+input on rom's response path, so a missing or malformed value degrades to an
+empty result rather than raising. If a second consumer ever appears, this is the
+natural thing to promote into wxyc-fastapi alongside ``as_server_timing``.
+"""
+
+from __future__ import annotations
+
+__all__ = ["parse_server_timing"]
+
+
+def parse_server_timing(header: str | None) -> list[tuple[str, float]]:
+    """Parse a ``Server-Timing`` header value into ordered ``(name, dur_ms)`` pairs.
+
+    Follows the `Server-Timing grammar
+    <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing>`_
+    loosely enough to survive real peer output: entries are comma-separated,
+    each is ``name`` followed by optional ``;key=value`` params, and only the
+    ``dur`` param is extracted (``desc`` and any others are ignored — rom has no
+    consumer for them).
+
+    Defensive by construction, because the value is a peer's header merged into
+    rom's own response:
+
+    * ``None`` / empty / whitespace-only -> ``[]``.
+    * An entry with no ``dur`` (a bare metric name) is skipped: it cannot merge
+      into ``as_server_timing(extra=...)``, which requires a float.
+    * An entry with a non-numeric ``dur`` is skipped without affecting the
+      other entries.
+
+    Order and duplicate names are preserved (a list, not a dict) so the caller
+    decides how to de-duplicate before merging.
+    """
+    if not header:
+        return []
+
+    legs: list[tuple[str, float]] = []
+    for raw_entry in header.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+
+        parts = entry.split(";")
+        name = parts[0].strip()
+        if not name:
+            continue
+
+        dur: float | None = None
+        for param in parts[1:]:
+            key, sep, value = param.partition("=")
+            if sep and key.strip().lower() == "dur":
+                try:
+                    dur = float(value.strip())
+                except ValueError:
+                    dur = None
+                break
+
+        if dur is None:
+            continue
+        legs.append((name, dur))
+
+    return legs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,9 @@ Slack is the only hard dependency. When Groq or LML are unavailable the listener
 
 If Slack itself fails the endpoint returns `502` — there is no further fallback. PostHog events for degraded requests carry `degraded_mode` and `degraded_reason` (the exception class name) so outages are visible in telemetry.
 
+## Server-Timing (observability, [Backend-Service#881](https://github.com/WXYC/Backend-Service/issues/881))
+`POST /request` attaches a `Server-Timing` response header (flag `ENABLE_SERVER_TIMING`, default on) that combines ROM's own per-stage timings (`parse`, `lookup_service`, `slack_post`) with the sub-stages LML forwards in its own `Server-Timing` header (`library_search`, `metadata_enrichment`, `discogs`), dropping LML's `total` so the merged header keeps exactly one (ROM's). It re-surfaces the `RequestTelemetry.track_step` durations already shipped to PostHog — no new capture layer — so a caller can localize latency (e.g. an ~8.5s `metadata_enrichment` Apple-probe stall) the JSON body doesn't reveal. The merge (`routers/request._emit_server_timing_header` + `core/server_timing.parse_server_timing`) is out-of-band and can never raise into the request path. Flag reference + wire-format example: [`docs/env-vars.md`](env-vars.md).
+
 ## Key Files
 - `models.py` - Re-exports `LibraryItem` (alias for `LibraryCatalogItem`) and `ReleaseMetadata` (alias for `DiscogsMatchResult`) from `generated.api_models`, plus the `preview_url(metadata)` helper for streaming-priority logic.
 - `generated/api_models.py` - Pydantic v2 models generated from `wxyc-shared/api.yaml`. Do not edit by hand; regenerate via `bash scripts/generate_api_models.sh`. The script prefers a sibling `wxyc-shared/` directory and falls back to downloading `api.yaml` from GitHub.
@@ -25,7 +28,8 @@ If Slack itself fails the endpoint returns `502` — there is no further fallbac
 - `routers/request.py` - Request handling: parse, delegate to lookup service, post to Slack
 - `routers/health.py` - Health check endpoints: `GET /health` (shallow liveness probe, no external calls) and `GET /health/ready` (deep readiness check: groq, lookup, slack services). Railway's `healthcheckPath` uses `/health` so the container becomes routable immediately on boot.
 - `services/parser.py` - Groq AI message parsing
-- `services/lookup_client.py` - HTTP client for library-metadata-lookup delegation
+- `services/lookup_client.py` - HTTP client for library-metadata-lookup delegation. `lookup()` returns a `LookupResult(response, server_timing)` pairing the parsed body with LML's raw `Server-Timing` header value (returned by value, not stashed on the shared client, to stay race-free under concurrent requests).
+- `core/server_timing.py` - `parse_server_timing(header)`: stdlib-only, defensive parse of an upstream `Server-Timing` header into ordered `(name, dur_ms)` legs (None/malformed → `[]`), used to merge LML's forwarded stages into ROM's header.
 - `services/ban_check_client.py` - HTTP client for Backend-Service `POST /auth/check-request-ban` (BS#1261). Fails open (raises `BanCheckUnavailableError`) on network errors, timeouts, or 5xx; treats BS 401/404 as proceed-as-unauth so the caller is never 401'd on `POST /request`.
 - `services/ua_gate.py` - Pure-function matcher `is_known_strict_client(user_agent)` for the UA gate (#155). Maintains the `_STRICT_CLIENT_REGISTRY` of product-token → minimum-version pairs. Adding `WXYC-Android` here is a one-line change when that team ships ban-aware code.
 - `services/slack.py` - Slack message formatting and posting

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -13,6 +13,7 @@ Optional:
 - `POSTHOG_HOST` - PostHog host URL (default: `https://us.i.posthog.com`)
 - `ENABLE_SLACK_INTEGRATION` - Enable/disable Slack notifications (default: `true`)
 - `ENABLE_TELEMETRY` - Enable/disable PostHog telemetry (default: `true`)
+- `ENABLE_SERVER_TIMING` - Enable/disable the `Server-Timing` response header on `POST /request` (default: `true`). See "Server-Timing header" below.
 
 Admin API for request-line bans (see [`docs/admin-bans.md`](admin-bans.md)):
 - `ADMIN_TOKEN` - Bearer token gating the `/admin/bans` endpoints. When unset, every admin request is rejected with 403 (fail-closed). Rotate by updating the Railway service variable.
@@ -34,3 +35,11 @@ Operator flip sequence (after iOS 3.2 ships):
 3. Wait for App Store rollout to reach ~90% (App Store Connect → Analytics → App Versions).
 4. Flip `STRICT_FINGERPRINT_FOR_KNOWN_CLIENTS=true` on staging, watch PostHog for `request_blocked` events keyed on `ban_source='rom_strict_mode'`. Spikes here indicate either a 3.2 fingerprint regression or active evasion attempts; a slow trickle is expected.
 5. Flip on production. Rollback recipe: set the var to `false` and restart; legitimate traffic recovers within one restart cycle.
+
+## Server-Timing header ([Backend-Service#881](https://github.com/WXYC/Backend-Service/issues/881))
+
+When `ENABLE_SERVER_TIMING=true` (default), `POST /request` attaches a [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) response header that merges ROM's own per-stage timings (`parse`, `lookup_service`, `slack_post`) with the sub-stage breakdown LML forwards in *its* `Server-Timing` header (`library_search`, `metadata_enrichment`, `discogs`). LML's `total` is dropped and ROM appends its own, so the header carries exactly one `total`, last — e.g. `parse;dur=3.1, lookup_service;dur=8560, slack_post;dur=42, library_search;dur=41, metadata_enrichment;dur=8500, discogs;dur=806, total;dur=8610`.
+
+This surfaces the same `RequestTelemetry.track_step` durations ROM and LML already ship to PostHog — no new capture layer — so a caller (e.g. the `lookup` CLI) can attribute a slow round-trip to a named server stage (the motivating case: an ~8.5s `metadata_enrichment` Apple-Music-probe stall the JSON body never revealed). It is purely additive/out-of-band: the response body is byte-identical whether the flag is on or off, so it is safe to toggle in production. Set `ENABLE_SERVER_TIMING=false` as the kill switch.
+
+Implementation: the shared serializer is `RequestTelemetry.as_server_timing` in [wxyc-fastapi](https://github.com/WXYC/wxyc-fastapi) (>=1.1.0); the forward/merge lives in `routers/request._emit_server_timing_header` + `core/server_timing.parse_server_timing`. The building of the header can never raise into the request path (all exceptions are logged and swallowed).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.25.0",
-    "wxyc-fastapi[posthog]>=1.0.0,<2.0.0",
+    "wxyc-fastapi[posthog]>=1.1.0,<2.0.0",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -179,5 +179,5 @@ urllib3==2.6.3
     #   sentry-sdk
 uvicorn==0.41.0
     # via request-o-matic
-wxyc-fastapi==1.0.0
+wxyc-fastapi==1.1.0
     # via request-o-matic

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,5 +101,5 @@ urllib3==2.6.3
     #   sentry-sdk
 uvicorn==0.41.0
     # via request-o-matic
-wxyc-fastapi==1.0.0
+wxyc-fastapi==1.1.0
     # via request-o-matic

--- a/routers/request.py
+++ b/routers/request.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 import sentry_sdk
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Response
 from groq import AsyncGroq
 from pydantic import BaseModel
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
@@ -40,6 +40,7 @@ from core.dependencies import (
     get_posthog_client,
     get_slack_service,
 )
+from core.server_timing import parse_server_timing
 
 if TYPE_CHECKING:
     from posthog import Posthog
@@ -176,6 +177,42 @@ async def _post_degraded_to_slack(
         raise HTTPException(status_code=502, detail=f"Failed to post to Slack: {e}") from e
 
 
+def _emit_server_timing_header(
+    http_response: Response,
+    telemetry: RequestTelemetry,
+    *,
+    enabled: bool,
+    lml_server_timing: str | None = None,
+) -> None:
+    """Attach a Server-Timing header from rom's telemetry + forwarded LML stages.
+
+    Merges the sub-stages LML returned in its own ``Server-Timing`` header into
+    rom's per-stage timings, so a caller (e.g. the ``lookup`` CLI) can attribute
+    a slow ``/request`` round-trip to a named server stage (Backend-Service#881).
+
+    Flag-gated and fully defensive: a disabled flag skips it, and any failure to
+    build the header is logged and swallowed so this observability path can never
+    break the request.
+    """
+    if not enabled:
+        return
+    try:
+        # Forwarded LML legs become ``extra`` legs in ``as_server_timing`` —
+        # appended after rom's own steps and before rom's canonical ``total``.
+        # Drop LML's ``total`` (rom appends its own) and any name that collides
+        # with a rom step (rom's own measurement wins) so the header stays
+        # single-total and strict-parser-safe. rom/LML stage names are disjoint
+        # today; the collision guard future-proofs against a rename.
+        extra = {
+            name: dur
+            for name, dur in parse_server_timing(lml_server_timing)
+            if name != "total" and name not in telemetry.steps
+        }
+        http_response.headers["Server-Timing"] = telemetry.as_server_timing(extra=extra or None)
+    except Exception:
+        logger.warning("Failed to build Server-Timing header", exc_info=True)
+
+
 @router.post(
     "/request",
     response_model=UnifiedResponse,
@@ -213,6 +250,7 @@ async def _post_degraded_to_slack(
 )
 async def handle_request(
     request: RequestBody,
+    http_response: Response,
     groq_client: AsyncGroq = Depends(get_groq_client),
     slack_service: SlackService | None = Depends(get_slack_service),
     posthog_client: Posthog | None = Depends(get_posthog_client),
@@ -368,6 +406,7 @@ async def handle_request(
                 posthog_client,
                 parse_props,
             )
+        _emit_server_timing_header(http_response, telemetry, enabled=settings.enable_server_timing)
         return UnifiedResponse(
             parsed=None,
             cache_stats=get_cache_stats(),
@@ -377,6 +416,7 @@ async def handle_request(
     if not parsed.is_request:
         if not request.skip_slack:
             await post_results_to_slack(slack_service, request.message, parsed, [], context=None)
+        _emit_server_timing_header(http_response, telemetry, enabled=settings.enable_server_timing)
         return UnifiedResponse(
             parsed=parsed,
             cache_stats=get_cache_stats(),
@@ -391,6 +431,11 @@ async def handle_request(
     search_type = "none"
     lookup_response = None
     lookup_failure: Exception | None = None
+    # Sentinel: the LML-outage path below (lookup_client is None, or the call
+    # raises) skips the assignment inside the try, so this must be bound before
+    # the merged-header emit at the final return — else an UnboundLocalError 500s
+    # the degraded path instead of returning the graceful search-unavailable 200.
+    lml_server_timing: str | None = None
 
     if lookup_client is None:
         # Treat missing LOOKUP_SERVICE_URL as a permanent LML outage rather than
@@ -406,9 +451,11 @@ async def handle_request(
                 raw_message=request.message,
             )
             try:
-                lookup_response = await lookup_client.lookup(
+                lookup_result = await lookup_client.lookup(
                     lookup_request, skip_cache=request.skip_cache
                 )
+                lookup_response = lookup_result.response
+                lml_server_timing = lookup_result.server_timing
             except _LML_TRANSIENT_ERRORS as e:
                 logger.warning(
                     "Search unavailable (%s: %s); posting parsed message to Slack",
@@ -496,6 +543,12 @@ async def handle_request(
             properties["ban_check_degraded"] = True
         telemetry.send_to_posthog(posthog_client, properties)
 
+    _emit_server_timing_header(
+        http_response,
+        telemetry,
+        enabled=settings.enable_server_timing,
+        lml_server_timing=lml_server_timing,
+    )
     return UnifiedResponse(
         parsed=parsed,
         artwork=artwork,

--- a/services/lookup_client.py
+++ b/services/lookup_client.py
@@ -25,8 +25,9 @@ class LookupResult(NamedTuple):
     ``server_timing`` is the verbatim header value LML returns (or ``None`` when
     absent), carried alongside the body so the router can forward and merge LML's
     per-stage timings without re-fetching. Returned by value rather than stashed
-    on the client instance because ``get_lookup_client`` may hand the same client
-    to concurrent requests — a per-instance attribute would race.
+    on the client instance so ``lookup()`` stays a pure function of its inputs —
+    the client wraps a shared ``httpx.AsyncClient`` singleton, so per-call state
+    on the instance would be fragile if the wrapper were ever cached too.
     """
 
     response: LookupResponse

--- a/services/lookup_client.py
+++ b/services/lookup_client.py
@@ -2,14 +2,35 @@
 
 import asyncio
 import logging
+from typing import NamedTuple
 
 import httpx
 
 from generated.api_models import LookupRequest, LookupResponse, LookupResultItem
 
-__all__ = ["LookupRequest", "LookupResponse", "LookupResultItem", "LookupServiceClient"]
+__all__ = [
+    "LookupRequest",
+    "LookupResponse",
+    "LookupResult",
+    "LookupResultItem",
+    "LookupServiceClient",
+]
 
 logger = logging.getLogger(__name__)
+
+
+class LookupResult(NamedTuple):
+    """The parsed LML response paired with its raw ``Server-Timing`` header.
+
+    ``server_timing`` is the verbatim header value LML returns (or ``None`` when
+    absent), carried alongside the body so the router can forward and merge LML's
+    per-stage timings without re-fetching. Returned by value rather than stashed
+    on the client instance because ``get_lookup_client`` may hand the same client
+    to concurrent requests — a per-instance attribute would race.
+    """
+
+    response: LookupResponse
+    server_timing: str | None
 
 
 class LookupServiceClient:
@@ -53,8 +74,8 @@ class LookupServiceClient:
     def _auth_headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
 
-    async def lookup(self, request: LookupRequest, skip_cache: bool = False) -> LookupResponse:
-        """Call the lookup service and return parsed response.
+    async def lookup(self, request: LookupRequest, skip_cache: bool = False) -> LookupResult:
+        """Call the lookup service and return the parsed response + timing header.
 
         Retries on ``ConnectError`` only. ``TimeoutException`` and HTTP status
         errors are raised immediately without retry.
@@ -64,7 +85,8 @@ class LookupServiceClient:
             skip_cache: If True, bypass the lookup service's caches
 
         Returns:
-            LookupResponse with results and metadata
+            LookupResult pairing the parsed ``LookupResponse`` with LML's raw
+            ``Server-Timing`` header value (``None`` when the header is absent).
 
         Raises:
             httpx.HTTPStatusError: On 4xx/5xx responses (no retry)
@@ -84,7 +106,10 @@ class LookupServiceClient:
                     timeout=self.per_attempt_timeout,
                 )
                 response.raise_for_status()
-                return LookupResponse.model_validate(response.json())
+                return LookupResult(
+                    response=LookupResponse.model_validate(response.json()),
+                    server_timing=response.headers.get("Server-Timing"),
+                )
             except self._RETRYABLE as exc:
                 last_exc = exc
                 if attempt < self.max_attempts:

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -1,6 +1,7 @@
 """Unit tests for the lookup delegation branch in handle_request."""
 
 import json
+import re
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -16,11 +17,26 @@ from core.dependencies import (
 )
 from generated.api_models import SearchType
 from routers.request import router
-from services.lookup_client import LookupResponse, LookupResultItem, LookupServiceClient
+from services.lookup_client import (
+    LookupResponse,
+    LookupResult,
+    LookupResultItem,
+    LookupServiceClient,
+)
 from tests.conftest import make_parsed_request
 from tests.factories import make_library_item, make_release_metadata
 
 # -- Fixtures -----------------------------------------------------------------
+
+
+def _lr(response: LookupResponse, server_timing: str | None = None) -> LookupResult:
+    """Wrap a LookupResponse as the LookupResult that ``lookup()`` now returns.
+
+    These cases assert on response fields, not timing, so they stage a response
+    and let the router observe ``server_timing`` (``None`` = no forwarded header)
+    exactly as the real client would deliver it.
+    """
+    return LookupResult(response=response, server_timing=server_timing)
 
 
 @pytest.fixture
@@ -98,7 +114,7 @@ class TestDelegationBranch:
     @pytest.mark.asyncio
     async def test_successful_delegation(self, app, mock_lookup_client, sample_lookup_response):
         """Delegation returns results from lookup service, skipping inline pipeline."""
-        mock_lookup_client.lookup.return_value = sample_lookup_response
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
 
         with patch(
             "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
@@ -127,13 +143,15 @@ class TestDelegationBranch:
     @pytest.mark.asyncio
     async def test_delegation_maps_response_fields(self, app, mock_lookup_client):
         """All LookupResponse metadata fields map to UnifiedResponse correctly."""
-        mock_lookup_client.lookup.return_value = LookupResponse(
-            results=[],
-            search_type=SearchType.compilation,
-            song_not_found=True,
-            found_on_compilation=True,
-            context_message='Found "Abele Dance" by Manu Dibango on:',
-            corrected_artist=None,
+        mock_lookup_client.lookup.return_value = _lr(
+            LookupResponse(
+                results=[],
+                search_type=SearchType.compilation,
+                song_not_found=True,
+                found_on_compilation=True,
+                context_message='Found "Abele Dance" by Manu Dibango on:',
+                corrected_artist=None,
+            )
         )
 
         with patch(
@@ -159,7 +177,7 @@ class TestDelegationBranch:
         sample_lookup_response.corrected_artist = "Living Colour"
 
         parsed = make_parsed_request(artist="Living Color", raw_message="play living color")
-        mock_lookup_client.lookup.return_value = sample_lookup_response
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
 
         with patch("routers.request.parse_request", new_callable=AsyncMock, return_value=parsed):
             async with AsyncClient(
@@ -260,7 +278,7 @@ class TestDelegationBranch:
     @pytest.mark.asyncio
     async def test_skip_cache_forwarded(self, app, mock_lookup_client, sample_lookup_response):
         """skip_cache=True is forwarded to the lookup service."""
-        mock_lookup_client.lookup.return_value = sample_lookup_response
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
 
         with patch(
             "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
@@ -285,11 +303,13 @@ class TestDelegationBranch:
     @pytest.mark.asyncio
     async def test_empty_results_from_delegation(self, app, mock_lookup_client):
         """Empty results from lookup service are handled correctly."""
-        mock_lookup_client.lookup.return_value = LookupResponse(
-            results=[],
-            search_type=SearchType.none,
-            song_not_found=True,
-            found_on_compilation=False,
+        mock_lookup_client.lookup.return_value = _lr(
+            LookupResponse(
+                results=[],
+                search_type=SearchType.none,
+                song_not_found=True,
+                found_on_compilation=False,
+            )
         )
 
         with patch(
@@ -312,33 +332,35 @@ class TestDelegationBranch:
     @pytest.mark.asyncio
     async def test_multiple_results_with_artwork(self, app, mock_lookup_client):
         """Multiple results with artwork are extracted correctly."""
-        mock_lookup_client.lookup.return_value = LookupResponse(
-            results=[
-                LookupResultItem(
-                    library_item=make_library_item(
-                        id=1,
-                        title="Aluminum Tunes",
-                        artist="Stereolab",
+        mock_lookup_client.lookup.return_value = _lr(
+            LookupResponse(
+                results=[
+                    LookupResultItem(
+                        library_item=make_library_item(
+                            id=1,
+                            title="Aluminum Tunes",
+                            artist="Stereolab",
+                        ),
+                        artwork=make_release_metadata(
+                            release_id=100,
+                            album="Aluminum Tunes",
+                            artist="Stereolab",
+                            artwork_url="https://img.discogs.com/aluminum.jpg",
+                            confidence=0.9,
+                        ),
                     ),
-                    artwork=make_release_metadata(
-                        release_id=100,
-                        album="Aluminum Tunes",
-                        artist="Stereolab",
-                        artwork_url="https://img.discogs.com/aluminum.jpg",
-                        confidence=0.9,
+                    LookupResultItem(
+                        library_item=make_library_item(
+                            id=2,
+                            title="Dots and Loops",
+                            artist="Stereolab",
+                            release_call_number=2,
+                        ),
+                        artwork=None,
                     ),
-                ),
-                LookupResultItem(
-                    library_item=make_library_item(
-                        id=2,
-                        title="Dots and Loops",
-                        artist="Stereolab",
-                        release_call_number=2,
-                    ),
-                    artwork=None,
-                ),
-            ],
-            search_type=SearchType.fallback,
+                ],
+                search_type=SearchType.fallback,
+            )
         )
 
         with patch(
@@ -369,7 +391,7 @@ class TestDelegationBranch:
         self, app, mock_lookup_client, sample_lookup_response
     ):
         """LookupRequest is built from parsed fields and raw message."""
-        mock_lookup_client.lookup.return_value = sample_lookup_response
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
 
         parsed = make_parsed_request(
             song="la paradoja",
@@ -402,26 +424,28 @@ class TestDelegationBranch:
         ``call_number="(external)"``) are albums not in the WXYC catalog. A DJ can't
         pull them off the shelf, so they must not reach the request channel — neither
         the response's ``library_results`` nor the Slack post."""
-        mock_lookup_client.lookup.return_value = LookupResponse(
-            results=[
-                LookupResultItem(
-                    library_item=make_library_item(
-                        id=42, title="Aluminum Tunes", artist="Stereolab"
+        mock_lookup_client.lookup.return_value = _lr(
+            LookupResponse(
+                results=[
+                    LookupResultItem(
+                        library_item=make_library_item(
+                            id=42, title="Aluminum Tunes", artist="Stereolab"
+                        ),
+                        artwork=None,
                     ),
-                    artwork=None,
-                ),
-                LookupResultItem(
-                    library_item=make_library_item(
-                        id=0,
-                        title="Unshelved Bootleg",
-                        artist="Not In Library",
-                        call_number="(external)",
-                        library_url="",
+                    LookupResultItem(
+                        library_item=make_library_item(
+                            id=0,
+                            title="Unshelved Bootleg",
+                            artist="Not In Library",
+                            call_number="(external)",
+                            library_url="",
+                        ),
+                        artwork=make_release_metadata(release_id=999),
                     ),
-                    artwork=make_release_metadata(release_id=999),
-                ),
-            ],
-            search_type=SearchType.direct,
+                ],
+                search_type=SearchType.direct,
+            )
         )
 
         with patch(
@@ -450,20 +474,22 @@ class TestDelegationBranch:
         """When every match is a row-less non-library result, filtering empties the
         list and the request channel falls through to the existing 'No results found'
         message rather than posting a non-library item."""
-        mock_lookup_client.lookup.return_value = LookupResponse(
-            results=[
-                LookupResultItem(
-                    library_item=make_library_item(
-                        id=0,
-                        title="Unshelved Bootleg",
-                        artist="Not In Library",
-                        call_number="(external)",
-                        library_url="",
+        mock_lookup_client.lookup.return_value = _lr(
+            LookupResponse(
+                results=[
+                    LookupResultItem(
+                        library_item=make_library_item(
+                            id=0,
+                            title="Unshelved Bootleg",
+                            artist="Not In Library",
+                            call_number="(external)",
+                            library_url="",
+                        ),
+                        artwork=make_release_metadata(release_id=999),
                     ),
-                    artwork=make_release_metadata(release_id=999),
-                ),
-            ],
-            search_type=SearchType.direct,
+                ],
+                search_type=SearchType.direct,
+            )
         )
 
         with patch(
@@ -508,7 +534,7 @@ class TestDelegatedCacheStats:
             "api_time_ms": 350.0,
         }
         sample_lookup_response.cache_stats = remote_stats
-        mock_lookup_client.lookup.return_value = sample_lookup_response
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
 
         with patch(
             "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
@@ -546,7 +572,7 @@ class TestDelegatedCacheStats:
             "api_time_ms": 200.0,
         }
         sample_lookup_response.cache_stats = remote_stats
-        mock_lookup_client.lookup.return_value = sample_lookup_response
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
 
         with patch(
             "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
@@ -572,7 +598,7 @@ class TestDelegatedCacheStats:
     ):
         """When lookup service returns no cache_stats, fall back to local counters."""
         sample_lookup_response.cache_stats = None
-        mock_lookup_client.lookup.return_value = sample_lookup_response
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
 
         with patch(
             "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
@@ -589,3 +615,139 @@ class TestDelegatedCacheStats:
         # Should still have cache_stats (from local init_cache_stats), just all zeros
         assert data["cache_stats"] is not None
         assert data["cache_stats"]["memory_hits"] == 0
+
+
+def _server_timing_names(header: str) -> list[str]:
+    """Ordered metric names from a Server-Timing header value."""
+    return [entry.split(";")[0].strip() for entry in header.split(",") if entry.strip()]
+
+
+class TestServerTimingForwarding:
+    """Server-Timing emission + LML sub-stage merge on /request (Backend-Service#881).
+
+    /request combines rom's own per-stage telemetry (parse, lookup_service,
+    slack_post) with the sub-stages LML forwards in its own Server-Timing header,
+    dropping LML's total so the merged header carries exactly one (rom's) total.
+    """
+
+    @pytest.mark.asyncio
+    async def test_header_present_by_default(self, app, mock_lookup_client, sample_lookup_response):
+        """With the flag at its default (on), /request attaches a Server-Timing
+        header carrying rom's own stages and exactly one total, last."""
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play la paradoja by juana molina", "skip_slack": True},
+                )
+
+        header = response.headers.get("server-timing")
+        assert header is not None
+        names = _server_timing_names(header)
+        assert "parse" in names
+        assert "lookup_service" in names
+        assert names.count("total") == 1
+        assert names[-1] == "total"
+
+    @pytest.mark.asyncio
+    async def test_forwarded_lml_substages_merged(
+        self, app, mock_lookup_client, sample_lookup_response
+    ):
+        """LML's forwarded sub-stages are merged in and its own total is dropped,
+        leaving a strict-parser-safe header with exactly one (rom's) total."""
+        mock_lookup_client.lookup.return_value = _lr(
+            sample_lookup_response,
+            server_timing=(
+                "library_search;dur=41.2, metadata_enrichment;dur=8500.7, "
+                "discogs;dur=806, total;dur=8560.1"
+            ),
+        )
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "milkman aphex twin", "skip_slack": True},
+                )
+
+        header = response.headers["server-timing"]
+        entries = [e.strip() for e in header.split(",") if e.strip()]
+        names = _server_timing_names(header)
+        # LML sub-stages surface, verbatim durations preserved
+        assert "library_search" in names
+        assert "metadata_enrichment" in names
+        assert "discogs" in names
+        assert "metadata_enrichment;dur=8500.7" in entries
+        # rom's own stages surface
+        assert "parse" in names
+        assert "lookup_service" in names
+        # LML's total is dropped; exactly one total (rom's), last
+        assert names.count("total") == 1
+        assert names[-1] == "total"
+        # strict-parser-safe wire format (name;dur=<plain-decimal>, ", "-joined)
+        grammar = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*;dur=\d+(?:\.\d+)?$")
+        for entry in entries:
+            assert grammar.match(entry), f"non-conforming Server-Timing entry: {entry!r}"
+
+    @pytest.mark.asyncio
+    async def test_header_absent_when_flag_disabled(
+        self, app, mock_lookup_client, sample_lookup_response
+    ):
+        """ENABLE_SERVER_TIMING=false suppresses the header entirely."""
+        from config.settings import Settings, get_settings
+
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
+        app.dependency_overrides[get_settings] = lambda: Settings(
+            groq_api_key="test", enable_server_timing=False
+        )
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play stereolab", "skip_slack": True},
+                )
+
+        assert response.status_code == 200
+        assert "server-timing" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_search_unavailable_still_emits_rom_only_header(self, app, mock_lookup_client):
+        """When LML is down, the sentinel keeps the request on the degraded path
+        (200, not a 500 from an unbound timing var) and the header carries rom's
+        own stages with no forwarded LML sub-stages."""
+        mock_lookup_client.lookup.side_effect = httpx.ConnectError("LML down")
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/api/v1/request",
+                    json={"message": "play stereolab", "skip_slack": True},
+                )
+
+        assert response.status_code == 200
+        assert response.json()["degraded_mode"] == "search_unavailable"
+        header = response.headers.get("server-timing")
+        assert header is not None
+        names = _server_timing_names(header)
+        assert "parse" in names
+        assert "library_search" not in names
+        assert names.count("total") == 1

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -8,6 +8,7 @@ import pytest
 from services.lookup_client import (
     LookupRequest,
     LookupResponse,
+    LookupResult,
     LookupResultItem,
     LookupServiceClient,
 )
@@ -81,7 +82,7 @@ class TestLookupServiceClient:
             return httpx.Response(200, json=SAMPLE_RESPONSE)
 
         client = _make_client(handler)
-        response = await client.lookup(
+        result = await client.lookup(
             LookupRequest(
                 artist="Stereolab",
                 song="Ping Pong",
@@ -89,6 +90,11 @@ class TestLookupServiceClient:
             )
         )
 
+        # lookup() returns a LookupResult pairing the parsed response with the
+        # raw Server-Timing header (None here — the handler sends no header).
+        assert isinstance(result, LookupResult)
+        assert result.server_timing is None
+        response = result.response
         assert isinstance(response, LookupResponse)
         assert response.results is not None
         assert len(response.results) == 1
@@ -99,6 +105,29 @@ class TestLookupServiceClient:
         assert response.search_type == "direct"
         assert response.song_not_found is False
         assert response.found_on_compilation is False
+
+    @pytest.mark.asyncio
+    async def test_lookup_captures_server_timing_header(self):
+        """When LML returns a Server-Timing header, it is captured on the result
+        so the router can forward and merge the sub-stage breakdown."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json=SAMPLE_RESPONSE,
+                headers={
+                    "Server-Timing": "library_search;dur=41.2, discogs;dur=806, total;dur=8560.1"
+                },
+            )
+
+        client = _make_client(handler)
+        result = await client.lookup(
+            LookupRequest(artist="Stereolab", raw_message="play stereolab")
+        )
+
+        assert isinstance(result, LookupResult)
+        assert result.server_timing == "library_search;dur=41.2, discogs;dur=806, total;dur=8560.1"
+        assert result.response.search_type == "direct"
 
     @pytest.mark.asyncio
     async def test_successful_lookup_with_all_fields(self):
@@ -135,9 +164,11 @@ class TestLookupServiceClient:
             return httpx.Response(200, json=empty_response)
 
         client = _make_client(handler)
-        response = await client.lookup(
-            LookupRequest(artist="ZZZNONEXISTENT", raw_message="play ZZZNONEXISTENT")
-        )
+        response = (
+            await client.lookup(
+                LookupRequest(artist="ZZZNONEXISTENT", raw_message="play ZZZNONEXISTENT")
+            )
+        ).response
 
         assert response.results == []
         assert response.search_type == "none"
@@ -155,9 +186,11 @@ class TestLookupServiceClient:
             return httpx.Response(200, json=response_data)
 
         client = _make_client(handler)
-        response = await client.lookup(
-            LookupRequest(artist="Living Color", raw_message="play living color")
-        )
+        response = (
+            await client.lookup(
+                LookupRequest(artist="Living Color", raw_message="play living color")
+            )
+        ).response
 
         assert response.corrected_artist == "Living Colour"
 
@@ -346,11 +379,12 @@ class TestLookupRetry:
             return httpx.Response(200, json=SAMPLE_RESPONSE)
 
         client = _make_client(handler)
-        response = await client.lookup(
+        result = await client.lookup(
             LookupRequest(artist="Stereolab", raw_message="play stereolab")
         )
         assert len(calls) == 2
-        assert isinstance(response, LookupResponse)
+        assert isinstance(result, LookupResult)
+        assert isinstance(result.response, LookupResponse)
 
     @pytest.mark.asyncio
     async def test_no_retry_on_timeout(self):
@@ -418,8 +452,9 @@ class TestLookupRetry:
             return httpx.Response(200, json=SAMPLE_RESPONSE)
 
         client = _make_client(handler)
-        response = await client.lookup(
+        result = await client.lookup(
             LookupRequest(artist="Jessica Pratt", raw_message="play jessica pratt")
         )
         assert len(calls) == 1
-        assert isinstance(response, LookupResponse)
+        assert isinstance(result, LookupResult)
+        assert isinstance(result.response, LookupResponse)

--- a/tests/unit/test_request_ban_enforcement.py
+++ b/tests/unit/test_request_ban_enforcement.py
@@ -38,7 +38,7 @@ from services.ban_check_client import (
     BanCheckResult,
     BanCheckUnavailableError,
 )
-from services.lookup_client import LookupResponse, LookupServiceClient
+from services.lookup_client import LookupResponse, LookupResult, LookupServiceClient
 from tests.conftest import make_parsed_request
 
 SAMPLE_PARSED = make_parsed_request(
@@ -90,7 +90,7 @@ def mock_ban_check_client():
 @pytest.fixture
 def mock_lookup_client():
     client = AsyncMock(spec=LookupServiceClient)
-    client.lookup.return_value = EMPTY_LOOKUP
+    client.lookup.return_value = LookupResult(response=EMPTY_LOOKUP, server_timing=None)
     return client
 
 

--- a/tests/unit/test_server_timing.py
+++ b/tests/unit/test_server_timing.py
@@ -1,0 +1,83 @@
+"""Unit tests for core/server_timing.py (Server-Timing header parsing)."""
+
+from core.server_timing import parse_server_timing
+
+
+class TestParseServerTiming:
+    """Tests for parse_server_timing()."""
+
+    def test_basic_two_entries(self):
+        """A well-formed two-entry header parses to ordered (name, dur) pairs."""
+        assert parse_server_timing("parse;dur=12.3, total;dur=45.6") == [
+            ("parse", 12.3),
+            ("total", 45.6),
+        ]
+
+    def test_none_returns_empty(self):
+        """A missing header (None) yields an empty list, never raises."""
+        assert parse_server_timing(None) == []
+
+    def test_empty_string_returns_empty(self):
+        """An empty string yields an empty list."""
+        assert parse_server_timing("") == []
+
+    def test_whitespace_only_returns_empty(self):
+        """A whitespace-only header yields an empty list."""
+        assert parse_server_timing("   ") == []
+
+    def test_no_space_after_comma(self):
+        """Entries separated by a bare comma (no space) still parse."""
+        assert parse_server_timing("parse;dur=12.3,total;dur=45.6") == [
+            ("parse", 12.3),
+            ("total", 45.6),
+        ]
+
+    def test_integer_dur_becomes_float(self):
+        """An integer-valued dur is returned as a float."""
+        assert parse_server_timing("discogs;dur=806") == [("discogs", 806.0)]
+
+    def test_zero_dur_is_kept(self):
+        """dur=0 is a real measurement, not a missing one — it must be kept."""
+        assert parse_server_timing("discogs;dur=0") == [("discogs", 0.0)]
+
+    def test_desc_param_is_ignored(self):
+        """A trailing desc parameter is ignored; only dur is extracted."""
+        assert parse_server_timing('cache;dur=53.2;desc="Cache Read"') == [("cache", 53.2)]
+
+    def test_desc_before_dur(self):
+        """dur is found regardless of parameter order within an entry."""
+        assert parse_server_timing("cpu;desc=compute;dur=2.1") == [("cpu", 2.1)]
+
+    def test_name_only_entry_is_skipped(self):
+        """An entry with no dur param cannot merge into as_server_timing(extra),
+        so it is skipped rather than raising or defaulting to 0."""
+        assert parse_server_timing("missedCache, parse;dur=1") == [("parse", 1.0)]
+
+    def test_non_numeric_dur_is_skipped(self):
+        """A malformed (non-numeric) dur skips only that entry, not the whole header."""
+        assert parse_server_timing("parse;dur=abc, total;dur=5") == [("total", 5.0)]
+
+    def test_order_and_duplicates_preserved(self):
+        """The return is an ordered list (not a dict): order and duplicate names survive."""
+        assert parse_server_timing("a;dur=1, b;dur=2, a;dur=3") == [
+            ("a", 1.0),
+            ("b", 2.0),
+            ("a", 3.0),
+        ]
+
+    def test_trailing_comma_and_blanks_skipped(self):
+        """Empty entries from stray/trailing commas are skipped."""
+        assert parse_server_timing("parse;dur=1, , total;dur=2,") == [
+            ("parse", 1.0),
+            ("total", 2.0),
+        ]
+
+    def test_realistic_lml_header(self):
+        """A realistic forwarded LML header parses in full."""
+        header = "library_search;dur=41.2, metadata_enrichment;dur=8500.7, discogs;dur=806, total;dur=8560.1"
+        assert parse_server_timing(header) == [
+            ("library_search", 41.2),
+            ("metadata_enrichment", 8500.7),
+            ("discogs", 806.0),
+            ("total", 8560.1),
+        ]

--- a/tests/unit/test_server_timing.py
+++ b/tests/unit/test_server_timing.py
@@ -74,10 +74,43 @@ class TestParseServerTiming:
 
     def test_realistic_lml_header(self):
         """A realistic forwarded LML header parses in full."""
-        header = "library_search;dur=41.2, metadata_enrichment;dur=8500.7, discogs;dur=806, total;dur=8560.1"
+        header = (
+            "library_search;dur=41.2, metadata_enrichment;dur=8500.7, "
+            "discogs;dur=806, total;dur=8560.1"
+        )
         assert parse_server_timing(header) == [
             ("library_search", 41.2),
             ("metadata_enrichment", 8500.7),
             ("discogs", 806.0),
             ("total", 8560.1),
+        ]
+
+    def test_non_finite_dur_is_skipped(self):
+        """``float()`` accepts 'inf'/'nan', but they are not valid Server-Timing
+        durations — emitting ``dur=inf`` would break a strict downstream parser,
+        so they are skipped like any other malformed dur."""
+        assert parse_server_timing("a;dur=inf, b;dur=nan, c;dur=5") == [("c", 5.0)]
+
+    def test_negative_dur_is_skipped(self):
+        """A negative dur is not a valid measurement; skip it, keep the rest."""
+        assert parse_server_timing("a;dur=-3, b;dur=5") == [("b", 5.0)]
+
+    def test_name_with_interior_whitespace_is_skipped(self):
+        """A name that is not a valid RFC token (e.g. contains a space) cannot be
+        emitted verbatim into a Server-Timing header, so the entry is skipped."""
+        assert parse_server_timing("cache hit;dur=5, discogs;dur=10") == [("discogs", 10.0)]
+
+    def test_name_with_control_chars_is_skipped(self):
+        """A CR/LF-bearing name (header-injection shaped) is skipped rather than
+        copied into rom's response header — latin-1 encodes CR/LF, so letting it
+        through would fail at the ASGI send layer, outside the caller's guard."""
+        injected = "foo\r\nX-Evil: bar;dur=1, discogs;dur=10"
+        assert parse_server_timing(injected) == [("discogs", 10.0)]
+
+    def test_rfc_token_names_are_kept(self):
+        """Valid RFC 7230 token names (letters, digits, and tchars) survive the
+        token filter — the guard rejects only genuinely non-token names."""
+        assert parse_server_timing("db.query_1;dur=2, cache-hit;dur=3") == [
+            ("db.query_1", 2.0),
+            ("cache-hit", 3.0),
         ]

--- a/tests/unit/test_ua_gate.py
+++ b/tests/unit/test_ua_gate.py
@@ -29,7 +29,7 @@ from core.dependencies import (
 from generated.api_models import CacheStats, SearchType
 from routers.request import router
 from services.ban_check_client import BanCheckClient
-from services.lookup_client import LookupResponse, LookupServiceClient
+from services.lookup_client import LookupResponse, LookupResult, LookupServiceClient
 from services.ua_gate import (
     UA_GATE_BAN_REASON,
     UA_GATE_BAN_SOURCE,
@@ -193,7 +193,7 @@ def mock_ban_check_client():
 @pytest.fixture
 def mock_lookup_client():
     client = AsyncMock(spec=LookupServiceClient)
-    client.lookup.return_value = EMPTY_LOOKUP
+    client.lookup.return_value = LookupResult(response=EMPTY_LOOKUP, server_timing=None)
     return client
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -954,7 +954,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
-    { name = "wxyc-fastapi", extras = ["posthog"], specifier = ">=1.0.0,<2.0.0" },
+    { name = "wxyc-fastapi", extras = ["posthog"], specifier = ">=1.1.0,<2.0.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1104,16 +1104,16 @@ wheels = [
 
 [[package]]
 name = "wxyc-fastapi"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "sentry-sdk", extra = ["fastapi"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/54/83a5e827e9bcc88f532f1a530dea94a794ebf8577dd9d2e9ac5c9f165162/wxyc_fastapi-1.0.0.tar.gz", hash = "sha256:628f70fa908717caa2a3122c446ed28e427f09814383056955b65c757f403ecd", size = 16805, upload-time = "2026-05-12T14:31:53.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/a9/fd42ba59ca2bcf0bdf4afd80e84bf91f133455bc7071e8e45fc8c09365df/wxyc_fastapi-1.1.0.tar.gz", hash = "sha256:4636465b3d124da5adf685bc8e23f8f0920d917811cfc12312721d2d8ff77421", size = 17656, upload-time = "2026-07-16T17:32:54.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b1/bcf58cc0ff027e0de5465d83b3ef3e5e520733e8d078c902e12a62a78323/wxyc_fastapi-1.0.0-py3-none-any.whl", hash = "sha256:47d7ea841a365400619afaec20e07d5d2051fff12761c88fab29cadbd532c239", size = 19224, upload-time = "2026-05-12T14:31:52.37Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/6d/567d0ea1c5bb1678f26f6bbff5cdcc91fa3ec0733b5fc8d2d86361b50056/wxyc_fastapi-1.1.0-py3-none-any.whl", hash = "sha256:8019fb2bc9d7c9497a499c9c85b4dd3ecad28847ef72e723bd3da394e31b74ef", size = 20115, upload-time = "2026-07-16T17:32:53.354Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #179.

## What

`POST /request` now attaches a [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) response header that **merges** ROM's own per-stage timings (`parse`, `lookup_service`, `slack_post`) with the sub-stage breakdown LML forwards in *its* `Server-Timing` header (`library_search`, `metadata_enrichment`, `discogs`). LML's `total` is dropped and ROM appends its own, so the merged header carries exactly one `total`, last.

Example (from a real merge):

```
parse;dur=0.03, lookup_service;dur=0.02, slack_post;dur=0, library_search;dur=41.2, metadata_enrichment;dur=8500.7, discogs;dur=806, total;dur=0.07
```

## Why

A `lookup "milkman aphex twin"` round-trip measured 8.99 s while the caller could only see the Discogs `cache_stats` block; the ~8.5 s actually spent in LML `metadata_enrichment` (Apple-Music-probe timeouts under the [BS#1631](https://github.com/WXYC/Backend-Service/issues/1631) backfill flood) was captured by telemetry but never reached the client. This surfaces the `RequestTelemetry.track_step` durations both services already ship to PostHog — **no new capture layer** — so a caller (e.g. the `lookup` CLI) can attribute a slow round-trip to a named server stage.

Third of a four-PR cross-repo trace: [wxyc-fastapi#30](https://github.com/WXYC/wxyc-fastapi/pull/30) (`as_server_timing`, released 1.1.0) and [library-metadata-lookup#828](https://github.com/WXYC/library-metadata-lookup/pull/828) (LML emit) landed first; the `lookup` CLI print is a stacked follow-up PR.

## Changes

- `services/lookup_client.py` — `lookup()` returns a `LookupResult(response, server_timing)` `NamedTuple` capturing LML's raw header value **by return** (not on the shared client instance) so it stays race-free under concurrent requests.
- `core/server_timing.py` (new) — stdlib-only, defensive `parse_server_timing(header) -> list[(name, dur_ms)]` (None / malformed / no-`dur` → `[]`).
- `routers/request.py` — `_emit_server_timing_header` helper (flag-gated; swallows all failures → WARN so observability can never break the request path); `http_response: Response` injected as the 2nd param; a `lml_server_timing = None` sentinel so the LML-outage path can't `UnboundLocalError` → 500; emitted at all three returns.
- `config/settings.py` — `enable_server_timing: bool = True` → env `ENABLE_SERVER_TIMING` (Railway kill switch).
- `pyproject.toml` / `uv.lock` / `requirements*.txt` — pin `wxyc-fastapi[posthog]` `>=1.0.0` → `>=1.1.0,<2.0.0` (re-locked + re-exported with `uv==0.11.21` so `deps-sync` stays green).
- `docs/env-vars.md`, `docs/architecture.md`, `CLAUDE.md`, `.env.example` — env entry, observability section, key-file pointers.
- Tests — new `tests/unit/test_server_timing.py` (14) + `TestServerTimingForwarding` in `test_delegation.py` (4) + `LookupResult` capture in `test_lookup_client.py`; existing lookup-client mock sites migrated to `LookupResult`.

## Test plan

Local (replicates CI):

- `pytest tests/unit` — **538 passed**.
- `ruff format --check .` / `ruff check .` — clean.
- `mypy . --ignore-missing-imports` — clean (74 files).
- `uv lock --locked` + `requirements*.txt` re-export — no drift (`deps-sync` parity).

New tests: strict wire-format grammar parse (14 `parse_server_timing` cases incl. None/malformed/no-`dur`/duplicate-name/desc-param); header present by default; forwarded LML sub-stages merged with LML's `total` dropped and exactly one (ROM's) `total` last; `ENABLE_SERVER_TIMING=false` suppresses the header; LML-outage path stays a graceful 200 with a ROM-only header (sentinel regression lock).

## Notes

- **Instrumentation-only / behavior-neutral** — the JSON body is byte-identical flag-on-vs-off (no `api.yaml` / `CacheStats` / `LookupResponse` change, no wxyc-shared regen). Merging to `main` auto-deploys to **staging** only; prod is a separate coordinated push.
- **Caveat (documented):** `metadata_enrichment` is wall-clock over concurrent probes, so `Σ steps + forwarded legs ≠ total`; ROM's `total` and LML's dropped `total` are two independent measurements.

## Related

Enrichment-observability hardening epic [Backend-Service#881](https://github.com/WXYC/Backend-Service/issues/881) (Epic G).
