### PR TITLE
feat(#161): send X-Caller-Budget-Ms on LML /lookup

### DIFF
--- a/services/lookup_client.py
+++ b/services/lookup_client.py
@@ -46,6 +46,14 @@ class LookupServiceClient:
         max_attempts: Total attempts per lookup (1 = no retry, 2 = one retry)
         retry_delay: Seconds to wait between retries
         per_attempt_timeout: Per-attempt timeout in seconds (overrides the client default)
+        caller_budget_ms: Value sent as the ``X-Caller-Budget-Ms`` header on every
+            ``POST /lookup``. LML uses it to bound its search-pipeline budget instead
+            of falling back to its ``LML_SEARCH_BUDGET_MS`` default. When ``None``
+            (the default), it is derived from ``per_attempt_timeout``:
+            ``max(int(per_attempt_timeout * 1000) - 200, 1000)`` — the 200 ms trims
+            transport overhead so LML returns a graceful in-budget result before ROM's
+            httpx client times out, and the 1000 ms floor guards tiny/zero timeouts.
+            An explicit value is used verbatim.
     """
 
     # Only retry transient connection-establishment failures. TimeoutException
@@ -64,6 +72,7 @@ class LookupServiceClient:
         max_attempts: int = 2,
         retry_delay: float = 1.0,
         per_attempt_timeout: float = 20.0,
+        caller_budget_ms: int | None = None,
     ):
         self.base_url = base_url.rstrip("/")
         self.http_client = http_client
@@ -71,6 +80,14 @@ class LookupServiceClient:
         self.max_attempts = max_attempts
         self.retry_delay = retry_delay
         self.per_attempt_timeout = per_attempt_timeout
+        # An explicit budget wins verbatim; otherwise derive it from the per-attempt
+        # timeout, shaving 200ms of transport overhead so LML can return a graceful
+        # in-budget result before ROM's httpx client times out, with a 1000ms floor.
+        self._effective_caller_budget_ms = (
+            caller_budget_ms
+            if caller_budget_ms is not None
+            else max(int(self.per_attempt_timeout * 1000) - 200, 1000)
+        )
 
     def _auth_headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
@@ -103,7 +120,10 @@ class LookupServiceClient:
                     f"{self.base_url}/lookup",
                     json=request.model_dump(exclude_none=True),
                     params=params,
-                    headers=self._auth_headers(),
+                    headers={
+                        **self._auth_headers(),
+                        "X-Caller-Budget-Ms": str(self._effective_caller_budget_ms),
+                    },
                     timeout=self.per_attempt_timeout,
                 )
                 response.raise_for_status()

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -315,6 +315,68 @@ class TestLookupServiceClient:
         await client.lookup(LookupRequest(artist="Cat Power", raw_message="play cat power"))
         assert calls == ["Bearer retry-token", "Bearer retry-token"]
 
+    @pytest.mark.asyncio
+    async def test_caller_budget_header_default_from_timeout(self):
+        """With the default 20s per-attempt timeout, X-Caller-Budget-Ms is 19800."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.headers["x-caller-budget-ms"] == "19800"
+            return httpx.Response(200, json=SAMPLE_RESPONSE)
+
+        client = _make_client(handler)  # per_attempt_timeout defaults to 20.0
+        await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
+
+    @pytest.mark.asyncio
+    async def test_caller_budget_header_explicit_wins(self):
+        """An explicit caller_budget_ms is sent verbatim, independent of the timeout."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.headers["x-caller-budget-ms"] == "5000"
+            return httpx.Response(200, json=SAMPLE_RESPONSE)
+
+        # per_attempt_timeout that would derive 9800 is overridden by the explicit budget.
+        client = _make_client(handler, per_attempt_timeout=10.0, caller_budget_ms=5000)
+        await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
+
+    @pytest.mark.asyncio
+    async def test_caller_budget_header_is_integer_string(self):
+        """The header value is a plain integer string, never a float like '19800.0'."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            value = request.headers["x-caller-budget-ms"]
+            assert "." not in value
+            assert int(value) == 19800
+            return httpx.Response(200, json=SAMPLE_RESPONSE)
+
+        client = _make_client(handler)
+        await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
+
+    @pytest.mark.asyncio
+    async def test_caller_budget_header_sent_on_retry(self):
+        """The X-Caller-Budget-Ms header rides every attempt, not just the first."""
+        calls = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request.headers.get("x-caller-budget-ms"))
+            if len(calls) == 1:
+                raise httpx.ConnectError("Connection refused")
+            return httpx.Response(200, json=SAMPLE_RESPONSE)
+
+        client = _make_client(handler)  # per_attempt_timeout defaults to 20.0
+        await client.lookup(LookupRequest(artist="Cat Power", raw_message="play cat power"))
+        assert calls == ["19800", "19800"]
+
+    @pytest.mark.asyncio
+    async def test_caller_budget_header_clamps_to_floor(self):
+        """A tiny per-attempt timeout clamps the derived budget to the 1000ms floor."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert request.headers["x-caller-budget-ms"] == "1000"
+            return httpx.Response(200, json=SAMPLE_RESPONSE)
+
+        client = _make_client(handler, per_attempt_timeout=0.5)
+        await client.lookup(LookupRequest(artist="Stereolab", raw_message="play stereolab"))
+
 
 class TestLookupModels:
     """Tests for lookup models."""


### PR DESCRIPTION
Closes #161

## Summary

`services/lookup_client.py` now sends an `X-Caller-Budget-Ms` request header on every `POST /lookup` attempt (including retries), so LML bounds its search-pipeline budget to what ROM will actually wait for instead of falling back to its `LML_SEARCH_BUDGET_MS=4000ms` default.

After #158 raised ROM's `per_attempt_timeout` to 20s, the two sides diverged: ROM waited up to 20s for a match while LML internally cut off at 4s and returned "no match", degrading cold-path lookups to `search_unavailable` even when LML could have found a result in the 5-15s window. The header closes that gap.

## Change

- New `caller_budget_ms: int | None = None` constructor parameter on `LookupServiceClient`.
- When `None` (the default and the only path exercised in prod today), the budget is derived from the per-attempt timeout: `max(int(per_attempt_timeout * 1000) - 200, 1000)`. The 200ms trims transport overhead so LML returns a graceful in-budget result before ROM's httpx client times out; the 1000ms floor guards tiny/zero timeouts.
- An explicit `caller_budget_ms` wins verbatim (for degraded-posture callers).
- The header is a plain integer string of milliseconds (never a float like `19800.0`) and merges on top of the existing `_auth_headers()` so both auth and budget ride every attempt.

## Before / after

- Before: no `X-Caller-Budget-Ms` header; LML falls back to `LML_SEARCH_BUDGET_MS`.
- After: with the default `per_attempt_timeout=20.0` (the value the client is constructed with in `core/dependencies.py`), the header is exactly `19800`.

## Tests

Added to `tests/unit/test_lookup_client.py`, mirroring the existing `httpx.MockTransport` style: default-from-timeout (`19800`), explicit-wins (`5000`, independent of timeout), integer-string (no decimal point), sent-on-retry, and floor-clamp for a tiny `0.5s` timeout (`1000`).

## Context

ROM-side mirror of the LML `X-Caller-Budget-Ms` acceptance (LML#345/#403) and the BS-side equivalent (BS#1053). Pairs with the recently-merged LML spine-deadline work (LML#865, PR WXYC/library-metadata-lookup#868), which extends the caller budget over LML's step 2 as well.