### PR TITLE
chore: regenerate api_models from wxyc-shared main

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -815,7 +815,11 @@ class Concert(BaseModel):
     )
     station_recommended: bool | None = Field(
         None,
-        description='True when the concert\'s resolved headliner (`headlining_artist_id`) has at least one WXYC library release that has been in rotation — any rotation row, past or present ("has been in rotation", not "currently in rotation"). Omitted or false for concerts with no library-resolved headliner, including Discogs-only resolutions (`headlining_discogs_artist_id` without `headlining_artist_id` in the Backend), which by construction have no library releases to hold rotation membership. The rotation-membership signal behind the On Tour "For You" station tier ("WXYC recommends", WXYC/wxyc-ios-64#576); replaces the deprecated `station_plays`. Identical for every listener; carries no listener data. Optional (not in `required`) so it can land ahead of the Backend-Service emitter and older clients decode forward-compatibly — same discipline as `Concert.similar_artists`.',
+        description='True when the concert\'s resolved headliner (`headlining_artist_id`) has at least one WXYC library release that has been in rotation — any rotation row, past or present ("has been in rotation", not "currently in rotation"). Omitted or false for concerts with no library-resolved headliner, including Discogs-only resolutions (`headlining_discogs_artist_id` without `headlining_artist_id` in the Backend), which by construction have no library releases to hold rotation membership. The rotation-membership signal behind the On Tour "For You" station tier ("WXYC recommends", WXYC/wxyc-ios-64#576); replaces the deprecated `station_plays`. This is the GATE (rotation membership) — see `station_recommended_rank` for the plays-ordered selection rank within that gate. Identical for every listener; carries no listener data. Optional (not in `required`) so it can land ahead of the Backend-Service emitter and older clients decode forward-compatibly — same discipline as `Concert.similar_artists`.',
+    )
+    station_recommended_rank: int | None = Field(
+        None,
+        description="1-based rank of this concert within the station's \"WXYC recommends\" set — among upcoming concerts whose resolved headliner is in rotation (station_recommended = true), ordered by the station's ranking signal (all-time WXYC plays), rank 1 = strongest. Null when the concert is not in the set (headliner not rotation-gated). This is the field the client sorts the station tier by; station_recommended is the gate (rotation membership), this is the plays-ordered selection rank within that gate. Identical for every listener; carries no listener data. Optional (not in `required`) and nullable so it can land ahead of the Backend-Service emitter and older clients decode forward-compatibly — same discipline as `Concert.station_plays`.",
     )
     artist_bio: str | None = Field(
         None,
@@ -1896,6 +1900,10 @@ class ArtistMetadataResponse(BaseModel):
     bio: str | None = Field(None, description="Artist biography from Discogs")
     wikipediaUrl: str | None = Field(None, description="Wikipedia URL for the artist")
     imageUrl: str | None = Field(None, description="Artist image URL from Discogs")
+    bioTokens: list[DiscogsResolvedToken] | None = Field(
+        None,
+        description="Pre-parsed structured tokens from the artist's Discogs profile markup. Pass-through of DiscogsArtistDetails.profile_tokens, so clients can share token rendering across the two payloads.\n",
+    )
 
 
 class ArtworkSearchResponse(BaseModel):


### PR DESCRIPTION
## What

Mechanical catch-up of `generated/api_models.py` to the wxyc-shared **main** contract, via `scripts/generate_api_models.sh` (no hand edits). Adds `Concert.station_recommended_rank` and `ArtistMetadataResponse.bioTokens`, and refreshes the `Concert.station_recommended` description.

## Why now

The `Codegen Freshness` CI job regenerates from wxyc-shared main and diffs against the committed models; that contract advanced (On Tour "WXYC recommends" ranking + Discogs bio tokens), so the check is currently red on `main` and on every open PR. This is the repo's routine regen chore — it un-reds the shared check for all in-flight PRs.

## Verification

- Diff is exactly the three expected additions (+9/-1); nothing else.
- Idempotent: re-running the generator produces no further diff, so `git diff --exit-code generated/` passes.
