### PR TITLE
chore(codegen): regenerate api_models.py for library_url description update

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1186,7 +1186,10 @@ class LibraryCatalogItem(BaseModel):
         ...,
         description='Full call number for shelf lookup, e.g. "Rock CD ABC 123/45". Computed from genre, format, call_letters, artist_call_number, and release_call_number.\n',
     )
-    library_url: str = Field(..., description="URL to view this release in the WXYC library")
+    library_url: str = Field(
+        ...,
+        description="Per-release dj.wxyc.org permalink for this release. Points at the dj-site legacy front door `/dashboard/album/legacy/{id}`, which resolves the legacy library `id` to the canonical release route server-side and 308-redirects. Empty string for a row-less result (`id == 0`).\n",
+    )
     on_streaming: bool | None = Field(
         None,
         description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
@@ -1797,7 +1800,10 @@ class LibrarySearchItem(BaseModel):
     label: str | None = None
     on_streaming: bool | None = None
     call_number: str | None = Field(None, description='Computed call number (e.g. "Rock CD S 1/1")')
-    library_url: str | None = Field(None, description="URL to the release on wxyc.info")
+    library_url: str | None = Field(
+        None,
+        description="Per-release dj.wxyc.org permalink for this release. Points at the dj-site legacy front door `/dashboard/album/legacy/{id}`, which resolves the legacy library `id` to the canonical release route server-side and 308-redirects. Null when unavailable.\n",
+    )
     matched_via: list[TrackMatchHint] | None = Field(
         None,
         description="Populated when a track-title match drove this release into the results (catalog-track-search plan §5.1). Empty or absent when the release matched on artist / title normally. Backward-compatible — existing consumers ignore the field.\n",


### PR DESCRIPTION
Closes #196.

## What

Regenerates the committed `generated/api_models.py` after [WXYC/wxyc-shared#269](https://github.com/WXYC/wxyc-shared/pull/269) (PR5a, merged) updated both `library_url` field descriptions. Only two `Field(description=...)` strings change:

- `LibraryCatalogItem.library_url`
- `LibrarySearchItem.library_url`

Both now describe the dj.wxyc.org `/dashboard/album/legacy/{id}` permalink (and its legacy-id → serial server-side resolution) instead of the legacy tubafrenzy target.

## Why now (the coupling)

`generated/api_models.py` is committed here and gated by the PR-only **Codegen Freshness** job, which regenerates from `wxyc-shared` **main** and `git diff --exit-code`s. PR5a is on `main`, so this repo's committed models are stale until regenerated — this PR closes that window.

## How

Pure `bash scripts/generate_api_models.sh` output, regenerated with the repo's pinned toolchain (`datamodel-code-generator==0.57.0`, `ruff==0.15.1`) so it byte-matches CI. No hand edits.

## Testing (local)

- `bash scripts/generate_api_models.sh` → re-run produces no further diff (Codegen Freshness will pass)
- `ruff check .`, `ruff format --check .` → clean (77 files)
- `mypy . --ignore-missing-imports` → Success, 77 files
- `pytest` → 580 passed, 54 deselected

## Note (separate follow-up, not in this PR)

r-o-m test fixtures still model the old library_url value — `tests/factories.py` default and `tests/unit/test_lookup_client.py` fixture use `http://www.wxyc.info/wxycdb/libraryRelease?id=...`. That's test data (r-o-m receives `library_url` from LML at runtime; it never constructs the URL), so it doesn't affect CI or production. Worth a small consistency refresh in a follow-up.

## Chain

PR5c of the dj.wxyc.org per-release permalink effort, alongside sibling regen [library-metadata-lookup#1017](https://github.com/WXYC/library-metadata-lookup/pull/1017) (PR5b).
