### PR TITLE
Revert #199: drop include_locations / also_available_on, locations now fold into results

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -2524,7 +2524,7 @@ class LookupResultItem(BaseModel):
     reconciled_identity: ReconciledIdentity | None = None
     matched_via: list[TrackMatchHint] | None = Field(
         None,
-        description="Populated when a track-title match drove this release into the results. Two producers: LML's SONG_AS_TRACK strategy (per catalog-track-search plan §5.1) for the primary match, and the comprehensive multi-location union (LML#1018/#1019/#1022) for every other WXYC shelf location carrying the same track (V/A compilations, soundtracks) — those rows are folded directly into `results` alongside the primary, tagged with `source: discogs_release` since the recall index is Discogs-release- derived. Empty or absent when the release matched via artist/album strategies. Backward-compatible — existing consumers ignore the field.\n",
+        description="Populated when a track-title match drove this release into the results. Two producers: LML's SONG_AS_TRACK strategy (per catalog-track-search plan §5.1) for the primary match, and the comprehensive multi-location union (LML#1018/#1019/#1022) for every other WXYC shelf location carrying the same track (V/A compilations, soundtracks) — those rows are folded directly into `results` alongside the primary, tagged with `source: discogs_release` since the recall index is Discogs-release-derived. Empty or absent when the release matched via artist/album strategies. Backward-compatible — existing consumers ignore the field.\n",
     )
     matched_via_alias: list[ArtistMatchHint] | None = Field(
         None,

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1179,10 +1179,6 @@ class LookupRequest(BaseModel):
         False,
         description="Per cross-cache-identity plan §3.2.2 (E2-LML write contract). When true, the response carries an additional `identity` block (the §3.2.5 cascade's per-source resolution detail), and `api_version` is set to 2. When false (the default), the response is byte-identical to v0.5.0 — `identity` is absent and `api_version` is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets this to true on every call; other consumers (catalog search, dj-site proxy, iOS apps) leave it false.\n",
     )
-    include_locations: bool | None = Field(
-        False,
-        description="Per the comprehensive multi-location union (LML#1018/#1022). When true, the response carries an additional `also_available_on` array — every other WXYC library shelf location that carries the same track (V/A compilations, soundtracks), ranked by LML, so a DJ can find a backup copy when the primary is missing or checked-out. When false (the default), the response is byte-identical to today — `also_available_on` is omitted. DJ-facing callers (dj-site catalog, request-o-matic) set this; Backend enrichment does not.\n",
-    )
     extended: bool | None = Field(
         None,
         description="When true, the top-1 result's `artwork` block is populated with additional fields LML already fetches during enrichment but normally discards: `discogs_artist_id`, `tracklist`, `genres`, `styles`, `label`, `full_release_date`, `artist_image_url`, and `profile_tokens` (cache-only deep parse of the artist's profile markup). Lets a caller obtain a full playcut metadata payload in a single `/lookup` call instead of following up with separate `/discogs/release/{id}` and `/discogs/artist/{id}` requests. Absent or false leaves the response shape unchanged.\n",
@@ -1261,37 +1257,6 @@ class DegradedReason(StrEnum):
     deadline_exceeded = "deadline_exceeded"
     cache_only = "cache_only"
     upstream_unavailable = "upstream_unavailable"
-
-
-class CreditRole(StrEnum):
-    primary = "primary"
-    featured = "featured"
-    extra = "extra"
-
-
-class LibraryLocation(BaseModel):
-    library_id: int = Field(..., description="WXYC library.id (shelf location) for this copy.")
-    artist: str | None = Field(None, description='Shelf/album artist (e.g. "Soundtracks - L").')
-    album_title: str | None = Field(
-        None, description='Album/release title (e.g. "Lost in Translation").'
-    )
-    track_position: str | None = Field(
-        None, description='The track\'s position on this release (e.g. "A1"), when known.'
-    )
-    track_title: str = Field(..., description="Track title.")
-    track_artist: str = Field(
-        ...,
-        description='Credited-as artist for this track (e.g. "Brian Reitzell And Roger J. Manning, Jr."), which may differ from the shelf artist on a compilation.\n',
-    )
-    credit_role: CreditRole | None = Field(
-        None, description="The role this credit represents on the track."
-    )
-    discogs_release_id: int | None = Field(
-        None, description="Discogs release ID, usable as an art re-resolution key."
-    )
-    artwork_url: str | None = Field(
-        None, description="Precomputed cover art URL for this location."
-    )
 
 
 class IdentitySource(StrEnum):
@@ -2559,7 +2524,7 @@ class LookupResultItem(BaseModel):
     reconciled_identity: ReconciledIdentity | None = None
     matched_via: list[TrackMatchHint] | None = Field(
         None,
-        description="Populated when a track-title match (LML's new SONG_AS_TRACK strategy) drove this release into the results, per catalog-track-search plan §5.1. Empty or absent when the release matched via artist/album strategies. Backward-compatible — existing consumers ignore the field.\n",
+        description="Populated when a track-title match drove this release into the results. Two producers: LML's SONG_AS_TRACK strategy (per catalog-track-search plan §5.1) for the primary match, and the comprehensive multi-location union (LML#1018/#1019/#1022) for every other WXYC shelf location carrying the same track (V/A compilations, soundtracks) — those rows are folded directly into `results` alongside the primary, tagged with `source: discogs_release` since the recall index is Discogs-release- derived. Empty or absent when the release matched via artist/album strategies. Backward-compatible — existing consumers ignore the field.\n",
     )
     matched_via_alias: list[ArtistMatchHint] | None = Field(
         None,
@@ -2595,10 +2560,6 @@ class LookupResponse(BaseModel):
     timeout: bool | None = Field(
         False,
         description="True when LML's server-side hard cap fired and the search pipeline was abandoned mid-execution (LML#370). `results` may be partial or empty in that case. Callers can use this to distinguish \"no match\" (empty `results`, `timeout: false`) from \"ran out of time\" (`results` may be empty, `timeout: true`). The hard cap is an internal LML safety floor independent of the caller's `X-Caller-Budget-Ms` header; see LML#338 / LML#340 / LML#370 for the cascade-budget design. Backend also forwards two sibling informal headers on the same `/lookup` and `/lookup/bulk` requests, both prose-referenced here rather than formal parameters (matching `X-Caller-Budget-Ms`'s own precedent): `X-Caller-Class` (the resolved BS→LML traffic class, an integer 1-5 per Backend-Service's per-caller policy, BS#1826) and `X-Caller-Reason` (the `caller` label string itself, e.g. `proxy-library-search` or `catalog-popularity-freetext-resolve`). Both are sent only when Backend has a registered caller for the request and are otherwise omitted; sending them is inert until LML reads them (LML#928 for `X-Caller-Class`-driven lane routing, LML#931 for `X-Caller-Reason` caller telemetry) — see BS#1843.\n",
-    )
-    also_available_on: list[LibraryLocation] | None = Field(
-        None,
-        description="Every other WXYC library shelf location that carries the same track (V/A compilations, soundtracks), ranked by LML so consumers can render in order. Present only when the request set `include_locations: true`; absent otherwise (empty when the flag is set but no other location carries the track) so existing consumers see a byte-identical response (LML#1018/#1022).\n",
     )
     degraded: bool | None = Field(
         False,

--- a/routers/request.py
+++ b/routers/request.py
@@ -44,7 +44,6 @@ from core.server_timing import parse_server_timing
 
 if TYPE_CHECKING:
     from posthog import Posthog
-from generated.api_models import LibraryLocation
 from models import LibraryItem, ReleaseMetadata
 from services.ban_check_client import BanCheckClient, BanCheckUnavailableError
 from services.lookup_client import LookupRequest, LookupServiceClient
@@ -121,7 +120,6 @@ async def post_results_to_slack(
     parsed: ParsedRequest,
     items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]],
     context: str | None = None,
-    also_available_on: list[LibraryLocation] | None = None,
 ) -> None:
     """Post formatted results to Slack.
 
@@ -131,8 +129,6 @@ async def post_results_to_slack(
         parsed: Parsed request
         items_with_artwork: Library items with their artwork
         context: Optional context message
-        also_available_on: Ranked alternate WXYC shelf locations for the track,
-            appended as an extra block when present (LML#1018/#1022)
 
     Raises:
         HTTPException: If posting to Slack fails
@@ -142,7 +138,7 @@ async def post_results_to_slack(
         return
 
     if items_with_artwork:
-        blocks = build_slack_blocks(message, items_with_artwork, context, also_available_on)
+        blocks = build_slack_blocks(message, items_with_artwork, context)
     elif not parsed.is_request:
         label = MESSAGE_TYPE_LABELS.get(parsed.message_type, "Other")
         blocks = build_simple_slack_blocks(message, f"_{label}_")
@@ -435,7 +431,6 @@ async def handle_request(
 
     library_results: list[LibraryItem] = []
     items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]] = []
-    also_available_on: list[LibraryLocation] = []
     song_not_found = False
     found_on_compilation = False
     context: str | None = None
@@ -461,11 +456,6 @@ async def handle_request(
                 song=parsed.song,
                 album=parsed.album,
                 raw_message=request.message,
-                # DJ-facing request fan-out: opt into the comprehensive multi-location
-                # union so the Slack post can show alternate WXYC shelf locations for the
-                # track (LML#1018/#1022). Not the enrichment path, so opting in is fine;
-                # absent/empty also_available_on renders nothing extra.
-                include_locations=True,
             )
             try:
                 lookup_result = await lookup_client.lookup(
@@ -498,10 +488,6 @@ async def handle_request(
         results = [item for item in results if item.library_item.id > 0]
         library_results = [item.library_item for item in results]
         items_with_artwork = [(item.library_item, item.artwork) for item in results]
-        # Alternate WXYC shelf locations for the track, ranked by LML (LML#1018/#1022).
-        # Present only when include_locations was set and a song was resolved; empty
-        # otherwise, so the Slack post is byte-identical to before.
-        also_available_on = lookup_response.also_available_on or []
         search_type = str(lookup_response.search_type or "none")
         song_not_found = bool(lookup_response.song_not_found)
         found_on_compilation = bool(lookup_response.found_on_compilation)
@@ -529,12 +515,7 @@ async def handle_request(
                 )
             else:
                 await post_results_to_slack(
-                    slack_service,
-                    request.message,
-                    parsed,
-                    items_with_artwork,
-                    context,
-                    also_available_on=also_available_on,
+                    slack_service, request.message, parsed, items_with_artwork, context
                 )
 
     # Extract main artwork from first result

--- a/services/slack.py
+++ b/services/slack.py
@@ -1,55 +1,17 @@
 import logging
 from typing import Any
 
-from generated.api_models import LibraryLocation
 from models import LibraryItem, ReleaseMetadata, preview_url
 
 logger = logging.getLogger(__name__)
-
-# Per-release permalink template (LML#1014 / dj-site#1050). LibraryLocation carries
-# only a library_id (the union is deliberately lean — no live URL resolution), so we
-# rebuild the same dj-site legacy front door LML emits for LibraryItem.library_url.
-_LIBRARY_PERMALINK_BASE = "https://dj.wxyc.org/dashboard/album/legacy"
-
-# Cap the alternate-locations section so a track carried on many compilations can't
-# overflow Slack's 3000-char section-text limit. Overflow is summarized as "…and N more".
-_MAX_ALSO_AVAILABLE_LOCATIONS = 10
-
-
-def _also_available_block(locations: list[LibraryLocation]) -> dict:
-    """Render the ranked alternate shelf locations as one Slack section block.
-
-    LML ranks ``also_available_on``; we preserve that order and link each entry to
-    its dj.wxyc.org shelf permalink so a DJ can pull a backup copy.
-    """
-    lines = ["*Also available on:*"]
-    for loc in locations[:_MAX_ALSO_AVAILABLE_LOCATIONS]:
-        title = loc.album_title or loc.track_title or "Unknown release"
-        url = f"{_LIBRARY_PERMALINK_BASE}/{loc.library_id}"
-        parts = [f"<{url}|{title}>"]
-        if loc.artist:
-            parts.append(f"— {loc.artist}")
-        if loc.track_position:
-            parts.append(f"({loc.track_position})")
-        lines.append("• " + " ".join(parts))
-    remaining = len(locations) - _MAX_ALSO_AVAILABLE_LOCATIONS
-    if remaining > 0:
-        lines.append(f"_…and {remaining} more_")
-    return {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}}
 
 
 def build_slack_blocks(
     message: str,
     items_with_artwork: list[tuple[LibraryItem, ReleaseMetadata | None]],
     context: str | None = None,
-    also_available_on: list[LibraryLocation] | None = None,
 ) -> list[dict]:
-    """Build Slack message blocks from library results with artwork.
-
-    When ``also_available_on`` is non-empty, a trailing "Also available on" section
-    lists the other WXYC shelf locations carrying the same track (LML#1018/#1022).
-    Absent or empty, the output is byte-identical to before.
-    """
+    """Build Slack message blocks from library results with artwork."""
     blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": f"*{message}*"}}]
 
     # Add context message if provided (e.g., "song not found, showing artist albums")
@@ -85,9 +47,6 @@ def build_slack_blocks(
             }
 
         blocks.append(block)
-
-    if also_available_on:
-        blocks.append(_also_available_block(also_available_on))
 
     return blocks
 

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -15,7 +15,7 @@ from core.dependencies import (
     get_posthog_client,
     get_slack_service,
 )
-from generated.api_models import LibraryLocation, SearchType
+from generated.api_models import SearchType
 from routers.request import router
 from services.lookup_client import (
     LookupResponse,
@@ -139,65 +139,6 @@ class TestDelegationBranch:
         assert data["artwork"]["artwork_url"] == "https://img.discogs.com/test.jpg"
         assert data["song_not_found"] is False
         assert data["found_on_compilation"] is False
-
-    @pytest.mark.asyncio
-    async def test_delegation_requests_locations(
-        self, app, mock_lookup_client, sample_lookup_response
-    ):
-        """The DJ-facing request opts into the multi-location union (ROM#199)."""
-        mock_lookup_client.lookup.return_value = _lr(sample_lookup_response)
-
-        with patch(
-            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
-        ):
-            async with AsyncClient(
-                transport=ASGITransport(app=app), base_url="http://test"
-            ) as client:
-                await client.post(
-                    "/api/v1/request",
-                    json={"message": "play tommib by squarepusher", "skip_slack": True},
-                )
-
-        sent_request = mock_lookup_client.lookup.call_args.args[0]
-        assert sent_request.include_locations is True
-
-    @pytest.mark.asyncio
-    async def test_also_available_on_reaches_slack_post(
-        self, app, mock_lookup_client, mock_slack, sample_lookup_response
-    ):
-        """also_available_on from LML surfaces as an extra Slack block."""
-        response = sample_lookup_response.model_copy(
-            update={
-                "also_available_on": [
-                    LibraryLocation(
-                        library_id=60654,
-                        album_title="Lost in Translation",
-                        artist="Soundtracks - L",
-                        track_position="A1",
-                        track_title="tommib",
-                        track_artist="Squarepusher",
-                    )
-                ]
-            }
-        )
-        mock_lookup_client.lookup.return_value = _lr(response)
-
-        with patch(
-            "routers.request.parse_request", new_callable=AsyncMock, return_value=SAMPLE_PARSED
-        ):
-            async with AsyncClient(
-                transport=ASGITransport(app=app), base_url="http://test"
-            ) as client:
-                await client.post(
-                    "/api/v1/request",
-                    json={"message": "play tommib by squarepusher"},
-                )
-
-        mock_slack.post_blocks.assert_awaited_once()
-        posted_blocks = mock_slack.post_blocks.call_args.args[0]
-        rendered = json.dumps(posted_blocks)
-        assert "Lost in Translation" in rendered
-        assert "dashboard/album/legacy/60654" in rendered
 
     @pytest.mark.asyncio
     async def test_delegation_maps_response_fields(self, app, mock_lookup_client):

--- a/tests/unit/test_lookup_client.py
+++ b/tests/unit/test_lookup_client.py
@@ -401,10 +401,9 @@ class TestLookupModels:
             "song": "la paradoja",
             "album": "DOGA",
             "raw_message": "msg",
-            # include_identity and include_locations both default to False (not None),
-            # so they survive exclude_none — the request builder here leaves them unset.
+            # include_identity is a non-optional bool with a False default, so it
+            # survives exclude_none (added to the LookupRequest contract upstream).
             "include_identity": False,
-            "include_locations": False,
         }
 
     def test_lookup_response_defaults(self):

--- a/tests/unit/test_slack_service.py
+++ b/tests/unit/test_slack_service.py
@@ -204,17 +204,17 @@ class TestBuildSlackBlocks:
 
 
 class TestLocationUnionFoldedIntoResults:
-    """Regression guard for the reverted separate-field "Also available on" design
+    """Regression guard for the reverted separate-field location design
     (request-o-matic#199, reverted per the location-union-transparent plan).
 
-    Alternate WXYC shelf locations for a track are no longer a bespoke
-    ``also_available_on`` collection with its own Slack section -- LML now folds
-    them directly into the ordinary ``results`` array, so from this module's
-    perspective they are just more ``items_with_artwork`` entries. This test pins
-    that an extra, physical-shelf-only row (no streaming links -- exactly what a
-    folded compilation-track location looks like, per the plan's honest
-    "streaming URLs stay null" design) renders through the normal per-item loop,
-    and that no separate "Also available on" section is ever emitted.
+    Alternate WXYC shelf locations for a track are no longer a bespoke separate
+    collection with its own Slack section -- LML now folds them directly into
+    the ordinary ``results`` array, so from this module's perspective they are
+    just more ``items_with_artwork`` entries. This test pins that an extra,
+    physical-shelf-only row (no streaming links -- exactly what a folded
+    compilation-track location looks like, per the plan's honest "streaming URLs
+    stay null" design) renders through the normal per-item loop, and that no
+    separate location section is ever emitted.
     """
 
     def test_extra_result_row_renders_through_normal_loop_with_no_separate_section(
@@ -245,7 +245,7 @@ class TestLocationUnionFoldedIntoResults:
         assert "Soundtracks - L" in rendered
         assert "Lost in Translation" in rendered
 
-    def test_build_slack_blocks_no_longer_accepts_also_available_on(self, sample_library_item):
+    def test_build_slack_blocks_rejects_the_removed_locations_kwarg(self, sample_library_item):
         """The separate-field parameter is fully removed, not merely unused."""
         with pytest.raises(TypeError):
             build_slack_blocks(

--- a/tests/unit/test_slack_service.py
+++ b/tests/unit/test_slack_service.py
@@ -1,23 +1,12 @@
 """Unit tests for services/slack.py."""
 
+import json
+
 import pytest
 
-from generated.api_models import LibraryLocation
 from models import ReleaseMetadata
 from services.slack import build_simple_slack_blocks, build_slack_blocks
 from tests.factories import make_library_item, make_release_metadata
-
-
-def _location(library_id, album_title, artist, track_position=None):
-    """Build a LibraryLocation the way LML returns it in also_available_on."""
-    return LibraryLocation(
-        library_id=library_id,
-        album_title=album_title,
-        artist=artist,
-        track_position=track_position,
-        track_title="tommib",
-        track_artist="Squarepusher",
-    )
 
 
 @pytest.fixture
@@ -214,69 +203,56 @@ class TestBuildSlackBlocks:
         assert "Unknown Artist" in item_block["text"]["text"]
 
 
-class TestAlsoAvailableOn:
-    """Tests for rendering LookupResponse.also_available_on (ROM#199)."""
+class TestLocationUnionFoldedIntoResults:
+    """Regression guard for the reverted separate-field "Also available on" design
+    (request-o-matic#199, reverted per the location-union-transparent plan).
 
-    def test_absent_locations_are_byte_identical(self, sample_library_item):
-        """No also_available_on (None, [], or omitted) leaves the blocks unchanged."""
-        baseline = build_slack_blocks(
-            message="Here's what I found:",
-            items_with_artwork=[(sample_library_item, None)],
-        )
-        assert (
-            build_slack_blocks(
-                message="Here's what I found:",
-                items_with_artwork=[(sample_library_item, None)],
-                also_available_on=None,
-            )
-            == baseline
-        )
-        assert (
-            build_slack_blocks(
-                message="Here's what I found:",
-                items_with_artwork=[(sample_library_item, None)],
-                also_available_on=[],
-            )
-            == baseline
+    Alternate WXYC shelf locations for a track are no longer a bespoke
+    ``also_available_on`` collection with its own Slack section -- LML now folds
+    them directly into the ordinary ``results`` array, so from this module's
+    perspective they are just more ``items_with_artwork`` entries. This test pins
+    that an extra, physical-shelf-only row (no streaming links -- exactly what a
+    folded compilation-track location looks like, per the plan's honest
+    "streaming URLs stay null" design) renders through the normal per-item loop,
+    and that no separate "Also available on" section is ever emitted.
+    """
+
+    def test_extra_result_row_renders_through_normal_loop_with_no_separate_section(
+        self, sample_library_item
+    ):
+        # A second row shaped like a folded compilation-track location: a real
+        # shelf item, no artwork/streaming metadata (LML's lean, physical-only
+        # union entries carry no live URL resolution).
+        location_item = make_library_item(
+            id=60654,
+            artist="Soundtracks - L",
+            title="Lost in Translation",
+            call_letters="L",
+            release_call_number=654,
         )
 
-    def test_renders_ranked_locations_in_order(self, sample_library_item):
-        """A populated also_available_on appends one section listing each location."""
-        locations = [
-            _location(60654, "Lost in Translation", "Soundtracks - L", track_position="A1"),
-            _location(70001, "Go Plastic", "Squarepusher"),
-        ]
         blocks = build_slack_blocks(
             message="Here's what I found:",
-            items_with_artwork=[(sample_library_item, None)],
-            also_available_on=locations,
+            items_with_artwork=[(sample_library_item, None), (location_item, None)],
         )
-        # An extra block beyond the header + single item.
+
+        # Header + 2 ordinary item blocks -- nothing else appended.
         assert len(blocks) == 3
-        extra = blocks[-1]
-        assert extra["type"] == "section"
-        text = extra["text"]["text"]
-        # Both releases are named, and the ranked order is preserved.
-        assert "Lost in Translation" in text
-        assert "Go Plastic" in text
-        assert text.index("Lost in Translation") < text.index("Go Plastic")
-        # Each entry links to the dj.wxyc.org shelf permalink built from library_id.
-        assert "https://dj.wxyc.org/dashboard/album/legacy/60654" in text
-        assert "https://dj.wxyc.org/dashboard/album/legacy/70001" in text
-        # The shelf artist and position are surfaced for the DJ pulling the copy.
-        assert "Soundtracks - L" in text
-        assert "A1" in text
+        rendered = json.dumps(blocks)
+        assert "Also available on" not in rendered
+        # Both rows rendered through the same per-item loop, with equal standing.
+        assert "Stereolab" in rendered
+        assert "Soundtracks - L" in rendered
+        assert "Lost in Translation" in rendered
 
-    def test_caps_long_lists_with_overflow_note(self, sample_library_item):
-        """A pathologically long union is capped so the Slack section stays lean."""
-        locations = [_location(1000 + i, f"Compilation {i}", "Various Artists") for i in range(25)]
-        blocks = build_slack_blocks(
-            message="Here's what I found:",
-            items_with_artwork=[(sample_library_item, None)],
-            also_available_on=locations,
-        )
-        text = blocks[-1]["text"]["text"]
-        assert "more" in text.lower()
+    def test_build_slack_blocks_no_longer_accepts_also_available_on(self, sample_library_item):
+        """The separate-field parameter is fully removed, not merely unused."""
+        with pytest.raises(TypeError):
+            build_slack_blocks(
+                message="Here's what I found:",
+                items_with_artwork=[(sample_library_item, None)],
+                also_available_on=[],  # type: ignore[call-arg]
+            )
 
 
 class TestBuildSimpleSlackBlocks:


### PR DESCRIPTION
## Summary

- Reverts #199 (PR #200, merged): drops `include_locations` from the outbound `/lookup` request, deletes `_also_available_block` and the "Also available on:" Slack section from `services/slack.py`, and removes the `also_available_on` threading through `routers/request.py`. Hand-reverted (not `git revert`) so the unrelated contract additions that landed in `generated/api_models.py` alongside #199's codegen commit (`discogsUnavailable`/`UpdateAlbumRequest`, `LiveFsInsertEvent`) are preserved rather than clobbered; `routers/request.py`, `services/slack.py`, and the three touched test files now match their pre-#199 state (`d42f701`) byte-for-byte.
- Regenerates `generated/api_models.py` against the **new** wxyc-shared contract that removes `LookupRequest.include_locations`, `LookupResponse.also_available_on`, and the `LibraryLocation` schema (WXYC/wxyc-shared#284, not yet merged — see caveat below).
- Adds a regression test (`TestLocationUnionFoldedIntoResults` in `tests/unit/test_slack_service.py`) pinning that an extra `results` row shaped like a folded compilation-track location (a real shelf item, no streaming links) renders through the ordinary per-item Slack loop with no separate section, and that `build_slack_blocks` no longer accepts `also_available_on` at all.

Product direction on LML's comprehensive multi-location union reversed: alternate WXYC shelf locations for a track (V/A compilations, soundtracks) must be transparent, ordinary `/lookup` `results` items rather than a separate opt-in collection every consumer special-cases. Full rationale in [`WXYC/library-metadata-lookup` `plans/location-union-transparent-results.md`](https://github.com/WXYC/library-metadata-lookup/blob/main/plans/location-union-transparent-results.md) §1/§2/§5.3/§6. Nothing user-visible changes here: the prod LML recall index has been empty throughout, so `also_available_on` has always been empty and the "Also available on:" section has never actually rendered in Slack.

Closes #201 (which itself documents the revert of #199 / PR #200).

## Cross-repo sequencing / drift-check caveat

This PR's `codegen-check` CI job will be **red**, expectedly: it curls `api.yaml` from wxyc-shared `main`, which does not yet have the contract change (that lives in unmerged WXYC/wxyc-shared#284). Locally, `generated/api_models.py` was regenerated against the api.yaml on the wxyc-shared `feature/location-union-transparent` branch (PR #284's source) using the exact `datamodel-codegen` invocation from `scripts/generate_api_models.sh`, and manually verified to contain zero occurrences of `include_locations`, `also_available_on`, or `LibraryLocation`. Once #284 merges to wxyc-shared `main` and the codegen-check job re-runs (or this PR is rebased/re-pushed), it will flip green — the committed `generated/api_models.py` here should already match what a fresh regen against merged `main` produces, since #284 is a straight subset of what's currently on this branch.

Landing order: wxyc-shared#284 (contract) → LML core PR (orchestrator fold) → this PR. This PR can merge to `main` (staging) independently of that order since it only removes dead call sites the prod recall index has never populated, but should not promote `main`→`prod` until the contract is live everywhere.

## Test plan

- [x] `uv run --no-sync pytest tests/unit/` — 582 passed (baseline was 585; net -3 tests removed with #199's revert, +2 new regression tests added)
- [x] `uv run --no-sync ruff check .` — all checks passed
- [x] `uv run --no-sync ruff format --check .` — 77 files already formatted
- [x] `uv run --no-sync mypy . --ignore-missing-imports` — no issues found
- [x] Confirmed a genuine red→green cycle for the new regression tests: stashing the revert back onto `services/slack.py` (while keeping the regenerated `generated/api_models.py`, which no longer has `LibraryLocation`) makes the test module fail to even import (`ImportError: cannot import name 'LibraryLocation'`); restoring the revert collects and passes cleanly.
- [ ] `codegen-check` CI job — expected red until WXYC/wxyc-shared#284 merges (see caveat above)
