### PR TITLE
test: point library_url fixtures at the dj.wxyc.org permalink

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -48,7 +48,7 @@ def make_library_item(
         "call_number",
         _compute_call_number(genre, format, call_letters, artist_call_number, release_call_number),
     )
-    kwargs.setdefault("library_url", f"http://www.wxyc.info/wxycdb/libraryRelease?id={id}")
+    kwargs.setdefault("library_url", f"https://dj.wxyc.org/dashboard/album/legacy/{id}")
     return LibraryCatalogItem(
         id=id,
         artist=artist,

--- a/tests/unit/test_factories.py
+++ b/tests/unit/test_factories.py
@@ -62,7 +62,7 @@ class TestMakeLibraryItem:
 
     def test_default_library_url_includes_id(self):
         item = make_library_item(id=42)
-        assert item.library_url == "http://www.wxyc.info/wxycdb/libraryRelease?id=42"
+        assert item.library_url == "https://dj.wxyc.org/dashboard/album/legacy/42"
 
     def test_call_number_recomputed_when_components_change(self):
         item = make_library_item(genre=None, format=None, release_call_number=None)

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -36,7 +36,7 @@ SAMPLE_RESPONSE = {
                 "genre": "Rock",
                 "format": "CD",
                 "call_number": "Rock CD S 1/2",
-                "library_url": "http://www.wxyc.info/wxycdb/libraryRelease?id=42",
+                "library_url": "https://dj.wxyc.org/dashboard/album/legacy/42",
             },
             "artwork": {
                 "album": "Aluminum Tunes",


### PR DESCRIPTION
## What

Refreshes request-o-matic's `library_url` test data from the legacy tubafrenzy URL to the dj.wxyc.org per-release permalink:

```
- http://www.wxyc.info/wxycdb/libraryRelease?id={id}
+ https://dj.wxyc.org/dashboard/album/legacy/{id}
```

Three spots: the `make_library_item` factory default (`tests/factories.py`), its assertion (`tests/unit/test_factories.py::test_default_library_url_includes_id`), and a mock LML response fixture (`tests/unit/test_lookup_client.py`).

## Why

LML started emitting the dj.wxyc.org permalink for `library_url` in [library-metadata-lookup#1015](https://github.com/WXYC/library-metadata-lookup/pull/1015) (live in prod). The r-o-m fixtures still modeled the old value, giving a misleading picture of what LML sends. **Test-only, no prod impact** — request-o-matic receives `library_url` from LML at runtime and never constructs it.

This is the consistency follow-up flagged in [#196](https://github.com/WXYC/request-o-matic/issues/196) / the PR5c ([#197](https://github.com/WXYC/request-o-matic/pull/197)) body.

## Testing (local)

- TDD: flipped the `test_default_library_url_includes_id` assertion red first, then updated the factory default to green.
- `ruff check .`, `ruff format --check .` → clean
- `mypy . --ignore-missing-imports` → Success, 77 files
- `pytest` → 580 passed, 54 deselected
- Confirmed no `wxyc.info` remains in any tracked `.py` file.
