### PR TITLE
feat(#199): send include_locations and render also_available_on in the Slack request post

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -2044,6 +2044,10 @@ class LiveFsRefetchEvent(BaseModel):
     timestamp: AwareDatetime
 
 
+class Type5(StrEnum):
+    insert = "insert"
+
+
 class AutoDJState(StrEnum):
     BOOTING = "BOOTING"
     CONNECTING = "CONNECTING"
@@ -2100,7 +2104,7 @@ class AutoDJLastTrack(BaseModel):
     posted_at: int = Field(..., description="Unix timestamp")
 
 
-class Type5(StrEnum):
+class Type6(StrEnum):
     heartbeat = "heartbeat"
 
 
@@ -2133,7 +2137,7 @@ class AutoDJHeartbeat(BaseModel):
     )
 
 
-class Type6(StrEnum):
+class Type7(StrEnum):
     command = "command"
 
 
@@ -2145,7 +2149,7 @@ class AutoDJCommand(BaseModel):
     value: str | None = Field(None, description="Config value (only for set_config)")
 
 
-class Type7(StrEnum):
+class Type8(StrEnum):
     ack = "ack"
 
 
@@ -2165,7 +2169,7 @@ class AutoDJAck(BaseModel):
     )
 
 
-class Type8(StrEnum):
+class Type9(StrEnum):
     now_playing = "now_playing"
 
 
@@ -2178,7 +2182,7 @@ class AutoDJNowPlaying(BaseModel):
     is_live: bool = Field(..., description="Whether a live DJ is streaming")
 
 
-class Type9(StrEnum):
+class Type10(StrEnum):
     error = "error"
 
 
@@ -2194,7 +2198,7 @@ class AutoDJErrorReport(BaseModel):
     count: int = Field(..., description="Occurrences since last report")
 
 
-class Type10(StrEnum):
+class Type11(StrEnum):
     button_toggle = "button_toggle"
 
 
@@ -2621,8 +2625,14 @@ class LiveFsUpdateEvent(BaseModel):
     timestamp: AwareDatetime
 
 
-class LiveFsEvent(RootModel[LiveFsUpdateEvent | LiveFsRefetchEvent]):
-    root: LiveFsUpdateEvent | LiveFsRefetchEvent = Field(
+class LiveFsInsertEvent(BaseModel):
+    type: Literal["insert"]
+    payload: FlowsheetEntryResponse
+    timestamp: AwareDatetime
+
+
+class LiveFsEvent(RootModel[LiveFsUpdateEvent | LiveFsRefetchEvent | LiveFsInsertEvent]):
+    root: LiveFsUpdateEvent | LiveFsRefetchEvent | LiveFsInsertEvent = Field(
         ...,
         description="Discriminated union of events emitted on the `live-fs-topic`. Every event has the same `{ type, payload, timestamp }` envelope — pinned by `CONTRACTS.LIVE_FS_EVENT_ENVELOPE_SHAPE`.\n",
         discriminator="type",

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -401,6 +401,30 @@ class Album(BaseModel):
         None,
         description='Credited album artist for compilations (e.g., "Kruder & Dorfmeister" on a DJ-Kicks release filed under Various Artists).',
     )
+    discogsUnavailable: bool | None = Field(
+        None,
+        description="MD-set marker indicating this release is intentionally not on\nDiscogs (embargoed promo, audience-segment release, etc.). When\ntrue, the LML runtime-lookup chokepoint does not attempt Discogs\nresolution for this release. See WXYC/wiki plans/rotation-discogs-unavailable.md.\n",
+    )
+    discogsUnavailableNote: constr(max_length=500) | None = Field(
+        None, description="Optional free-text reason for `discogsUnavailable`."
+    )
+    lastDiscogsRecheckAt: AwareDatetime | None = Field(
+        None,
+        description="Stamped on every recheck attempt by the\n`library-discogs-unavailable-recheck` cron. Read-only from the\nclient side.\n",
+    )
+
+
+class UpdateAlbumRequest(BaseModel):
+    album_title: str | None = None
+    label: str | None = None
+    label_id: int | None = None
+    genre_id: int | None = None
+    format_id: int | None = None
+    artist_id: int | None = None
+    alternate_artist_name: str | None = None
+    disc_quantity: int | None = None
+    discogsUnavailable: bool | None = None
+    discogsUnavailableNote: constr(max_length=500) | None = None
 
 
 class CatalogExportRow(BaseModel):
@@ -1155,6 +1179,10 @@ class LookupRequest(BaseModel):
         False,
         description="Per cross-cache-identity plan §3.2.2 (E2-LML write contract). When true, the response carries an additional `identity` block (the §3.2.5 cascade's per-source resolution detail), and `api_version` is set to 2. When false (the default), the response is byte-identical to v0.5.0 — `identity` is absent and `api_version` is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets this to true on every call; other consumers (catalog search, dj-site proxy, iOS apps) leave it false.\n",
     )
+    include_locations: bool | None = Field(
+        False,
+        description="Per the comprehensive multi-location union (LML#1018/#1022). When true, the response carries an additional `also_available_on` array — every other WXYC library shelf location that carries the same track (V/A compilations, soundtracks), ranked by LML, so a DJ can find a backup copy when the primary is missing or checked-out. When false (the default), the response is byte-identical to today — `also_available_on` is omitted. DJ-facing callers (dj-site catalog, request-o-matic) set this; Backend enrichment does not.\n",
+    )
     extended: bool | None = Field(
         None,
         description="When true, the top-1 result's `artwork` block is populated with additional fields LML already fetches during enrichment but normally discards: `discogs_artist_id`, `tracklist`, `genres`, `styles`, `label`, `full_release_date`, `artist_image_url`, and `profile_tokens` (cache-only deep parse of the artist's profile markup). Lets a caller obtain a full playcut metadata payload in a single `/lookup` call instead of following up with separate `/discogs/release/{id}` and `/discogs/artist/{id}` requests. Absent or false leaves the response shape unchanged.\n",
@@ -1233,6 +1261,37 @@ class DegradedReason(StrEnum):
     deadline_exceeded = "deadline_exceeded"
     cache_only = "cache_only"
     upstream_unavailable = "upstream_unavailable"
+
+
+class CreditRole(StrEnum):
+    primary = "primary"
+    featured = "featured"
+    extra = "extra"
+
+
+class LibraryLocation(BaseModel):
+    library_id: int = Field(..., description="WXYC library.id (shelf location) for this copy.")
+    artist: str | None = Field(None, description='Shelf/album artist (e.g. "Soundtracks - L").')
+    album_title: str | None = Field(
+        None, description='Album/release title (e.g. "Lost in Translation").'
+    )
+    track_position: str | None = Field(
+        None, description='The track\'s position on this release (e.g. "A1"), when known.'
+    )
+    track_title: str = Field(..., description="Track title.")
+    track_artist: str = Field(
+        ...,
+        description='Credited-as artist for this track (e.g. "Brian Reitzell And Roger J. Manning, Jr."), which may differ from the shelf artist on a compilation.\n',
+    )
+    credit_role: CreditRole | None = Field(
+        None, description="The role this credit represents on the track."
+    )
+    discogs_release_id: int | None = Field(
+        None, description="Discogs release ID, usable as an art re-resolution key."
+    )
+    artwork_url: str | None = Field(
+        None, description="Precomputed cover art URL for this location."
+    )
 
 
 class IdentitySource(StrEnum):
@@ -2532,6 +2591,10 @@ class LookupResponse(BaseModel):
     timeout: bool | None = Field(
         False,
         description="True when LML's server-side hard cap fired and the search pipeline was abandoned mid-execution (LML#370). `results` may be partial or empty in that case. Callers can use this to distinguish \"no match\" (empty `results`, `timeout: false`) from \"ran out of time\" (`results` may be empty, `timeout: true`). The hard cap is an internal LML safety floor independent of the caller's `X-Caller-Budget-Ms` header; see LML#338 / LML#340 / LML#370 for the cascade-budget design. Backend also forwards two sibling informal headers on the same `/lookup` and `/lookup/bulk` requests, both prose-referenced here rather than formal parameters (matching `X-Caller-Budget-Ms`'s own precedent): `X-Caller-Class` (the resolved BS→LML traffic class, an integer 1-5 per Backend-Service's per-caller policy, BS#1826) and `X-Caller-Reason` (the `caller` label string itself, e.g. `proxy-library-search` or `catalog-popularity-freetext-resolve`). Both are sent only when Backend has a registered caller for the request and are otherwise omitted; sending them is inert until LML reads them (LML#928 for `X-Caller-Class`-driven lane routing, LML#931 for `X-Caller-Reason` caller telemetry) — see BS#1843.\n",
+    )
+    also_available_on: list[LibraryLocation] | None = Field(
+        None,
+        description="Every other WXYC library shelf location that carries the same track (V/A compilations, soundtracks), ranked by LML so consumers can render in order. Present only when the request set `include_locations: true`; absent otherwise (empty when the flag is set but no other location carries the track) so existing consumers see a byte-identical response (LML#1018/#1022).\n",
     )
     degraded: bool | None = Field(
         False,

--- a/routers/request.py
+++ b/routers/request.py
@@ -44,6 +44,7 @@ from core.server_timing import parse_server_timing
 
 if TYPE_CHECKING:
     from posthog import Posthog
+from generated.api_models import LibraryLocation
 from models import LibraryItem, ReleaseMetadata
 from services.ban_check_client import BanCheckClient, BanCheckUnavailableError
 from services.lookup_client import LookupRequest, LookupServiceClient
@@ -120,6 +121,7 @@ async def post_results_to_slack(
     parsed: ParsedRequest,
     items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]],
     context: str | None = None,
+    also_available_on: list[LibraryLocation] | None = None,
 ) -> None:
     """Post formatted results to Slack.
 
@@ -129,6 +131,8 @@ async def post_results_to_slack(
         parsed: Parsed request
         items_with_artwork: Library items with their artwork
         context: Optional context message
+        also_available_on: Ranked alternate WXYC shelf locations for the track,
+            appended as an extra block when present (LML#1018/#1022)
 
     Raises:
         HTTPException: If posting to Slack fails
@@ -138,7 +142,7 @@ async def post_results_to_slack(
         return
 
     if items_with_artwork:
-        blocks = build_slack_blocks(message, items_with_artwork, context)
+        blocks = build_slack_blocks(message, items_with_artwork, context, also_available_on)
     elif not parsed.is_request:
         label = MESSAGE_TYPE_LABELS.get(parsed.message_type, "Other")
         blocks = build_simple_slack_blocks(message, f"_{label}_")
@@ -431,6 +435,7 @@ async def handle_request(
 
     library_results: list[LibraryItem] = []
     items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]] = []
+    also_available_on: list[LibraryLocation] = []
     song_not_found = False
     found_on_compilation = False
     context: str | None = None
@@ -456,6 +461,11 @@ async def handle_request(
                 song=parsed.song,
                 album=parsed.album,
                 raw_message=request.message,
+                # DJ-facing request fan-out: opt into the comprehensive multi-location
+                # union so the Slack post can show alternate WXYC shelf locations for the
+                # track (LML#1018/#1022). Not the enrichment path, so opting in is fine;
+                # absent/empty also_available_on renders nothing extra.
+                include_locations=True,
             )
             try:
                 lookup_result = await lookup_client.lookup(
@@ -488,6 +498,10 @@ async def handle_request(
         results = [item for item in results if item.library_item.id > 0]
         library_results = [item.library_item for item in results]
         items_with_artwork = [(item.library_item, item.artwork) for item in results]
+        # Alternate WXYC shelf locations for the track, ranked by LML (LML#1018/#1022).
+        # Present only when include_locations was set and a song was resolved; empty
+        # otherwise, so the Slack post is byte-identical to before.
+        also_available_on = lookup_response.also_available_on or []
         search_type = str(lookup_response.search_type or "none")
         song_not_found = bool(lookup_response.song_not_found)
         found_on_compilation = bool(lookup_response.found_on_compilation)
@@ -515,7 +529,12 @@ async def handle_request(
                 )
             else:
                 await post_results_to_slack(
-                    slack_service, request.message, parsed, items_with_artwork, context
+                    slack_service,
+                    request.message,
+                    parsed,
+                    items_with_artwork,
+                    context,
+                    also_available_on=also_available_on,
                 )
 
     # Extract main artwork from first result

--- a/services/slack.py
+++ b/services/slack.py
@@ -1,17 +1,55 @@
 import logging
 from typing import Any
 
+from generated.api_models import LibraryLocation
 from models import LibraryItem, ReleaseMetadata, preview_url
 
 logger = logging.getLogger(__name__)
+
+# Per-release permalink template (LML#1014 / dj-site#1050). LibraryLocation carries
+# only a library_id (the union is deliberately lean — no live URL resolution), so we
+# rebuild the same dj-site legacy front door LML emits for LibraryItem.library_url.
+_LIBRARY_PERMALINK_BASE = "https://dj.wxyc.org/dashboard/album/legacy"
+
+# Cap the alternate-locations section so a track carried on many compilations can't
+# overflow Slack's 3000-char section-text limit. Overflow is summarized as "…and N more".
+_MAX_ALSO_AVAILABLE_LOCATIONS = 10
+
+
+def _also_available_block(locations: list[LibraryLocation]) -> dict:
+    """Render the ranked alternate shelf locations as one Slack section block.
+
+    LML ranks ``also_available_on``; we preserve that order and link each entry to
+    its dj.wxyc.org shelf permalink so a DJ can pull a backup copy.
+    """
+    lines = ["*Also available on:*"]
+    for loc in locations[:_MAX_ALSO_AVAILABLE_LOCATIONS]:
+        title = loc.album_title or loc.track_title or "Unknown release"
+        url = f"{_LIBRARY_PERMALINK_BASE}/{loc.library_id}"
+        parts = [f"<{url}|{title}>"]
+        if loc.artist:
+            parts.append(f"— {loc.artist}")
+        if loc.track_position:
+            parts.append(f"({loc.track_position})")
+        lines.append("• " + " ".join(parts))
+    remaining = len(locations) - _MAX_ALSO_AVAILABLE_LOCATIONS
+    if remaining > 0:
+        lines.append(f"_…and {remaining} more_")
+    return {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}}
 
 
 def build_slack_blocks(
     message: str,
     items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]],
     context: str | None = None,
+    also_available_on: list[LibraryLocation] | None = None,
 ) -> list[dict]:
-    """Build Slack message blocks from library results with artwork."""
+    """Build Slack message blocks from library results with artwork.
+
+    When ``also_available_on`` is non-empty, a trailing "Also available on" section
+    lists the other WXYC shelf locations carrying the same track (LML#1018/#1022).
+    Absent or empty, the output is byte-identical to before.
+    """
     blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": f"*{message}*"}}]
 
     # Add context message if provided (e.g., "song not found, showing artist albums")
@@ -47,6 +85,9 @@ def build_slack_blocks(
             }
 
         blocks.append(block)
+
+    if also_available_on:
+        blocks.append(_also_available_block(also_available_on))
 
     return blocks
 

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -15,7 +15,7 @@ from core.dependencies import (
     get_posthog_client,
     get_slack_service,
 )
-from generated.api_models import SearchType
+from generated.api_models import LibraryLocation, SearchType
 from routers.request import router
 from services.lookup_client import (
     LookupResponse,
@@ -139,6 +139,65 @@ class TestDelegationBranch:
         assert data["artwork"]["artwork_url"] == "https://img.discogs.com/test.jpg"
         assert data["song_not_found"] is False
         assert data["found_on_compilation"] is False
+
+    @pytest.mark.asyncio
+    async def test_delegation_requests_locations(
+        self, app, mock_lookup_client, sample_lookup_response
+    ):
+        """The DJ-facing request opts into the multi-location union (ROM#199)."""
+        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                await client.post(
+                    "/api/v1/request",
+                    json={"message": "play tommib by squarepusher", "skip_slack": True},
+                )
+
+        sent_request = mock_lookup_client.lookup.call_args.args[0]
+        assert sent_request.include_locations is True
+
+    @pytest.mark.asyncio
+    async def test_also_available_on_reaches_slack_post(
+        self, app, mock_lookup_client, mock_slack, sample_lookup_response
+    ):
+        """also_available_on from LML surfaces as an extra Slack block."""
+        response = sample_lookup_response.model_copy(
+            update={
+                "also_available_on": [
+                    LibraryLocation(
+                        library_id=60654,
+                        album_title="Lost in Translation",
+                        artist="Soundtracks - L",
+                        track_position="A1",
+                        track_title="tommib",
+                        track_artist="Squarepusher",
+                    )
+                ]
+            }
+        )
+        mock_lookup_client.lookup.return_value = _lr(response)
+
+        with patch(
+            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                await client.post(
+                    "/api/v1/request",
+                    json={"message": "play tommib by squarepusher"},
+                )
+
+        mock_slack.post_blocks.assert_awaited_once()
+        posted_blocks = mock_slack.post_blocks.call_args.args[0]
+        rendered = json.dumps(posted_blocks)
+        assert "Lost in Translation" in rendered
+        assert "dashboard/album/legacy/60654" in rendered
 
     @pytest.mark.asyncio
     async def test_delegation_maps_response_fields(self, app, mock_lookup_client):

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -401,9 +401,10 @@ class TestLookupModels:
             "song": "la paradoja",
             "album": "DOGA",
             "raw_message": "msg",
-            # include_identity is a non-optional bool with a False default, so it
-            # survives exclude_none (added to the LookupRequest contract upstream).
+            # include_identity and include_locations both default to False (not None),
+            # so they survive exclude_none — the request builder here leaves them unset.
             "include_identity": False,
+            "include_locations": False,
         }
 
     def test_lookup_response_defaults(self):

--- a/tests/unit/test_slack_service.py
+++ b/tests/unit/test_slack_service.py
@@ -2,9 +2,22 @@
 
 import pytest
 
+from generated.api_models import LibraryLocation
 from models import ReleaseMetadata
 from services.slack import build_simple_slack_blocks, build_slack_blocks
 from tests.factories import make_library_item, make_release_metadata
+
+
+def _location(library_id, album_title, artist, track_position=None):
+    """Build a LibraryLocation the way LML returns it in also_available_on."""
+    return LibraryLocation(
+        library_id=library_id,
+        album_title=album_title,
+        artist=artist,
+        track_position=track_position,
+        track_title="tommib",
+        track_artist="Squarepusher",
+    )
 
 
 @pytest.fixture
@@ -199,6 +212,71 @@ class TestBuildSlackBlocks:
 
         item_block = blocks[1]
         assert "Unknown Artist" in item_block["text"]["text"]
+
+
+class TestAlsoAvailableOn:
+    """Tests for rendering LookupResponse.also_available_on (ROM#199)."""
+
+    def test_absent_locations_are_byte_identical(self, sample_library_item):
+        """No also_available_on (None, [], or omitted) leaves the blocks unchanged."""
+        baseline = build_slack_blocks(
+            message="Here's what I found:",
+            items_with_artwork=[(sample_library_item, None)],
+        )
+        assert (
+            build_slack_blocks(
+                message="Here's what I found:",
+                items_with_artwork=[(sample_library_item, None)],
+                also_available_on=None,
+            )
+            == baseline
+        )
+        assert (
+            build_slack_blocks(
+                message="Here's what I found:",
+                items_with_artwork=[(sample_library_item, None)],
+                also_available_on=[],
+            )
+            == baseline
+        )
+
+    def test_renders_ranked_locations_in_order(self, sample_library_item):
+        """A populated also_available_on appends one section listing each location."""
+        locations = [
+            _location(60654, "Lost in Translation", "Soundtracks - L", track_position="A1"),
+            _location(70001, "Go Plastic", "Squarepusher"),
+        ]
+        blocks = build_slack_blocks(
+            message="Here's what I found:",
+            items_with_artwork=[(sample_library_item, None)],
+            also_available_on=locations,
+        )
+        # An extra block beyond the header + single item.
+        assert len(blocks) == 3
+        extra = blocks[-1]
+        assert extra["type"] == "section"
+        text = extra["text"]["text"]
+        # Both releases are named, and the ranked order is preserved.
+        assert "Lost in Translation" in text
+        assert "Go Plastic" in text
+        assert text.index("Lost in Translation") < text.index("Go Plastic")
+        # Each entry links to the dj.wxyc.org shelf permalink built from library_id.
+        assert "https://dj.wxyc.org/dashboard/album/legacy/60654" in text
+        assert "https://dj.wxyc.org/dashboard/album/legacy/70001" in text
+        # The shelf artist and position are surfaced for the DJ pulling the copy.
+        assert "Soundtracks - L" in text
+        assert "A1" in text
+
+    def test_caps_long_lists_with_overflow_note(self, sample_library_item):
+        """A pathologically long union is capped so the Slack section stays lean."""
+        locations = [_location(1000 + i, f"Compilation {i}", "Various Artists") for i in range(25)]
+        blocks = build_slack_blocks(
+            message="Here's what I found:",
+            items_with_artwork=[(sample_library_item, None)],
+            also_available_on=locations,
+        )
+        text = blocks[-1]["text"]["text"]
+        assert "more" in text.lower()
 
 
 class TestBuildSimpleSlackBlocks:


### PR DESCRIPTION
## What

The DJ-facing request fan-out now opts into LML's comprehensive multi-location union (LML#1018/#1022):

- `LookupRequest` sets `include_locations=True` (only here — the DJ-facing request path, not enrichment).
- When LML returns a ranked `also_available_on`, the Slack post appends an **"Also available on"** section listing the other WXYC shelf locations that carry the requested track, each linked to its `dj.wxyc.org` permalink so a DJ can pull a backup copy when the primary is missing or checked-out.
- Regenerates `generated/api_models.py` to pick up `LookupRequest.include_locations`, `LookupResponse.also_available_on`, and `LibraryLocation` from the wxyc-shared contract (WXYC/wxyc-shared#270, published as `@wxyc/shared` v2.5.0).

## Behavior

Additive and gated on LML's server-side kill switch plus a resolved song, so an **absent or empty `also_available_on` renders byte-identical Slack blocks to before**. The alternate-locations section is capped at 10 entries (with a "…and N more" summary) to stay under Slack's section-text limit.

## Tests (TDD)

- `build_slack_blocks` renders the ranked list when present and is byte-identical when absent/empty; long lists are capped.
- The delegation branch sends `include_locations=True` and surfaces `also_available_on` in the posted Slack blocks.

Implements the request-o-matic consumer side (step 4) of the WXYC/library-metadata-lookup#1027 enablement tracker.

Closes #199