### PR TITLE
fix(#193): decline album pre-pass when a "by <artist>" clause is in the album tail

### DIFF
--- a/services/parser.py
+++ b/services/parser.py
@@ -132,6 +132,11 @@ _PREP_TOKEN_PRESCREEN_RE = re.compile(
 # prepositions themselves carry enough signal.
 _REQUEST_SIGNAL_RE = re.compile(r"\bby\b|,", re.IGNORECASE)
 
+# A standalone "by" authorship token. In the album text it marks a trailing
+# "by <artist>" clause (the reverse-order shape below); it is not matched inside
+# words ("baby", "goodbye", "rugby") thanks to the word boundaries.
+_ARTIST_BY_TOKEN_RE = re.compile(r"\bby\b", re.IGNORECASE)
+
 
 # Trailing words that look like an album in surface form but are idioms.
 # Compare against the *first* significant token after the preposition.
@@ -241,6 +246,19 @@ def extract_album_prefix(raw_message: str) -> tuple[str, str] | None:
         return None
 
     prefix = match.group("prefix").strip()
+
+    # Reverse-order shape "<song> {prep} <album> by <artist>": the album group is
+    # anchored to end-of-string, so a trailing "by <artist>" authorship clause is
+    # swallowed into the album ("neptune by prince jammy") and Groq -- handed only
+    # the "<song>" prefix -- cannot recover the artist. An album title can itself
+    # contain "by" ("Death By Chocolate", "One By One"), so we cannot safely split
+    # the clause off here; decline instead and defer the whole message to Groq's
+    # world knowledge. Gate on the prefix NOT already naming an artist (no "by"/
+    # comma before the preposition): when it has -- the pre-pass's core case, e.g.
+    # "moon pix by cat power off death by chocolate" -- the album's "by" is title
+    # text, so keep firing. WXYC/request-o-matic#193 (sibling of #188).
+    if _ARTIST_BY_TOKEN_RE.search(album_raw) and _REQUEST_SIGNAL_RE.search(prefix) is None:
+        return None
 
     # `from` has a different false-positive surface than `on`/`off`/`off of`:
     # the album side after `from` is typically a proper noun (boston, new york),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -32,6 +32,7 @@ from tests.scenarios import (
     PLUG_ALIAS,
     PLUG_COMMA_FORMAT,
     PLUG_NO_ALBUM,
+    PRINCE_JAMMY_REVERSE_ARTIST,
     QUIXOTIC_SPECIAL_CHARS,
     RAGA_UNSPECIFIED_ARTIST,
     SARA_FLEETWOOD_MAC_GREETING,
@@ -261,6 +262,52 @@ class TestParserIntegration:
         assert result.album is None, f"Expected album to be null, got: {result.album}"
 
         print("  ✅ Parser extracted only names from the original message!")
+
+    @pytest.mark.asyncio
+    @skip_if_no_groq
+    async def test_reverse_order_album_by_artist_does_not_null_artist(self):
+        """Reverse-order "<song> on <album> by <artist>" recovers the artist.
+
+        Bug: "conspiracy on neptune by prince jammy" fired the album pre-pass,
+        which greedily swallowed the trailing "by <artist>" clause into the album
+        ("neptune by prince jammy") and left artist null -- so the search fell back
+        to the compilation strategy and returned unrelated 'various' comps.
+
+        Fix: the pre-pass declines this shape (prefix names no artist yet), so Groq
+        parses the whole message and recovers the artist. This asserts the two
+        defects the listener saw are gone -- the artist is non-null and the album is
+        no longer polluted with the artist name -- without pinning Groq's exact
+        song/album split (it merges "conspiracy on neptune" into the song title).
+        """
+        from groq import AsyncGroq
+
+        from services.parser import parse_request
+
+        client = AsyncGroq(api_key=GROQ_API_KEY)
+        s = PRINCE_JAMMY_REVERSE_ARTIST
+        assert s.artist is not None
+
+        result = await parse_request(s.raw_message, client)
+
+        print("\n📝 Parsed result:")
+        print(f"  Song: {result.song}")
+        print(f"  Artist: {result.artist}")
+        print(f"  Album: {result.album}")
+
+        assert result.is_request is True, "Should recognize as a request"
+
+        # Defect 1 gone: the artist is recovered (was null).
+        assert result.artist is not None, "Artist must not be null for the reverse-order shape"
+        assert "prince jammy" in result.artist.lower(), (
+            f"Expected artist 'Prince Jammy', got: {result.artist}"
+        )
+
+        # Defect 2 gone: the album is no longer polluted with the "by <artist>" clause.
+        assert result.album is None or "prince jammy" not in result.album.lower(), (
+            f"Album must not carry the artist clause, got: {result.album}"
+        )
+
+        print("  ✅ Reverse-order shape recovers the artist, album not polluted!")
 
     @pytest.mark.asyncio
     @skip_if_no_groq

--- a/tests/scenarios.py
+++ b/tests/scenarios.py
@@ -283,6 +283,21 @@ ETERNAL_HALLUCINATION = _register(
     tags=frozenset({"parser", "hallucination"}),
 )
 
+PRINCE_JAMMY_REVERSE_ARTIST = _register(
+    id="prince_jammy_reverse_artist",
+    description="Reverse-order '<song> on <album> by <artist>' must not null the artist",
+    raw_message="conspiracy on neptune by prince jammy",
+    artist="Prince Jammy",
+    song="Conspiracy",
+    album="Neptune",
+    bug=(
+        "Album pre-pass fired on the reverse-order shape and swallowed the trailing "
+        "'by <artist>' clause into the album ('neptune by prince jammy'), leaving artist "
+        "null. The pre-pass now declines this shape so Groq recovers the artist."
+    ),
+    tags=frozenset({"parser", "prepass", "reverse_artist"}),
+)
+
 SPOONFUL_DASH_FORMAT = _register(
     id="spoonful_dash_format",
     description="Dash-separated 'Spoonful-Cream-Wheels of Fire lp' parsed correctly",
@@ -575,6 +590,24 @@ ALBUM_PREPASS_CASES: list[AlbumPrepassCase] = [
     ),
     # -- Negatives: pre-pass must decline (idioms, greetings, bare short-forms).
     # The id documents the tail that a false-fire would wrongly capture as album.
+    # Reverse-order "<song> {prep} <album> by <artist>": the greedy album group
+    # swallows the trailing "by <artist>" clause, so the album becomes
+    # "neptune by prince jammy" and Groq -- handed only the "conspiracy" prefix --
+    # cannot recover the artist. Because an album title may legitimately contain
+    # "by" ("Death By Chocolate"), the pre-pass cannot safely split it; it declines
+    # whenever the prefix has not already named an artist and defers the whole
+    # message to Groq's world knowledge. See PRINCE_JAMMY_REVERSE_ARTIST and
+    # WXYC/request-o-matic#193.
+    AlbumPrepassCase(
+        id="prince_jammy_on_neptune_by_artist",
+        raw_message="conspiracy on neptune by prince jammy",
+        preposition="on",
+    ),
+    AlbumPrepassCase(
+        id="conspiracy_on_death_by_chocolate",
+        raw_message="conspiracy on death by chocolate",
+        preposition="on",
+    ),
     AlbumPrepassCase(
         id="catpower_on_the_radio",
         raw_message="moon pix by cat power on the radio",

--- a/tests/unit/test_album_extraction.py
+++ b/tests/unit/test_album_extraction.py
@@ -162,6 +162,36 @@ def test_returns_none_for_messages_without_album_marker() -> None:
     assert extract_album_prefix("Spoonful-Cream-Wheels of Fire lp") is None
 
 
+def test_declines_when_album_tail_carries_an_unclaimed_artist_clause() -> None:
+    """Reverse-order "<song> {prep} <album> by <artist>" declines -> defers to Groq.
+
+    The greedy album group swallows the trailing "by <artist>" authorship clause
+    ("neptune by prince jammy"), which pollutes the album *and* starves Groq of the
+    artist (it only ever sees the "conspiracy" prefix). An album title can
+    legitimately contain "by" ("Death By Chocolate", "One By One"), so the pre-pass
+    cannot safely split it here -- it declines whenever the prefix has not already
+    named an artist, handing the whole message to Groq's world knowledge instead.
+    """
+    assert extract_album_prefix("conspiracy on neptune by prince jammy") is None
+    # Same shape, but the "by" belongs to a real album title -- also declined, so
+    # Groq (not the regex) decides album vs artist.
+    assert extract_album_prefix("conspiracy on death by chocolate") is None
+
+
+def test_still_fires_when_prefix_already_names_the_artist() -> None:
+    """A "by <artist>" already in the prefix means the album's own "by" is title text.
+
+    "moon pix by cat power off death by chocolate" already identifies the artist
+    before the preposition, so the album's "by" ("Death By Chocolate") is part of
+    the title, not an unclaimed artist -- the pre-pass keeps extracting the album.
+    """
+    result = extract_album_prefix("moon pix by cat power off death by chocolate")
+    assert result is not None
+    album, stripped = result
+    assert album.strip().lower() == "death by chocolate"
+    assert stripped.strip().lower() == "moon pix by cat power"
+
+
 def test_returns_none_for_empty_input() -> None:
     """Defensive: empty input returns None instead of raising."""
     assert extract_album_prefix("") is None

--- a/tests/unit/test_parser_album_overlay.py
+++ b/tests/unit/test_parser_album_overlay.py
@@ -101,6 +101,39 @@ async def test_no_overlay_when_pre_pass_declines() -> None:
 
 
 @pytest.mark.asyncio
+async def test_no_overlay_and_full_message_when_album_tail_carries_artist() -> None:
+    """Reverse-order "<song> on <album> by <artist>": pre-pass declines.
+
+    The trailing "by <artist>" clause would otherwise be swallowed into the album
+    (and the artist nulled). The pre-pass declines, so Groq sees the *whole*
+    message -- artist clause intact -- and its artist survives. No album overlay.
+    """
+    client = _make_mock_groq(
+        {
+            "song": "Conspiracy on Neptune",
+            "album": None,
+            "artist": "Prince Jammy",
+            "is_request": True,
+            "message_type": "request",
+        }
+    )
+
+    result = await parse_request("conspiracy on neptune by prince jammy", client)
+
+    # No overlay: Groq's null album stands (not the polluted "neptune by prince jammy").
+    assert result.album is None
+    assert result.artist == "Prince Jammy"
+
+    # Pre-pass declined -> Groq received the whole message, "by <artist>" and album
+    # text both present (nothing was stripped).
+    call_args = client.chat.completions.create.await_args
+    user_msg = next(m for m in call_args.kwargs["messages"] if m["role"] == "user")
+    user_content = user_msg["content"].lower()
+    assert "by prince jammy" in user_content
+    assert "neptune" in user_content
+
+
+@pytest.mark.asyncio
 async def test_groq_receives_stripped_message_when_pre_pass_fires() -> None:
     """Pre-pass strips the trailing 'on <album>' suffix before Groq sees it.
 


### PR DESCRIPTION
Closes #193.

## Problem

The album pre-pass (`services/parser.py::extract_album_prefix`) fires on the reverse-order request shape `<song> {on|from|off|off of} <album> by <artist>`. Because the album capture group is anchored to end-of-string, it swallows the trailing `by <artist>` authorship clause into the album. `conspiracy on neptune by prince jammy` parsed as:

- song `Conspiracy`
- album `neptune by prince jammy` — the artist clause leaked in
- artist _null_ — Groq only ever saw the stripped `conspiracy` prefix

so search fell back to the `compilation` strategy and returned unrelated `various` comps.

## Fix

An album title can legitimately contain `by` ("Death By Chocolate", "One By One"), so the clause can't be safely split off in the regex. The pre-pass **declines** when the album text has a standalone `by` **and** the prefix hasn't already named an artist (no `by`/comma before the preposition), deferring the whole message to Groq — which recovers `artist="Prince Jammy"` and drops the polluted album. When the prefix already names an artist (`moon pix by cat power off death by chocolate`), the album's `by` is title text and the pre-pass keeps firing. This stays in the module's "decline when ambiguous" lineage (sibling of #188) rather than adding an aggressive split.

## Tests (bug-fix protocol: paired unit + integration)

- **Unit** — `extract_album_prefix` declines the reverse shape (incl. the ambiguous `death by chocolate` case) and still fires when the prefix names the artist; overlay decline-path with mocked Groq confirms the full message reaches Groq and the artist survives. Added as focused tests + shared corpus cases (`PRINCE_JAMMY_REVERSE_ARTIST`, two negative `AlbumPrepassCase`s).
- **Integration** (`external_api`, real Groq) — the reported message yields a non-null artist and an album free of the artist name.

## Verification

- Full unit suite: **589 passed**, 0 regressions
- New `external_api` E2E: passed against real Groq
- Existing album pre-pass live positives (10× determinism + per-preposition overlays): still pass
- `ruff format --check .`, `ruff check .`, `mypy`: clean
