### PR TITLE
fix: keep descriptor noun and trailing feedback out of pre-pass album

### DIFF
--- a/services/parser.py
+++ b/services/parser.py
@@ -41,6 +41,37 @@ _TRAILING_POLITENESS_RE = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
+# A whole feedback/greeting clause appended after the request -- e.g. the
+# listener writes "<song> by <artist> from <album>....  thanks for your set!".
+# The trailing-politeness trim above only removes a single trailing token; this
+# removes the politeness lead-in word AND everything after it. It fires ONLY when
+# a sentence boundary -- punctuation, a comma, or a run of 2+ spaces -- precedes
+# the politeness word. That boundary requirement is what distinguishes an
+# appended clause from a title that merely *contains* a politeness word
+# ("Pretty Please Goodbye"), where the word sits behind a single space.
+# The lead-in set mirrors _TRAILING_POLITENESS_RE so the two stay consistent.
+_TRAILING_FEEDBACK_RE = re.compile(
+    r"""
+    (?: [.!?…]+ | ,+ | \s{2,} )         # a clause boundary (never a lone space)
+    \s*
+    (?: please | thanks | thank\ you | thx )   # feedback lead-in
+    \b
+    [\s\S]*                              # ... and the rest of the appended clause
+    $
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# A descriptor noun introducing the album title -- "from album <title>", "off
+# the record <title>". The noun (with an optional leading "the") is a lead-in,
+# not part of the title, so strip it. Anchored with a trailing `\s+` so it only
+# fires when title text follows: a real album literally titled "Album" (PiL) or
+# "Record" survives the bare "off album" phrasing.
+_LEADING_ALBUM_DESCRIPTOR_RE = re.compile(
+    r"^(?:the\s+)?(?:album|record|lp|ep)\s+",
+    re.IGNORECASE,
+)
+
 # Single source of truth for the album prepositions the pre-pass recognises.
 # Order matters: multi-word forms must precede their own prefixes ("off of"
 # before "off") so the regex alternation is greedy-correct.
@@ -158,8 +189,19 @@ def extract_album_prefix(raw_message: str) -> tuple[str, str] | None:
         return None
 
     album_raw = match.group("album").strip()
-    # Trim trailing politeness ("please", "thanks") that listeners append.
+    # Trim a trailing feedback clause ("...doga.  thanks for the set!") first,
+    # then any bare trailing politeness token ("...doga please"). The feedback
+    # trim requires a sentence boundary before the politeness word, so a title
+    # that merely contains one ("Pretty Please Goodbye") is left intact.
+    album_raw = _TRAILING_FEEDBACK_RE.sub("", album_raw)
     album_raw = _TRAILING_POLITENESS_RE.sub("", album_raw).strip()
+    if not album_raw:
+        return None
+
+    # Drop a leading album-descriptor noun ("from album <title>" -> "<title>").
+    # The noun introduces the title rather than being part of it. The regex is
+    # anchored so it only fires when title text follows (see its definition).
+    album_raw = _LEADING_ALBUM_DESCRIPTOR_RE.sub("", album_raw).strip()
     if not album_raw:
         return None
 

--- a/services/parser.py
+++ b/services/parser.py
@@ -45,14 +45,17 @@ _TRAILING_POLITENESS_RE = re.compile(
 # listener writes "<song> by <artist> from <album>....  thanks for your set!".
 # The trailing-politeness trim above only removes a single trailing token; this
 # removes the politeness lead-in word AND everything after it. It fires ONLY when
-# a sentence boundary -- punctuation, a comma, or a run of 2+ spaces -- precedes
-# the politeness word. That boundary requirement is what distinguishes an
-# appended clause from a title that merely *contains* a politeness word
-# ("Pretty Please Goodbye"), where the word sits behind a single space.
-# The lead-in set mirrors _TRAILING_POLITENESS_RE so the two stay consistent.
+# a sentence boundary -- terminal punctuation or a comma -- precedes the
+# politeness word. That boundary requirement is what distinguishes an appended
+# clause from a title that merely *contains* a politeness word ("Pretty Please
+# Goodbye"). A run of spaces is deliberately NOT a boundary: a double-space typo
+# inside a title ("pretty  please goodbye") would otherwise truncate it, and a
+# genuine appended clause is reliably introduced by punctuation or a comma
+# anyway. The lead-in set mirrors _TRAILING_POLITENESS_RE so the two stay
+# consistent.
 _TRAILING_FEEDBACK_RE = re.compile(
     r"""
-    (?: [.!?…]+ | ,+ | \s{2,} )         # a clause boundary (never a lone space)
+    (?: [.!?…]+ | ,+ )                   # a clause boundary (punctuation or comma)
     \s*
     (?: please | thanks | thank\ you | thx )   # feedback lead-in
     \b
@@ -63,13 +66,33 @@ _TRAILING_FEEDBACK_RE = re.compile(
 )
 
 # A descriptor noun introducing the album title -- "from album <title>", "off
-# the record <title>". The noun (with an optional leading "the") is a lead-in,
-# not part of the title, so strip it. Anchored with a trailing `\s+` so it only
-# fires when title text follows: a real album literally titled "Album" (PiL) or
-# "Record" survives the bare "off album" phrasing.
+# the record <title>". The noun is a lead-in, not part of the title, so strip it.
+# The tricky part is that "album"/"record"/"lp"/"ep" are also legitimate *title*
+# words ("Album of the Year", "Record Collection", "EP 3", "LP 2"), so the strip
+# is deliberately narrow -- it fires in only two unambiguous shapes:
+#
+#   1. determiner-led -- "the album <title>" / "the record <title>". A real title
+#      virtually never begins "the album ..."/"the record ...", so "the" is a
+#      confident descriptor signal.
+#   2. bare "album <title>" -- the attested telegraphic form listeners actually
+#      type ("from album my love is"). Guarded by a negative lookahead so the
+#      "Album of ..." title pattern ("Album of the Year") keeps its first word.
+#
+# Bare "record"/"lp"/"ep" are intentionally NOT stripped: their bare descriptor
+# use is unattested and they collide with real titles ("Record Collection",
+# "EP 3", "LP 2"). The trailing `\s+` requires title text to follow, so a bare
+# album titled "Album" (PiL) survives "off album".
 _LEADING_ALBUM_DESCRIPTOR_RE = re.compile(
-    r"^(?:the\s+)?(?:album|record|lp|ep)\s+",
-    re.IGNORECASE,
+    r"""
+    ^
+    (?:
+        the \s+ (?: album | record )   # 1. determiner-led descriptor
+      |
+        album (?! \s+ of \b )          # 2. bare "album", but not "Album of ..."
+    )
+    \s+
+    """,
+    re.IGNORECASE | re.VERBOSE,
 )
 
 # Single source of truth for the album prepositions the pre-pass recognises.

--- a/tests/scenarios.py
+++ b/tests/scenarios.py
@@ -533,6 +533,46 @@ ALBUM_PREPASS_CASES: list[AlbumPrepassCase] = [
         expected_album="doga",
         expected_stripped="la paradoja by juana molina",
     ),
+    # Leading "album"/"record"/"the album" descriptor after the preposition is a
+    # noun that introduces the title, not part of it -- strip it. (Mirrors the
+    # trailing "lp"/"cd" format-descriptor rule the Groq prompt already applies.)
+    AlbumPrepassCase(
+        id="juana_from_album_descriptor",
+        raw_message="la paradoja by juana molina from album doga",
+        preposition="from",
+        expected_album="doga",
+        expected_stripped="la paradoja by juana molina",
+    ),
+    AlbumPrepassCase(
+        id="orb_on_the_album_descriptor",
+        raw_message="tower of dub by the orb on the album live '93",
+        preposition="on",
+        expected_album="live '93",
+        expected_stripped="tower of dub by the orb",
+    ),
+    # A whole feedback sentence appended after the request must not be swallowed
+    # into the album. The trailing-politeness trim only caught a single trailing
+    # token; a clause introduced by a politeness word after a sentence boundary
+    # ("...doga.  thanks for the great set!") is cut in full.
+    AlbumPrepassCase(
+        id="jessica_off_trailing_feedback_clause",
+        raw_message="back, baby by jessica pratt off on your own love again, thanks for the great set!",
+        preposition="off",
+        expected_album="on your own love again",
+        expected_stripped="back, baby by jessica pratt",
+    ),
+    # Regression repro of the production miss (WXYC/request-o-matic): a leading
+    # "album" descriptor AND a trailing feedback sentence in the same message.
+    AlbumPrepassCase(
+        id="harveymilk_album_descriptor_and_feedback",
+        raw_message=(
+            "anvil will fall by harvey milk from album my love is....     "
+            "thanks for your set we're enjoying it!!!"
+        ),
+        preposition="from",
+        expected_album="my love is",
+        expected_stripped="anvil will fall by harvey milk",
+    ),
     # -- Negatives: pre-pass must decline (idioms, greetings, bare short-forms).
     # The id documents the tail that a false-fire would wrongly capture as album.
     AlbumPrepassCase(

--- a/tests/unit/test_album_extraction.py
+++ b/tests/unit/test_album_extraction.py
@@ -101,14 +101,58 @@ def test_leading_descriptor_strip_leaves_single_word_titles_intact() -> None:
 def test_trailing_feedback_strip_preserves_politeness_word_inside_title() -> None:
     """A politeness word mid-title (no sentence boundary) is part of the title.
 
-    The trailing-feedback trim only fires after a sentence boundary (punctuation,
-    comma, or a 2+ space gap), so a single space before a politeness word -- as in
+    The trailing-feedback trim only fires after a sentence boundary (terminal
+    punctuation or a comma), so a single space before a politeness word -- as in
     an album whose title merely contains one -- does not truncate the title.
     """
     result = extract_album_prefix("some song by stereolab off pretty please goodbye")
     assert result is not None
     album, _ = result
     assert album.strip().lower() == "pretty please goodbye"
+
+
+def test_trailing_feedback_strip_ignores_double_space_before_politeness_word() -> None:
+    """A run of spaces is NOT a feedback boundary -- only punctuation/comma is.
+
+    A double-space typo in a title ("pretty  please goodbye") must not be read as
+    an appended feedback clause and truncated; a genuine feedback clause is
+    introduced by punctuation or a comma instead.
+    """
+    result = extract_album_prefix("some song by stereolab off pretty  please goodbye")
+    assert result is not None
+    album, _ = result
+    assert "please goodbye" in album.strip().lower()
+
+
+def test_leading_descriptor_strip_preserves_titles_that_begin_with_the_noun() -> None:
+    """Real titles beginning with the descriptor word keep their first word.
+
+    "Album of the Year" and "Record Collection" are real albums; the strip fires
+    only for the determiner-led form or a bare "album" not followed by "of", so
+    the title-word usage survives.
+    """
+    # bare "album" + "of ..." is the title pattern, not a descriptor
+    r1 = extract_album_prefix("some song by stereolab off album of the year")
+    assert r1 is not None and r1[0].strip().lower() == "album of the year"
+    # bare "record <word>" is left intact (only "the record" reads as a descriptor)
+    r2 = extract_album_prefix("some song by cat power off record collection")
+    assert r2 is not None and r2[0].strip().lower() == "record collection"
+
+
+def test_leading_descriptor_strip_preserves_ep_lp_volume_titles() -> None:
+    """ "EP 3" / "LP 2" volume-named releases: "ep"/"lp" are not descriptors."""
+    r1 = extract_album_prefix("some track by chuquimamani-condori off ep 3")
+    assert r1 is not None and r1[0].strip().lower() == "ep 3"
+    r2 = extract_album_prefix("some track by juana molina off lp 2")
+    assert r2 is not None and r2[0].strip().lower() == "lp 2"
+
+
+def test_leading_descriptor_strip_fires_on_determiner_led_forms() -> None:
+    """ "the album X" / "the record X" are unambiguous descriptors -> stripped."""
+    r1 = extract_album_prefix("some song by cat power on the album moon pix")
+    assert r1 is not None and r1[0].strip().lower() == "moon pix"
+    r2 = extract_album_prefix("some song by stereolab off the record collection")
+    assert r2 is not None and r2[0].strip().lower() == "collection"
 
 
 def test_returns_none_for_messages_without_album_marker() -> None:

--- a/tests/unit/test_album_extraction.py
+++ b/tests/unit/test_album_extraction.py
@@ -86,6 +86,31 @@ def test_does_not_extract_album_for_idioms_or_short_forms(case) -> None:
     )
 
 
+def test_leading_descriptor_strip_leaves_single_word_titles_intact() -> None:
+    """A bare "album"/"record" title (no trailing text) must not be stripped away.
+
+    The leading-descriptor strip requires trailing title text after the noun, so
+    a real album literally titled "Album" (PiL) survives the "off album" phrasing.
+    """
+    result = extract_album_prefix("metal box by public image ltd off album")
+    assert result is not None
+    album, _ = result
+    assert album.strip().lower() == "album"
+
+
+def test_trailing_feedback_strip_preserves_politeness_word_inside_title() -> None:
+    """A politeness word mid-title (no sentence boundary) is part of the title.
+
+    The trailing-feedback trim only fires after a sentence boundary (punctuation,
+    comma, or a 2+ space gap), so a single space before a politeness word -- as in
+    an album whose title merely contains one -- does not truncate the title.
+    """
+    result = extract_album_prefix("some song by stereolab off pretty please goodbye")
+    assert result is not None
+    album, _ = result
+    assert album.strip().lower() == "pretty please goodbye"
+
+
 def test_returns_none_for_messages_without_album_marker() -> None:
     """No "on" / "from" / "off" -> pre-pass declines to fire."""
     assert extract_album_prefix("la paradoja by juana molina") is None

--- a/tests/unit/test_parser_album_overlay.py
+++ b/tests/unit/test_parser_album_overlay.py
@@ -174,6 +174,45 @@ async def test_overlay_works_for_off_phrasing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_overlay_strips_descriptor_and_trailing_feedback() -> None:
+    """Production repro: "<song> by <artist> from album <title>....  <feedback>".
+
+    The pre-pass must (a) drop the leading "album" descriptor noun and (b) not
+    swallow the appended feedback sentence into the album, while Groq -- which
+    only ever sees the stripped song+artist prefix -- returns song/artist cleanly.
+    """
+    client = _make_mock_groq(
+        {
+            "song": "Anvil Will Fall",
+            "album": None,
+            "artist": "Harvey Milk",
+            "is_request": True,
+            "message_type": "request",
+        }
+    )
+
+    message = (
+        "anvil will fall by harvey milk from album my love is....     "
+        "thanks for your set we're enjoying it!!!"
+    )
+    result = await parse_request(message, client)
+
+    assert result.album is not None
+    assert result.album.strip().lower() == "my love is"
+    assert result.song == "Anvil Will Fall"
+    assert result.artist == "Harvey Milk"
+
+    # Groq saw only the song+artist prefix -- no descriptor, no album, no feedback.
+    call_args = client.chat.completions.create.await_args
+    user_msg = next(m for m in call_args.kwargs["messages"] if m["role"] == "user")
+    user_content = user_msg["content"].lower()
+    assert "album" not in user_content
+    assert "my love is" not in user_content
+    assert "thanks" not in user_content
+    assert "anvil will fall by harvey milk" in user_content
+
+
+@pytest.mark.asyncio
 async def test_overlay_works_for_off_of_phrasing() -> None:
     client = _make_mock_groq(
         {


### PR DESCRIPTION
Closes #188

## Problem

A production request parsed with a contaminated album field. The listener wrote `anvil will fall by harvey milk from album my love is....     thanks for your set we're enjoying it!!!` and the album came out as `album my love is....     thanks for your set we're enjoying it!!!` — the leading `album` descriptor and the whole appended thank-you sentence were both swallowed.

## Root cause

The deterministic album pre-pass `extract_album_prefix` (`services/parser.py`, from #140) — not Groq. It strips the album suffix, sends only the prefix to Groq, then trusts its own album value. Groq only saw `anvil will fall by harvey milk` and returned song/artist correctly. Two defects in the pre-pass: (1) the album group grabs to end-of-string and the politeness trim only removed a single trailing token, so a whole feedback sentence survived; (2) the `album` descriptor noun in `from album <title>` was kept verbatim.

## Fix

- **`_TRAILING_FEEDBACK_RE`** — cuts a politeness lead-in *and everything after it*, but only behind a sentence boundary (punctuation, comma, or a 2+ space gap). The boundary requirement is what keeps a title that merely contains a politeness word (`Pretty Please Goodbye`) intact — the observed message had `is....     thanks`, an unmistakable boundary.
- **`_LEADING_ALBUM_DESCRIPTOR_RE`** — strips a leading `album`/`record`/`lp`/`ep` (with optional `the`), anchored so a real album titled `Album` (PiL) survives a bare `off album`.

The message now yields album=`my love is`, song/artist unchanged.

## Tests (TDD, red → green)

- 4 shared-corpus positives in `tests/scenarios.py` (incl. the exact production repro) driving the parametrized pre-pass unit test.
- 2 focused guards against over-stripping (mid-title politeness word; bare `Album`/`Record` title).
- 1 mocked-Groq overlay test through `parse_request` asserting the full pipeline (`tests/unit/test_parser_album_overlay.py`).

Paired unit + overlay coverage per the repo's bug-fix protocol. The E2E smoke picks one positive *per preposition* (pre-existing first match), so the new corpus cases add **no** live-Groq calls.

## Local CI

All gates green: `ruff format --check .`, `ruff check .`, `mypy . --ignore-missing-imports`, `pytest tests/unit/` (573 passed), `uv lock --locked` + requirements diff, and `generate_api_models.sh` codegen-freshness. E2E (`external_api`) not run — it is manual-only and shares the org Groq TPM bucket.

## Scope note

Feedback clauses that don't start with a politeness word (`...my love is....   you guys rock!`) are still not trimmed — generalizing that is Groq's job, and song/artist stay correct there regardless. The lead-in set is held identical to the existing `_TRAILING_POLITENESS_RE` set to keep the false-positive surface flat.