### PR TITLE
feat(#179): print the merged Server-Timing breakdown in the lookup CLI

### DIFF
--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -2,15 +2,16 @@
 """CLI script to test the /request endpoint without posting to Slack.
 
 Usage:
-    python scripts/lookup.py "play bohemian rhapsody by queen"
-    python scripts/lookup.py --staging "the beatles abbey road"
-    python scripts/lookup.py --verbose "the beatles abbey road"
+    python scripts/lookup.py "milkman aphex twin"
+    python scripts/lookup.py --staging "juana molina la paradoja"
+    python scripts/lookup.py --verbose "juana molina la paradoja"
 """
 
 import argparse
 import asyncio
 import logging
 import sys
+import time
 from pathlib import Path
 from typing import Any, cast
 
@@ -19,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import httpx
 
+from core.server_timing import parse_server_timing
 from scripts._common import LOCAL_URL, PROD_URL, STAGING_URL, set_up_logging
 
 logger = logging.getLogger(__name__)
@@ -150,6 +152,46 @@ def print_cache_stats(cache_stats: dict) -> None:
         print(f"  API time:          {api_time:.0f} ms")
 
 
+# Friendly labels + provenance for the stages ROM emits in its merged
+# Server-Timing header. Leaves (parse, slack_post, and the forwarded LML
+# sub-stages) render first; the roll-ups render after them. Unmapped stage
+# names fall through to their raw form so a new stage is never silently dropped.
+_STAGE_LABELS = {
+    "parse": "Parse (Groq)",
+    "slack_post": "Slack post",
+    "library_search": "LML: library search",
+    "metadata_enrichment": "LML: metadata enrichment",
+    "discogs": "LML: Discogs cache/API",
+    "lookup_service": "LML round-trip (server)",
+    "total": "Server total",
+}
+_ROLLUP_STAGES = ("lookup_service", "total")
+
+
+def print_server_timing(header: str | None, round_trip_ms: float) -> None:
+    """Print the `/request` Server-Timing breakdown, client round-trip last.
+
+    ``header`` is the raw ``Server-Timing`` value ROM returns (rom's own stages
+    merged with LML's forwarded sub-stages; see WXYC/request-o-matic#179). The
+    per-stage leaves print in header order, then the roll-ups (LML round-trip,
+    server total), then the client-measured ``round_trip_ms`` — so a reader sees
+    where the time went (e.g. an 8.5s ``metadata_enrichment`` Apple-probe stall)
+    and can reconcile it against the totals. When the server sent no header
+    (older ROM, or ``ENABLE_SERVER_TIMING=false``), only the round-trip shows.
+    """
+    print_section("Server Timing")
+    legs = parse_server_timing(header)
+    if legs:
+        leaves = [(name, dur) for name, dur in legs if name not in _ROLLUP_STAGES]
+        rollups = [(name, dur) for name, dur in legs if name in _ROLLUP_STAGES]
+        for name, dur in leaves + rollups:
+            label = _STAGE_LABELS.get(name, name)
+            print(f"  {label + ':':32s}{dur:8.0f} ms")
+    print(f"  {'Round-trip (client):':32s}{round_trip_ms:8.0f} ms")
+    if not legs:
+        print("  (server sent no Server-Timing header)")
+
+
 async def run_lookup(
     query: str,
     verbose: bool = False,
@@ -170,11 +212,14 @@ async def run_lookup(
                 body["skip_cache"] = True
                 logger.info("Cache bypass enabled (skip_cache=True)")
             logger.info("Calling /request endpoint...")
+            start = time.perf_counter()
             response = await client.post(
                 f"{base_url}/request",
                 json=body,
             )
+            round_trip_ms = (time.perf_counter() - start) * 1000
             response.raise_for_status()
+            server_timing = response.headers.get("Server-Timing")
             data = response.json()
 
             # Display parsed request
@@ -186,6 +231,7 @@ async def run_lookup(
 
             # Skip library results for non-requests
             if not parsed.get("is_request", False):
+                print_server_timing(server_timing, round_trip_ms)
                 return cast(dict[str, Any], data)
 
             # Display library results and context
@@ -201,6 +247,9 @@ async def run_lookup(
             cache_stats = data.get("cache_stats")
             if cache_stats:
                 print_cache_stats(cache_stats)
+
+            # Display the server-side stage breakdown + client round-trip
+            print_server_timing(server_timing, round_trip_ms)
 
             return cast(dict[str, Any], data)
 

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -159,9 +159,15 @@ def print_cache_stats(cache_stats: dict) -> None:
 _STAGE_LABELS = {
     "parse": "Parse (Groq)",
     "slack_post": "Slack post",
+    # LML's forwarded sub-stages (order LML emits them within its own header).
+    "album_lookup": "LML: album lookup",
     "library_search": "LML: library search",
+    "track_validation": "LML: track validation",
+    "artwork_fetch": "LML: artwork fetch",
     "metadata_enrichment": "LML: metadata enrichment",
+    "identity_resolution": "LML: identity resolution",
     "discogs": "LML: Discogs cache/API",
+    # Roll-ups.
     "lookup_service": "LML round-trip (server)",
     "total": "Server total",
 }

--- a/scripts/lookup.py
+++ b/scripts/lookup.py
@@ -195,7 +195,10 @@ def print_server_timing(header: str | None, round_trip_ms: float) -> None:
             print(f"  {label + ':':32s}{dur:8.0f} ms")
     print(f"  {'Round-trip (client):':32s}{round_trip_ms:8.0f} ms")
     if not legs:
-        print("  (server sent no Server-Timing header)")
+        # Distinguish an absent header (older ROM / flag off) from a present but
+        # unparseable one (every entry rejected) — different debugging signals.
+        note = "no" if not header else "an unparseable"
+        print(f"  (server sent {note} Server-Timing header)")
 
 
 async def run_lookup(
@@ -272,9 +275,9 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s "play bohemian rhapsody by queen"
-  %(prog)s "the beatles abbey road"
-  %(prog)s --verbose "Play 'Abele Dance (85 Remix)' by Manu Dibango"
+  %(prog)s "milkman aphex twin"
+  %(prog)s "jessica pratt on your own love again"
+  %(prog)s --verbose "Play 'la paradoja' by Juana Molina"
         """,
     )
     parser.add_argument(

--- a/tests/unit/test_lookup_script.py
+++ b/tests/unit/test_lookup_script.py
@@ -57,6 +57,15 @@ class TestPrintServerTiming:
         assert "mystery_stage" in out
         assert "12" in out
 
+    def test_present_but_unparseable_header_is_noted_as_such(self, capsys):
+        """A present-but-corrupt header (every entry rejected) is reported as
+        unparseable, not as absent — the two situations mean different things to
+        someone debugging why the trace is empty."""
+        print_server_timing("no_dur_here, another_no_dur", round_trip_ms=10.0)
+        out = capsys.readouterr().out
+        assert "unparseable" in out.lower()
+        assert "10" in out
+
     def test_all_forwarded_lml_substages_get_friendly_labels(self, capsys):
         """Every sub-stage LML forwards renders with an ``LML:`` provenance label,
         not its raw snake_case name. Regression guard: the map originally covered

--- a/tests/unit/test_lookup_script.py
+++ b/tests/unit/test_lookup_script.py
@@ -1,0 +1,58 @@
+"""Unit tests for scripts/lookup.py Server-Timing rendering (PR 3b)."""
+
+from scripts.lookup import print_server_timing
+
+# A realistic merged header as ROM emits it: rom stages (parse, lookup_service,
+# slack_post) + forwarded LML sub-stages (library_search, metadata_enrichment,
+# discogs) + rom's single total.
+MERGED_HEADER = (
+    "parse;dur=3.1, lookup_service;dur=8560, slack_post;dur=42, "
+    "library_search;dur=41, metadata_enrichment;dur=8500, discogs;dur=806, total;dur=8610"
+)
+
+
+class TestPrintServerTiming:
+    def test_all_stage_durations_rendered(self, capsys):
+        """Every leg's duration surfaces, plus the client round-trip."""
+        print_server_timing(MERGED_HEADER, round_trip_ms=8990.0)
+        out = capsys.readouterr().out
+        # the 8.5s metadata_enrichment culprit is visible, with its friendly label
+        assert "metadata enrichment" in out.lower()
+        assert "8500" in out
+        # server total and the client-measured round-trip both surface
+        assert "8610" in out
+        assert "8990" in out
+        assert "round-trip" in out.lower()
+
+    def test_client_round_trip_printed_last(self, capsys):
+        """Leaves + roll-ups print first; the client round-trip line is last."""
+        print_server_timing(MERGED_HEADER, round_trip_ms=8990.0)
+        timing_lines = [ln for ln in capsys.readouterr().out.splitlines() if "ms" in ln]
+        assert timing_lines, "expected at least one timing line"
+        assert "8990" in timing_lines[-1]
+        assert "client" in timing_lines[-1].lower()
+
+    def test_leaf_before_rollup_ordering(self, capsys):
+        """A forwarded LML sub-stage (leaf) prints before the lookup_service roll-up."""
+        print_server_timing(MERGED_HEADER, round_trip_ms=8990.0)
+        lines = capsys.readouterr().out.splitlines()
+        idx_enrich = next(i for i, ln in enumerate(lines) if "metadata enrichment" in ln.lower())
+        idx_rollup = next(i for i, ln in enumerate(lines) if "lml round-trip" in ln.lower())
+        assert idx_enrich < idx_rollup
+
+    def test_absent_header_prints_round_trip_only(self, capsys):
+        """No server header (older ROM / flag off) → round-trip plus an explanatory note."""
+        print_server_timing(None, round_trip_ms=512.0)
+        out = capsys.readouterr().out
+        assert "512" in out
+        assert "round-trip" in out.lower()
+        assert "no server-timing" in out.lower()
+        # no per-stage lines when the header is absent
+        assert "metadata enrichment" not in out.lower()
+
+    def test_unknown_stage_falls_through_to_raw_name(self, capsys):
+        """An unmapped stage name is printed verbatim rather than dropped."""
+        print_server_timing("mystery_stage;dur=12, total;dur=20", round_trip_ms=25.0)
+        out = capsys.readouterr().out
+        assert "mystery_stage" in out
+        assert "12" in out

--- a/tests/unit/test_lookup_script.py
+++ b/tests/unit/test_lookup_script.py
@@ -56,3 +56,27 @@ class TestPrintServerTiming:
         out = capsys.readouterr().out
         assert "mystery_stage" in out
         assert "12" in out
+
+    def test_all_forwarded_lml_substages_get_friendly_labels(self, capsys):
+        """Every sub-stage LML forwards renders with an ``LML:`` provenance label,
+        not its raw snake_case name. Regression guard: the map originally covered
+        only 3 of LML's 7 forwarded stages, so album_lookup / track_validation /
+        artwork_fetch / identity_resolution leaked through raw (confirmed against
+        staging on 2026-07-16)."""
+        header = (
+            "parse;dur=5, album_lookup;dur=1, library_search;dur=2, "
+            "track_validation;dur=1, artwork_fetch;dur=3, metadata_enrichment;dur=4, "
+            "identity_resolution;dur=2, discogs;dur=6, lookup_service;dur=20, total;dur=25"
+        )
+        print_server_timing(header, round_trip_ms=30.0)
+        out = capsys.readouterr().out
+        for label in (
+            "LML: album lookup",
+            "LML: track validation",
+            "LML: artwork fetch",
+            "LML: identity resolution",
+        ):
+            assert label in out
+        # the raw snake_case forms must not leak once the stage is mapped
+        for raw in ("album_lookup", "track_validation", "artwork_fetch", "identity_resolution"):
+            assert raw not in out


### PR DESCRIPTION
Completes the CLI half (item 4) of the four-PR Server-Timing trace in #179. **#180 (the ROM forward/merge) is merged**, so this now targets `main` and its diff is CLI-only.

## What

The `lookup` CLI prints a **Server Timing** section from the `Server-Timing` header ROM attaches to `/request`, so a slow round-trip is attributable to a named server stage right at the terminal. Per-stage leaves (parse, slack_post, and the forwarded LML sub-stages) print first, then the roll-ups (LML round-trip, server total), then the client-measured round-trip — so the reader sees where the time went and can reconcile it against the totals.

Verified live against staging (`lookup -s "milkman aphex twin"`):

```
  Server Timing
============================================================
  Parse (Groq):                        504 ms
  Slack post:                            0 ms
  LML: album lookup:                     1 ms
  LML: library search:                   0 ms
  LML: track validation:                 1 ms
  LML: artwork fetch:                    0 ms
  LML: metadata enrichment:              1 ms
  LML: identity resolution:            115 ms
  LML: Discogs cache/API:                0 ms
  LML round-trip (server):            2907 ms
  Server total:                       3412 ms
  Round-trip (client):                4162 ms
```

## Why

The motivating `lookup "milkman aphex twin"` measured 8.99 s but the CLI only surfaced the Discogs `cache_stats` block; the ~8.5 s spent in LML `metadata_enrichment` (Apple-Music-probe timeouts under the backfill flood) was invisible. This is the last of the four-PR trace — [wxyc-fastapi#30](https://github.com/WXYC/wxyc-fastapi/pull/30) → [LML#828](https://github.com/WXYC/library-metadata-lookup/pull/828) → #180 (ROM forward/merge) → **this** (CLI print).

## Changes

- `scripts/lookup.py` — `run_lookup` times the POST with `time.perf_counter` and reads the response's `Server-Timing` header; `print_server_timing(header, round_trip_ms)` renders it with a friendly-label + provenance map (`_STAGE_LABELS`), reusing the (now-hardened) `core.server_timing.parse_server_timing` rather than duplicating the parser. Unmapped stages fall through to their raw name; an absent header vs a present-but-unparseable one are reported distinctly.
- `_STAGE_LABELS` covers all **seven** stages LML forwards — `album_lookup`, `library_search`, `track_validation`, `artwork_fetch`, `metadata_enrichment`, `identity_resolution`, `discogs` — confirmed against the live staging header (an earlier draft labeled only three, leaving four printing raw).
- Docstring and `--help` examples use WXYC-representative artists (Aphex Twin / Jessica Pratt / Juana Molina).
- `tests/unit/test_lookup_script.py` (new) — 8 `capsys` tests: all durations rendered, client round-trip last, leaf-before-roll-up ordering, absent-header round-trip-only, present-but-unparseable note, unknown-stage passthrough, and all-seven-LML-labels.

## Follow-up (not in this PR)

On a slow **5xx** the breakdown isn't printed — the header and round-trip are read after `raise_for_status()`, and the `HTTPStatusError` handler logs and exits. A latency tool ideally shows timing on the error path too, but `run_lookup` has no error-path test scaffolding today, so that is deferred to a separate change rather than bolted on untested.

## Test plan

Local (replicates CI): `pytest tests/unit` **556 passed**; `ruff format --check .` / `ruff check .` clean; `mypy . --ignore-missing-imports` clean (77 files).

## Related

Trace parent [#179](https://github.com/WXYC/request-o-matic/issues/179); enrichment-observability epic [Backend-Service#881](https://github.com/WXYC/Backend-Service/issues/881).
